### PR TITLE
feat(chat): arrow-key send history in MessageInput

### DIFF
--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -1113,11 +1113,7 @@ export function MessageInput({
         return
       }
 
-      if (
-        (e.key === "Process" || e.keyCode === 229) &&
-        !isArrowUp &&
-        !isArrowDown
-      ) {
+      if (e.key === "Process" || e.keyCode === 229) {
         return
       }
 


### PR DESCRIPTION
Support navigating previously sent user messages with ArrowUp/ArrowDown in the message input, Codex-style (edit breaks navigation). History is scoped by draft key and seeded from existing conversation turns.