### PR TITLE
fix(chat): prevent textarea scroll content under bottom toolbar

### DIFF
--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -1213,7 +1213,7 @@ export function MessageInput({
       )}
       <div
         className={cn(
-          "pointer-events-none absolute left-px right-px bottom-px z-10 rounded-b-xl bg-background",
+          "pointer-events-none absolute left-px right-12 bottom-px z-10 rounded-bl-xl bg-background",
           "h-14"
         )}
         aria-hidden="true"


### PR DESCRIPTION
Fix MessageInput textarea so long text never scrolls under the bottom toolbar (attach/mode + send/cancel) while keeping the original auto-grow behavior.