### PR TITLE
Add session locator navigation across conversation and sidebar views

### DIFF
--- a/src/app/folder/layout.tsx
+++ b/src/app/folder/layout.tsx
@@ -13,6 +13,7 @@ import { AcpConnectionsProvider } from "@/contexts/acp-connections-context"
 import { ConversationRuntimeProvider } from "@/contexts/conversation-runtime-context"
 import { TabProvider } from "@/contexts/tab-context"
 import { SessionStatsProvider } from "@/contexts/session-stats-context"
+import { SessionLocatorProvider } from "@/contexts/session-locator-context"
 import { SidebarProvider, useSidebarContext } from "@/contexts/sidebar-context"
 import {
   AuxPanelProvider,
@@ -648,30 +649,32 @@ function FolderLayoutInner({ children }: { children: React.ReactNode }) {
               <WorkspaceProvider key={`workspace-${normalizedFolderId}`}>
                 <TabProvider>
                   <SessionStatsProvider>
-                    <SidebarProvider
-                      key={`left-sidebar-${normalizedFolderId}`}
-                      folderId={normalizedFolderId}
-                    >
-                      <AuxPanelProvider
-                        key={`right-sidebar-${normalizedFolderId}`}
+                    <SessionLocatorProvider>
+                      <SidebarProvider
+                        key={`left-sidebar-${normalizedFolderId}`}
                         folderId={normalizedFolderId}
                       >
-                        <TerminalProvider>
-                          <div className="flex h-screen flex-col overflow-hidden">
-                            <FolderTitleBar />
-                            <FolderWorkspaceShell>
-                              {children}
-                            </FolderWorkspaceShell>
-                            <StatusBar />
-                            <AppToaster
-                              position="bottom-right"
-                              duration={TOAST_DURATION_MS}
-                              closeButton
-                            />
-                          </div>
-                        </TerminalProvider>
-                      </AuxPanelProvider>
-                    </SidebarProvider>
+                        <AuxPanelProvider
+                          key={`right-sidebar-${normalizedFolderId}`}
+                          folderId={normalizedFolderId}
+                        >
+                          <TerminalProvider>
+                            <div className="flex h-screen flex-col overflow-hidden">
+                              <FolderTitleBar />
+                              <FolderWorkspaceShell>
+                                {children}
+                              </FolderWorkspaceShell>
+                              <StatusBar />
+                              <AppToaster
+                                position="bottom-right"
+                                duration={TOAST_DURATION_MS}
+                                closeButton
+                              />
+                            </div>
+                          </TerminalProvider>
+                        </AuxPanelProvider>
+                      </SidebarProvider>
+                    </SessionLocatorProvider>
                   </SessionStatsProvider>
                 </TabProvider>
               </WorkspaceProvider>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -517,3 +517,78 @@
     background-color: rgba(248, 81, 73, 0.35);
   }
 }
+
+@keyframes session-locator-highlight-fade {
+  0% {
+    opacity: 0;
+    border-color: color-mix(in srgb, var(--primary) 14%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+
+  10% {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+
+  40% {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--primary) 46%, transparent);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--primary) 12%, transparent);
+  }
+
+  68% {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--primary) 26%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 6%, transparent);
+  }
+
+  100% {
+    opacity: 0;
+    border-color: color-mix(in srgb, var(--primary) 14%, transparent);
+    box-shadow: 0 0 0 10px color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+}
+
+.session-locator-turn-highlight {
+  isolation: isolate;
+  position: relative;
+}
+
+.session-locator-turn-highlight::after {
+  content: "";
+  position: absolute;
+  inset: -10px;
+  pointer-events: none;
+  border-radius: calc(1rem + 10px);
+  border: 1px solid color-mix(in srgb, var(--primary) 28%, transparent);
+  background: transparent;
+  animation: session-locator-highlight-fade 1500ms
+    cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.session-locator-part-highlight {
+  isolation: isolate;
+  position: relative;
+}
+
+.session-locator-part-highlight::after {
+  content: "";
+  position: absolute;
+  inset-block: -8px;
+  inset-inline: -6px;
+  pointer-events: none;
+  border-radius: calc(0.75rem + 6px);
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  background: transparent;
+  animation: session-locator-highlight-fade 1500ms
+    cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-locator-turn-highlight::after,
+  .session-locator-part-highlight::after {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -56,9 +56,9 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex min-w-0 flex-col gap-2 overflow-hidden text-sm",
-      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:max-w-full group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
-      "group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground",
+      "is-user:dark flex min-w-0 flex-col gap-2 text-sm",
+      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:max-w-full group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-assistant]:w-full group-[.is-assistant]:overflow-visible group-[.is-assistant]:text-foreground",
       className
     )}
     {...props}

--- a/src/components/chat/agent-plan-overlay.tsx
+++ b/src/components/chat/agent-plan-overlay.tsx
@@ -22,9 +22,10 @@ interface AgentPlanOverlayProps {
   planKey?: string | null
   visible?: boolean
   defaultExpanded?: boolean
+  className?: string
 }
 
-function getLatestPlanEntries(message: LiveMessage | null): PlanEntryInfo[] {
+export function getLatestPlanEntries(message: LiveMessage | null): PlanEntryInfo[] {
   if (!message) return []
 
   for (let i = message.content.length - 1; i >= 0; i -= 1) {
@@ -106,6 +107,7 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
   planKey,
   visible = true,
   defaultExpanded = true,
+  className,
 }: AgentPlanOverlayProps) {
   const t = useTranslations("Folder.chat.agentPlanOverlay")
   const liveEntries = useMemo(
@@ -146,12 +148,12 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
 
   if (!isExpanded) {
     return (
-      <div className="pointer-events-none absolute right-8 top-4 z-20 flex">
+      <div className={cn("pointer-events-auto flex", className)}>
         <Button
           type="button"
           variant="secondary"
           size="sm"
-          className="cursor-pointer pointer-events-auto shadow-md bg-secondary/70 hover:bg-secondary"
+          className="cursor-pointer shadow-md bg-secondary/70 hover:bg-secondary"
           onClick={() =>
             setCollapsedByPlanKey((prev) => ({
               ...prev,
@@ -172,10 +174,10 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
 
   return (
     <div
-      className="pointer-events-none absolute right-8 top-4 z-20 flex max-w-[min(22rem,calc(100%-2rem))]"
+      className={cn("pointer-events-auto flex w-full sm:w-72", className)}
       data-plan-key={currentPlanKey ?? undefined}
     >
-      <div className="pointer-events-auto w-72 max-w-full rounded-xl border bg-card/60 hover:bg-card/95 shadow-lg backdrop-blur transition-colors supports-[backdrop-filter]:bg-card/50 supports-[backdrop-filter]:hover:bg-card/85">
+      <div className="w-full max-w-full rounded-xl border bg-card/60 shadow-lg backdrop-blur transition-colors hover:bg-card/95 supports-[backdrop-filter]:bg-card/50 supports-[backdrop-filter]:hover:bg-card/85">
         <div className="flex items-center justify-between border-b px-3 py-2">
           <div className="flex items-center gap-2 min-w-0">
             <ListTodoIcon className="h-4 w-4 text-muted-foreground" />

--- a/src/components/chat/session-locator-overlay.tsx
+++ b/src/components/chat/session-locator-overlay.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import { memo, useMemo, useState } from "react"
+import { useTranslations } from "next-intl"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import type {
+  SessionLocatorItem,
+  SessionLocatorPreview,
+  SessionLocatorTarget,
+} from "@/lib/session-locator"
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, ChevronUpIcon, MapIcon } from "lucide-react"
+
+interface SessionLocatorOverlayProps {
+  items: SessionLocatorItem[]
+  locatorKey?: string | null
+  visible?: boolean
+  defaultExpanded?: boolean
+  className?: string
+  onJumpToTarget: (target: SessionLocatorTarget) => void
+}
+
+function getPreviewText(
+  preview: SessionLocatorPreview,
+  t: ReturnType<typeof useTranslations>
+): string {
+  switch (preview.kind) {
+    case "text":
+      return preview.text
+    case "tool_only":
+      return t("toolOnly")
+    case "attachment_only":
+      return t("attachmentOnly")
+    case "pending_reply":
+      return t("pendingReply")
+    default:
+      return t("emptyPreview")
+  }
+}
+
+const LocatorRow = memo(function LocatorRow({
+  label,
+  preview,
+  ariaLabel,
+  onClick,
+  disabled = false,
+}: {
+  label: string
+  preview: string
+  ariaLabel?: string
+  onClick?: () => void
+  disabled?: boolean
+}) {
+  const rowClassName = cn(
+    "flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+    disabled
+      ? "cursor-default text-muted-foreground"
+      : "cursor-pointer hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+  )
+
+  if (disabled) {
+    return (
+      <div className={rowClassName}>
+        <Badge
+          variant="outline"
+          className="mt-0.5 h-5 shrink-0 text-[10px] uppercase"
+        >
+          {label}
+        </Badge>
+        <p className="min-w-0 flex-1 line-clamp-2 break-words text-sm leading-5 text-muted-foreground">
+          {preview}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={rowClassName}
+      onClick={onClick}
+    >
+      {ariaLabel ? <span className="sr-only">{ariaLabel} </span> : null}
+      <Badge
+        variant="outline"
+        className="mt-0.5 h-5 shrink-0 text-[10px] uppercase"
+      >
+        {label}
+      </Badge>
+      <p className="min-w-0 flex-1 line-clamp-2 break-words text-sm leading-5 text-foreground">
+        {preview}
+      </p>
+    </button>
+  )
+})
+
+export const SessionLocatorOverlay = memo(function SessionLocatorOverlay({
+  items,
+  locatorKey,
+  visible = true,
+  defaultExpanded = false,
+  className,
+  onJumpToTarget,
+}: SessionLocatorOverlayProps) {
+  const t = useTranslations("Folder.chat.sessionLocatorOverlay")
+  const hasItems = visible && items.length > 0
+  const fallbackKey = useMemo(() => {
+    if (items.length === 0) return null
+    return items
+      .map((item) => `${item.id}:${item.status}:${item.user.turnId}`)
+      .join("|")
+  }, [items])
+  const currentLocatorKey = locatorKey ?? fallbackKey
+  const currentLocatorStateKey =
+    currentLocatorKey ?? "__session_locator__default__"
+  const resolvedDefaultExpanded = defaultExpanded
+  const [collapsedByLocatorKey, setCollapsedByLocatorKey] = useState<
+    Record<string, boolean>
+  >({})
+  const isExpanded = !(
+    collapsedByLocatorKey[currentLocatorStateKey] ?? !resolvedDefaultExpanded
+  )
+
+  if (!hasItems) {
+    return null
+  }
+
+  if (!isExpanded) {
+    return (
+      <div className={cn("pointer-events-auto flex", className)}>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="cursor-pointer shadow-md bg-secondary/70 hover:bg-secondary"
+          onClick={() =>
+            setCollapsedByLocatorKey((prev) => ({
+              ...prev,
+              [currentLocatorStateKey]: false,
+            }))
+          }
+        >
+          <MapIcon className="h-4 w-4" />
+          {t("collapsedSummary", { count: items.length })}
+          <ChevronUpIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn("pointer-events-auto flex w-full sm:w-72", className)}
+      data-locator-key={currentLocatorKey ?? undefined}
+    >
+      <div className="w-full max-w-full rounded-xl border bg-card/60 shadow-lg backdrop-blur transition-colors hover:bg-card/95 supports-[backdrop-filter]:bg-card/50 supports-[backdrop-filter]:hover:bg-card/85">
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <MapIcon className="h-4 w-4 text-muted-foreground" />
+            <span className="truncate text-sm font-medium">{t("title")}</span>
+            <Badge variant="secondary" className="h-5">
+              {items.length}
+            </Badge>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={t("collapseAria")}
+            onClick={() =>
+              setCollapsedByLocatorKey((prev) => ({
+                ...prev,
+                [currentLocatorStateKey]: true,
+              }))
+            }
+          >
+            <ChevronDownIcon className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div
+          className="max-h-96 space-y-2 overflow-y-auto p-3"
+          role="navigation"
+          aria-label={t("title")}
+        >
+          {items.map((item) => {
+            const userPreview = getPreviewText(item.user.preview, t)
+            const assistantTarget = item.assistant
+            const assistantPreview = assistantTarget
+              ? getPreviewText(assistantTarget.preview, t)
+              : t("pendingReply")
+
+            return (
+              <div
+                key={item.id}
+                className="rounded-lg border bg-transparent px-1.5 py-1.5"
+              >
+                <LocatorRow
+                  label={t("userLabel")}
+                  preview={userPreview}
+                  ariaLabel={t("jumpToUserAria")}
+                  onClick={() => onJumpToTarget(item.user)}
+                />
+                <LocatorRow
+                  label={t("assistantLabel")}
+                  preview={assistantPreview}
+                  ariaLabel={t("jumpToAssistantAria")}
+                  onClick={
+                    assistantTarget
+                      ? () => onJumpToTarget(assistantTarget)
+                      : undefined
+                  }
+                  disabled={!assistantTarget}
+                />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+})

--- a/src/components/layout/sidebar-directory-tab.tsx
+++ b/src/components/layout/sidebar-directory-tab.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { memo, useMemo } from "react"
+import { useTranslations } from "next-intl"
+import { useFolderContext } from "@/contexts/folder-context"
+import { useSessionLocatorContext } from "@/contexts/session-locator-context"
+import { useTabContext } from "@/contexts/tab-context"
+import { useConversationDetail } from "@/hooks/use-conversation-detail"
+import { useSessionLocatorItems } from "@/hooks/use-session-locator-items"
+import type {
+  SessionLocatorPreview,
+  SessionLocatorTarget,
+} from "@/lib/session-locator"
+import { cn } from "@/lib/utils"
+
+function getPreviewText(
+  preview: SessionLocatorPreview,
+  t: ReturnType<typeof useTranslations>
+): string {
+  switch (preview.kind) {
+    case "text":
+      return preview.text
+    case "tool_only":
+      return t("toolOnly")
+    case "attachment_only":
+      return t("attachmentOnly")
+    case "pending_reply":
+      return t("pendingReply")
+    default:
+      return t("emptyPreview")
+  }
+}
+
+const DirectoryRow = memo(function DirectoryRow({
+  label,
+  preview,
+  onClick,
+  disabled = false,
+  active = false,
+}: {
+  label: string
+  preview: string
+  onClick?: () => void
+  disabled?: boolean
+  active?: boolean
+}) {
+  const rowClassName = cn(
+    "w-full rounded-md px-3 py-2 text-left transition-colors",
+    disabled
+      ? "cursor-default text-muted-foreground"
+      : active
+        ? "cursor-pointer bg-sidebar-accent text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        : "cursor-pointer hover:bg-sidebar-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+  )
+
+  if (disabled) {
+    return (
+      <div className={rowClassName}>
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/80">
+            {label}
+          </span>
+        </div>
+        <p className="mt-1 line-clamp-2 break-words text-[13px] leading-5 text-muted-foreground">
+          {preview}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <button type="button" className={rowClassName} onClick={onClick}>
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className={cn(
+            "text-[10px] font-semibold uppercase tracking-[0.08em]",
+            active
+              ? "text-sidebar-accent-foreground/80"
+              : "text-muted-foreground/80"
+          )}
+        >
+          {label}
+        </span>
+      </div>
+      <p
+        className={cn(
+          "mt-1 line-clamp-2 break-words text-[13px] leading-5",
+          active ? "font-medium text-sidebar-accent-foreground" : "text-foreground"
+        )}
+      >
+        {preview}
+      </p>
+    </button>
+  )
+})
+
+function isSameTarget(
+  left: SessionLocatorTarget | null,
+  right: SessionLocatorTarget | null
+) {
+  if (!left || !right) return false
+  return (
+    left.role === right.role &&
+    left.turnId === right.turnId &&
+    left.partIndex === right.partIndex
+  )
+}
+
+export const SidebarDirectoryTab = memo(function SidebarDirectoryTab() {
+  const t = useTranslations("Folder.sidebar")
+  const locatorT = useTranslations("Folder.chat.sessionLocatorOverlay")
+  const { selectedConversation } = useFolderContext()
+  const { tabs, activeTabId } = useTabContext()
+  const { getActiveTarget, jumpToTarget } = useSessionLocatorContext()
+
+  const activeConversationId = useMemo(() => {
+    const activeTab =
+      tabs.find((tab) => tab.id === activeTabId && tab.kind === "conversation") ??
+      null
+
+    return (
+      activeTab?.runtimeConversationId ??
+      activeTab?.conversationId ??
+      selectedConversation?.id ??
+      null
+    )
+  }, [activeTabId, selectedConversation?.id, tabs])
+
+  const { loading } = useConversationDetail(activeConversationId ?? -1)
+  const items = useSessionLocatorItems(activeConversationId)
+  const activeTarget =
+    activeConversationId != null
+      ? getActiveTarget(activeConversationId)
+      : null
+
+  if (activeConversationId == null) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+        {t("directory.noConversation")}
+      </div>
+    )
+  }
+
+  if (loading && items.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+        {t("directory.loading")}
+      </div>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+        {t("directory.empty")}
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto px-2 py-2">
+      {items.map((item, index) => {
+        const userPreview = getPreviewText(item.user.preview, locatorT)
+        const assistantTarget = item.assistant
+        const assistantPreview = assistantTarget
+          ? getPreviewText(assistantTarget.preview, locatorT)
+          : locatorT("pendingReply")
+        const isUserActive = isSameTarget(activeTarget, item.user)
+        const isAssistantActive = isSameTarget(activeTarget, assistantTarget)
+
+        return (
+          <div
+            key={item.id}
+            className={cn(
+              "py-1.5",
+              index > 0 && "border-t border-border/60"
+            )}
+          >
+            <DirectoryRow
+              label={locatorT("userLabel")}
+              preview={userPreview}
+              onClick={() => jumpToTarget(activeConversationId, item.user)}
+              active={isUserActive}
+            />
+            <DirectoryRow
+              label={locatorT("assistantLabel")}
+              preview={assistantPreview}
+              onClick={
+                assistantTarget
+                  ? () => jumpToTarget(activeConversationId, assistantTarget)
+                  : undefined
+              }
+              disabled={!assistantTarget}
+              active={isAssistantActive}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+})

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import { useCallback, useRef } from "react"
-import { ChevronsDownUp, ChevronsUpDown, Crosshair, Plus } from "lucide-react"
+import {
+  ChevronsDownUp,
+  ChevronsUpDown,
+  Crosshair,
+  ListTree,
+  MessageSquareText,
+  Plus,
+} from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useFolderContext } from "@/contexts/folder-context"
 import { useTabContext } from "@/contexts/tab-context"
@@ -10,13 +17,15 @@ import {
   SidebarConversationList,
   type SidebarConversationListHandle,
 } from "@/components/conversations/sidebar-conversation-list"
+import { SidebarDirectoryTab } from "@/components/layout/sidebar-directory-tab"
 import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export function Sidebar() {
   const t = useTranslations("Folder.sidebar")
   const { folder } = useFolderContext()
   const { openNewConversationTab } = useTabContext()
-  const { isOpen } = useSidebarContext()
+  const { isOpen, activeTab, setActiveTab } = useSidebarContext()
   const listRef = useRef<SidebarConversationListHandle>(null)
 
   const handleNewConversation = useCallback(() => {
@@ -28,49 +37,98 @@ export function Sidebar() {
 
   return (
     <aside className="group/sidebar flex h-full min-h-0 flex-col overflow-hidden bg-sidebar text-sidebar-foreground select-none">
-      <div className="flex h-10 items-center justify-between border-b border-border px-4">
-        <h2 className="text-xs font-bold">{t("title")}</h2>
-        <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/sidebar:opacity-100">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 shrink-0 text-muted-foreground"
-            onClick={() => listRef.current?.scrollToActive()}
-            title={t("locateActiveConversation")}
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) =>
+          setActiveTab(value as "conversations" | "directory")
+        }
+        className="flex h-full flex-col gap-0"
+      >
+        <div className="flex h-10 items-center justify-between border-b border-border px-2.5">
+          <TabsList
+            variant="line"
+            className="h-full justify-start gap-1 border-0 px-0 group-data-horizontal/tabs:h-full"
           >
-            <Crosshair className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 shrink-0 text-muted-foreground"
-            onClick={() => listRef.current?.expandAll()}
-            title={t("expandAllGroups")}
-          >
-            <ChevronsUpDown className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 shrink-0 text-muted-foreground"
-            onClick={() => listRef.current?.collapseAll()}
-            title={t("collapseAllGroups")}
-          >
-            <ChevronsDownUp className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 shrink-0 text-muted-foreground"
-            onClick={handleNewConversation}
-            title={t("newConversation")}
-          >
-            <Plus className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-      </div>
+            <TabsTrigger
+              value="conversations"
+              title={t("title")}
+              aria-label={t("title")}
+              className="h-full flex-none gap-1.5 rounded-none border-b-2 border-transparent px-2.5 text-[12px] font-medium text-muted-foreground data-active:border-foreground/60 data-active:bg-transparent data-active:text-foreground after:hidden"
+            >
+              <MessageSquareText className="h-3.5 w-3.5" />
+              {t("title")}
+            </TabsTrigger>
+            <TabsTrigger
+              value="directory"
+              title={t("tabs.directory")}
+              aria-label={t("tabs.directory")}
+              className="h-full flex-none gap-1.5 rounded-none border-b-2 border-transparent px-2.5 text-[12px] font-medium text-muted-foreground data-active:border-foreground/60 data-active:bg-transparent data-active:text-foreground after:hidden"
+            >
+              <ListTree className="h-3.5 w-3.5" />
+              {t("tabs.directory")}
+            </TabsTrigger>
+          </TabsList>
 
-      <SidebarConversationList ref={listRef} />
+          {activeTab === "conversations" ? (
+            <div className="flex items-center gap-0.5 opacity-60 transition-opacity group-hover/sidebar:opacity-100">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 rounded-md text-muted-foreground"
+                onClick={() => listRef.current?.scrollToActive()}
+                title={t("locateActiveConversation")}
+              >
+                <Crosshair className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 rounded-md text-muted-foreground"
+                onClick={() => listRef.current?.expandAll()}
+                title={t("expandAllGroups")}
+              >
+                <ChevronsUpDown className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 rounded-md text-muted-foreground"
+                onClick={() => listRef.current?.collapseAll()}
+                title={t("collapseAllGroups")}
+              >
+                <ChevronsDownUp className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0 rounded-md text-muted-foreground"
+                onClick={handleNewConversation}
+                title={t("newConversation")}
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ) : (
+            <div className="w-0" />
+          )}
+        </div>
+
+        <TabsContent
+          value="conversations"
+          forceMount
+          className="mt-0 flex-1 min-h-0 overflow-hidden"
+        >
+          <SidebarConversationList ref={listRef} />
+        </TabsContent>
+
+        <TabsContent
+          value="directory"
+          forceMount
+          className="mt-0 flex-1 min-h-0 overflow-hidden"
+        >
+          <SidebarDirectoryTab />
+        </TabsContent>
+      </Tabs>
     </aside>
   )
 }

--- a/src/components/message/content-parts-renderer.tsx
+++ b/src/components/message/content-parts-renderer.tsx
@@ -8,6 +8,7 @@ import {
   countUnifiedDiffLineChanges,
   estimateChangedLineStats,
 } from "@/lib/line-change-stats"
+import { cn } from "@/lib/utils"
 import { MessageResponse } from "@/components/ai-elements/message"
 import {
   Tool,
@@ -2300,37 +2301,81 @@ const ReasoningPart = memo(function ReasoningPart({
 interface ContentPartsRendererProps {
   parts: AdaptedContentPart[]
   role?: MessageRole
+  highlightedPartIndex?: number | null
+  highlightToken?: string | number
 }
 
 export const ContentPartsRenderer = memo(function ContentPartsRenderer({
   parts,
   role,
+  highlightedPartIndex = null,
+  highlightToken,
 }: ContentPartsRendererProps) {
+  const getPartClassName = (index: number) =>
+    cn(
+      "relative z-10 rounded-xl",
+      highlightedPartIndex === index &&
+        highlightToken !== undefined &&
+        "session-locator-part-highlight"
+    )
+
   return (
     <div className="space-y-2">
       {parts.map((part, i) => {
         if (part.type === "text") {
           return (
-            <TextPart
+            <div
               key={`text-${i}`}
-              text={part.text}
-              preserveNewlines={role === "user"}
-            />
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="text"
+              data-highlight-token={highlightToken}
+            >
+              <TextPart text={part.text} preserveNewlines={role === "user"} />
+            </div>
           )
         }
 
         if (part.type === "tool-call") {
-          return <ToolCallPart key={`tc-${part.toolCallId ?? i}`} part={part} />
+          return (
+            <div
+              key={`tc-${part.toolCallId ?? i}`}
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="tool-call"
+              data-highlight-token={highlightToken}
+            >
+              <ToolCallPart part={part} />
+            </div>
+          )
         }
 
         if (part.type === "tool-result") {
           return (
-            <ToolResultPart key={`tr-${part.toolCallId ?? i}`} part={part} />
+            <div
+              key={`tr-${part.toolCallId ?? i}`}
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="tool-result"
+              data-highlight-token={highlightToken}
+            >
+              <ToolResultPart part={part} />
+            </div>
           )
         }
 
         if (part.type === "reasoning") {
-          return <ReasoningPart key={`reasoning-${i}`} part={part} />
+          return (
+            <div
+              key={`reasoning-${i}`}
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="reasoning"
+              data-highlight-token={highlightToken}
+            >
+              <ReasoningPart part={part} />
+            </div>
+          )
         }
 
         return null

--- a/src/components/message/message-list-view.tsx
+++ b/src/components/message/message-list-view.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { memo, useCallback, useEffect, useMemo, useRef } from "react"
+import type { StickToBottomContext } from "use-stick-to-bottom"
 import { useConversationRuntime } from "@/contexts/conversation-runtime-context"
 import { ContentPartsRenderer } from "./content-parts-renderer"
 import {
@@ -14,7 +15,10 @@ import { LiveTurnStats } from "./live-turn-stats"
 import { UserResourceLinks } from "./user-resource-links"
 import { UserImageAttachments } from "./user-image-attachments"
 import { useSessionStats } from "@/contexts/session-stats-context"
-import { AgentPlanOverlay } from "@/components/chat/agent-plan-overlay"
+import {
+  AgentPlanOverlay,
+  getLatestPlanEntries,
+} from "@/components/chat/agent-plan-overlay"
 import { MessageThread } from "@/components/ai-elements/message-thread"
 import { Message, MessageContent } from "@/components/ai-elements/message"
 import { Loader2 } from "lucide-react"
@@ -24,7 +28,13 @@ import {
   extractLatestPlanEntriesFromMessages,
 } from "@/lib/agent-plan"
 import type { AgentType, ConnectionStatus, SessionStats } from "@/lib/types"
-import { VirtualizedMessageThread } from "@/components/message/virtualized-message-thread"
+import {
+  VirtualizedMessageThread,
+  type VirtualizedMessageThreadHandle,
+} from "@/components/message/virtualized-message-thread"
+import { useMessageHighlight } from "@/components/message/use-message-highlight"
+import { useSessionLocatorContext } from "@/contexts/session-locator-context"
+import { cn } from "@/lib/utils"
 import { useStickToBottomContext } from "use-stick-to-bottom"
 
 interface MessageListViewProps {
@@ -66,18 +76,39 @@ type ThreadRenderItem =
 const HistoricalMessageGroup = memo(function HistoricalMessageGroup({
   group,
   dimmed = false,
+  highlightedPartIndex = null,
+  highlightTurn = false,
+  highlightToken,
 }: {
   group: ResolvedMessageGroup
   dimmed?: boolean
+  highlightedPartIndex?: number | null
+  highlightTurn?: boolean
+  highlightToken?: number
 }) {
   return (
-    <div className={dimmed ? "opacity-70" : undefined}>
+    <div
+      className={cn(
+        "rounded-2xl",
+        dimmed && "opacity-70",
+        highlightTurn &&
+          highlightToken !== undefined &&
+          "session-locator-turn-highlight"
+      )}
+      data-turn-id={group.id}
+      data-highlight-token={highlightToken}
+    >
       <Message from={group.role}>
         {group.role === "user" && group.images.length > 0 ? (
           <UserImageAttachments images={group.images} className="self-end" />
         ) : null}
         <MessageContent>
-          <ContentPartsRenderer parts={group.parts} role={group.role} />
+          <ContentPartsRenderer
+            parts={group.parts}
+            role={group.role}
+            highlightedPartIndex={highlightedPartIndex}
+            highlightToken={highlightToken}
+          />
         </MessageContent>
         {group.role === "user" && group.resources.length > 0 ? (
           <UserResourceLinks resources={group.resources} className="self-end" />
@@ -152,6 +183,20 @@ export function MessageListView({
   const timelineTurns = getTimelineTurns(conversationId)
 
   const { setSessionStats } = useSessionStats()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const threadRef = useRef<VirtualizedMessageThreadHandle | null>(null)
+  const stickToBottomContextRef = useRef<StickToBottomContext | null>(null)
+  const { registerJumpHandler } = useSessionLocatorContext()
+  const { highlightedTarget, jumpToTarget } = useMessageHighlight({
+    rootRef,
+    threadRef,
+    stopAutoStick: () => stickToBottomContextRef.current?.stopScroll(),
+  })
+
+  useEffect(
+    () => registerJumpHandler(conversationId, jumpToTarget),
+    [conversationId, jumpToTarget, registerJumpHandler]
+  )
 
   useEffect(() => {
     if (isActive) {
@@ -233,22 +278,41 @@ export function MessageListView({
     () => buildPlanKey(historicalPlanEntries),
     [historicalPlanEntries]
   )
+  const livePlanEntries = useMemo(
+    () => getLatestPlanEntries(liveMessage ?? null),
+    [liveMessage]
+  )
 
-  const renderThreadItem = useCallback((item: ThreadRenderItem) => {
-    switch (item.kind) {
-      case "turn":
-        return (
-          <HistoricalMessageGroup
-            group={item.group}
-            dimmed={item.phase === "optimistic"}
-          />
-        )
-      case "typing":
-        return <PendingTypingIndicator />
-      default:
-        return null
-    }
-  }, [])
+  const renderThreadItem = useCallback(
+    (item: ThreadRenderItem) => {
+      switch (item.kind) {
+        case "turn": {
+          const isHighlightedTurn = highlightedTarget?.turnId === item.group.id
+          const highlightedPartIndex = isHighlightedTurn
+            ? highlightedTarget.partIndex
+            : null
+          const shouldHighlightWholeTurn =
+            isHighlightedTurn && highlightedPartIndex === null
+          return (
+            <HistoricalMessageGroup
+              group={item.group}
+              dimmed={item.phase === "optimistic"}
+              highlightedPartIndex={highlightedPartIndex}
+              highlightTurn={shouldHighlightWholeTurn}
+              highlightToken={
+                isHighlightedTurn ? highlightedTarget.token : undefined
+              }
+            />
+          )
+        }
+        case "typing":
+          return <PendingTypingIndicator />
+        default:
+          return null
+      }
+    },
+    [highlightedTarget]
+  )
 
   const emptyState = useMemo(
     () =>
@@ -263,8 +327,9 @@ export function MessageListView({
   )
 
   const agentPlanOverlayKey = liveMessage?.id ?? `history-${conversationId}`
-
   const hasRenderableContent = threadItems.length > 0 || Boolean(liveMessage)
+  const hasAgentPlanOverlay =
+    livePlanEntries.length > 0 || historicalPlanEntries.length > 0
 
   if (detailLoading && !hasRenderableContent) {
     return (
@@ -290,13 +355,15 @@ export function MessageListView({
   }
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col">
+    <div ref={rootRef} className="relative flex h-full min-h-0 flex-col">
       <MessageThread
         className="flex-1 min-h-0"
+        contextRef={stickToBottomContextRef}
         resize={shouldUseSmoothResize ? "smooth" : undefined}
       >
         <AutoScrollOnSend signal={sendSignal} />
         <VirtualizedMessageThread
+          ref={threadRef}
           items={threadItems}
           getItemKey={(item) => item.key}
           renderItem={renderThreadItem}
@@ -312,13 +379,20 @@ export function MessageListView({
           isStreaming={connStatus === "prompting"}
         />
       )}
-      <AgentPlanOverlay
-        key={agentPlanOverlayKey}
-        message={liveMessage ?? null}
-        entries={historicalPlanEntries}
-        planKey={historicalPlanKey}
-        defaultExpanded={connStatus === "prompting"}
-      />
+      {hasAgentPlanOverlay && (
+        <div className="pointer-events-none absolute inset-x-0 top-4 z-20 px-4 sm:px-8">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+            <AgentPlanOverlay
+              key={agentPlanOverlayKey}
+              className="max-w-full sm:ml-auto"
+              message={liveMessage ?? null}
+              entries={historicalPlanEntries}
+              planKey={historicalPlanKey}
+              defaultExpanded={connStatus === "prompting"}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/message/use-message-highlight.ts
+++ b/src/components/message/use-message-highlight.ts
@@ -1,0 +1,172 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
+import type { SessionLocatorTarget } from "@/lib/session-locator"
+import type { VirtualizedMessageThreadHandle } from "./virtualized-message-thread"
+
+export interface HighlightedMessageTarget {
+  turnId: string
+  partIndex: number | null
+  token: number
+}
+
+interface UseMessageHighlightOptions {
+  rootRef: RefObject<HTMLElement | null>
+  threadRef: RefObject<VirtualizedMessageThreadHandle | null>
+  stopAutoStick?: () => void
+}
+
+const HIGHLIGHT_ANIMATION_DURATION_MS = 1800
+const HIGHLIGHT_STATE_RESET_DELAY_MS = HIGHLIGHT_ANIMATION_DURATION_MS + 300
+const TARGET_TOP_OFFSET_PX = 88
+const TARGET_ALIGNMENT_TOLERANCE_PX = 12
+const TARGET_VISIBILITY_PADDING_PX = 24
+const TARGET_MAX_ALIGNMENT_ATTEMPTS = 36
+const ALIGNMENT_FRAME_DELAY = 2
+
+function scheduleFrameDelay(frameDelay: number, callback: () => void) {
+  let remainingFrames = frameDelay
+
+  const tick = () => {
+    if (remainingFrames <= 0) {
+      callback()
+      return
+    }
+
+    remainingFrames -= 1
+    requestAnimationFrame(tick)
+  }
+
+  requestAnimationFrame(tick)
+}
+
+export function useMessageHighlight({
+  rootRef,
+  threadRef,
+  stopAutoStick,
+}: UseMessageHighlightOptions) {
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const jumpTokenRef = useRef(0)
+  const [highlightedTarget, setHighlightedTarget] =
+    useState<HighlightedMessageTarget | null>(null)
+
+  const clearHighlightTimeout = useCallback(() => {
+    if (highlightTimeoutRef.current) {
+      clearTimeout(highlightTimeoutRef.current)
+      highlightTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => clearHighlightTimeout, [clearHighlightTimeout])
+
+  const jumpToTarget = useCallback(
+    (target: SessionLocatorTarget) => {
+      jumpTokenRef.current += 1
+      const activeJumpToken = jumpTokenRef.current
+
+      stopAutoStick?.()
+
+      const nextHighlight: HighlightedMessageTarget = {
+        turnId: target.turnId,
+        partIndex: target.partIndex,
+        token: Date.now(),
+      }
+
+      clearHighlightTimeout()
+      setHighlightedTarget(null)
+
+      threadRef.current?.scrollToIndex(target.threadIndex, {
+        align: "start",
+        behavior: "auto",
+      })
+
+      let attempts = 0
+
+      const finalizeHighlight = () => {
+        if (jumpTokenRef.current !== activeJumpToken) return
+
+        setHighlightedTarget(nextHighlight)
+        clearHighlightTimeout()
+        highlightTimeoutRef.current = setTimeout(() => {
+          setHighlightedTarget((current) =>
+            current?.token === nextHighlight.token ? null : current
+          )
+          highlightTimeoutRef.current = null
+        }, HIGHLIGHT_STATE_RESET_DELAY_MS)
+      }
+
+      const alignTarget = () => {
+        if (jumpTokenRef.current !== activeJumpToken) return
+
+        const root = rootRef.current
+        const scrollElement = threadRef.current?.getScrollElement()
+        if (!root || !scrollElement) {
+          finalizeHighlight()
+          return
+        }
+
+        const turnElement = Array.from(
+          root.querySelectorAll<HTMLElement>("[data-turn-id]")
+        ).find((element) => element.dataset.turnId === target.turnId)
+
+        const targetElement =
+          target.partIndex === null
+            ? turnElement
+            : (turnElement?.querySelector<HTMLElement>(
+                `[data-content-part-index="${target.partIndex}"]`
+              ) ?? turnElement)
+
+        if (targetElement) {
+          const scrollRect = scrollElement.getBoundingClientRect()
+          const targetRect = targetElement.getBoundingClientRect()
+          const nextTop =
+            scrollElement.scrollTop +
+            (targetRect.top - scrollRect.top) -
+            TARGET_TOP_OFFSET_PX
+          const anchorTop = scrollRect.top + TARGET_TOP_OFFSET_PX
+          const distanceFromAnchor = targetRect.top - anchorTop
+          const isVisible =
+            targetRect.bottom >=
+              scrollRect.top + TARGET_VISIBILITY_PADDING_PX &&
+            targetRect.top <= scrollRect.bottom - TARGET_VISIBILITY_PADDING_PX
+          const isAligned =
+            Math.abs(distanceFromAnchor) <= TARGET_ALIGNMENT_TOLERANCE_PX
+
+          if (isVisible && isAligned) {
+            finalizeHighlight()
+            return
+          }
+
+          scrollElement.scrollTo({
+            top: Math.max(0, nextTop),
+            behavior: "auto",
+          })
+        }
+
+        attempts += 1
+        if (attempts < TARGET_MAX_ALIGNMENT_ATTEMPTS) {
+          scheduleFrameDelay(ALIGNMENT_FRAME_DELAY, alignTarget)
+          return
+        }
+
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[session-locator] Unable to fully align jump target", {
+            partIndex: target.partIndex,
+            threadIndex: target.threadIndex,
+            turnId: target.turnId,
+          })
+        }
+
+        finalizeHighlight()
+      }
+
+      scheduleFrameDelay(ALIGNMENT_FRAME_DELAY, alignTarget)
+    },
+    [clearHighlightTimeout, rootRef, stopAutoStick, threadRef]
+  )
+
+  return {
+    highlightedTarget,
+    jumpToTarget,
+  }
+}

--- a/src/components/message/virtualized-message-thread.tsx
+++ b/src/components/message/virtualized-message-thread.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useCallback } from "react"
-import type { ReactNode } from "react"
+import { useCallback, useImperativeHandle } from "react"
+import type { ReactNode, Ref } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { useStickToBottomContext } from "use-stick-to-bottom"
 import {
@@ -9,6 +9,17 @@ import {
   type MessageThreadContentProps,
 } from "@/components/ai-elements/message-thread"
 import { cn } from "@/lib/utils"
+
+export interface VirtualizedMessageThreadHandle {
+  scrollToIndex: (
+    index: number,
+    options?: {
+      align?: "start" | "center" | "end" | "auto"
+      behavior?: "auto" | "smooth"
+    }
+  ) => void
+  getScrollElement: () => HTMLElement | null
+}
 
 interface VirtualizedMessageThreadProps<T> {
   items: T[]
@@ -20,6 +31,7 @@ interface VirtualizedMessageThreadProps<T> {
   className?: string
   contentClassName?: string
   contentProps?: Omit<MessageThreadContentProps, "children" | "className">
+  ref?: Ref<VirtualizedMessageThreadHandle>
 }
 
 export function VirtualizedMessageThread<T>({
@@ -32,6 +44,7 @@ export function VirtualizedMessageThread<T>({
   className,
   contentClassName,
   contentProps,
+  ref,
 }: VirtualizedMessageThreadProps<T>) {
   const { scrollRef } = useStickToBottomContext()
 
@@ -51,6 +64,19 @@ export function VirtualizedMessageThread<T>({
       return item ? getItemKey(item, index) : index
     },
   })
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToIndex(index, options) {
+        virtualizer.scrollToIndex(index, options)
+      },
+      getScrollElement() {
+        return scrollRef.current
+      },
+    }),
+    [scrollRef, virtualizer]
+  )
 
   const renderVirtualRow = useCallback(
     (virtualItem: ReturnType<typeof virtualizer.getVirtualItems>[number]) => {

--- a/src/contexts/session-locator-context.tsx
+++ b/src/contexts/session-locator-context.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useRef,
+  type ReactNode,
+} from "react"
+import type { SessionLocatorTarget } from "@/lib/session-locator"
+
+type SessionLocatorJumpHandler = (target: SessionLocatorTarget) => void
+
+interface SessionLocatorContextValue {
+  registerJumpHandler: (
+    conversationId: number,
+    handler: SessionLocatorJumpHandler
+  ) => () => void
+  jumpToTarget: (conversationId: number, target: SessionLocatorTarget) => void
+  getActiveTarget: (conversationId: number) => SessionLocatorTarget | null
+}
+
+const SessionLocatorContext = createContext<SessionLocatorContextValue | null>(
+  null
+)
+
+export function SessionLocatorProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const handlersRef = useRef(new Map<number, SessionLocatorJumpHandler>())
+  const [activeTargets, setActiveTargets] = useState<
+    Record<number, SessionLocatorTarget | null>
+  >({})
+
+  const registerJumpHandler = useCallback(
+    (conversationId: number, handler: SessionLocatorJumpHandler) => {
+      handlersRef.current.set(conversationId, handler)
+
+      return () => {
+        const currentHandler = handlersRef.current.get(conversationId)
+        if (currentHandler === handler) {
+          handlersRef.current.delete(conversationId)
+        }
+      }
+    },
+    []
+  )
+
+  const jumpToTarget = useCallback(
+    (conversationId: number, target: SessionLocatorTarget) => {
+      setActiveTargets((prev) => ({
+        ...prev,
+        [conversationId]: target,
+      }))
+      handlersRef.current.get(conversationId)?.(target)
+    },
+    []
+  )
+
+  const getActiveTarget = useCallback(
+    (conversationId: number) => activeTargets[conversationId] ?? null,
+    [activeTargets]
+  )
+
+  const value = useMemo(
+    () => ({
+      registerJumpHandler,
+      jumpToTarget,
+      getActiveTarget,
+    }),
+    [getActiveTarget, jumpToTarget, registerJumpHandler]
+  )
+
+  return (
+    <SessionLocatorContext.Provider value={value}>
+      {children}
+    </SessionLocatorContext.Provider>
+  )
+}
+
+export function useSessionLocatorContext() {
+  const ctx = useContext(SessionLocatorContext)
+  if (!ctx) {
+    throw new Error(
+      "useSessionLocatorContext must be used within SessionLocatorProvider"
+    )
+  }
+  return ctx
+}

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -19,13 +19,17 @@ const MIN_WIDTH = 200
 const MAX_WIDTH = 600
 const DEFAULT_IS_OPEN = true
 
+export type SidebarTab = "conversations" | "directory"
+
 interface SidebarContextValue {
   isOpen: boolean
   width: number
   minWidth: number
   maxWidth: number
+  activeTab: SidebarTab
   toggle: () => void
   setWidth: (w: number) => void
+  setActiveTab: (tab: SidebarTab) => void
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null)
@@ -54,6 +58,7 @@ export function SidebarProvider({ children, folderId }: SidebarProviderProps) {
   )
   const [isOpen, setIsOpen] = useState(DEFAULT_IS_OPEN)
   const [width, setWidthState] = useState(DEFAULT_WIDTH)
+  const [activeTab, setActiveTab] = useState<SidebarTab>("conversations")
   const [restored, setRestored] = useState(false)
 
   const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
@@ -82,10 +87,12 @@ export function SidebarProvider({ children, folderId }: SidebarProviderProps) {
       width,
       minWidth: MIN_WIDTH,
       maxWidth: MAX_WIDTH,
+      activeTab,
       toggle,
       setWidth,
+      setActiveTab,
     }),
-    [isOpen, width, toggle, setWidth]
+    [activeTab, isOpen, width, toggle, setWidth]
   )
 
   return (

--- a/src/hooks/use-session-locator-items.ts
+++ b/src/hooks/use-session-locator-items.ts
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo } from "react"
+import { useTranslations } from "next-intl"
+import { useConversationRuntime } from "@/contexts/conversation-runtime-context"
+import { adaptMessageTurns } from "@/lib/adapters/ai-elements-adapter"
+import {
+  buildSessionLocatorItems,
+  type SessionLocatorItem,
+  type SessionLocatorRawTurn,
+} from "@/lib/session-locator"
+
+export function useSessionLocatorItems(
+  conversationId: number | null
+): SessionLocatorItem[] {
+  const sharedT = useTranslations("Folder.chat.shared")
+  const { getTimelineTurns } = useConversationRuntime()
+  const resolvedConversationId = conversationId ?? -1
+  const timelineTurns = getTimelineTurns(resolvedConversationId)
+
+  const adapterText = useMemo(
+    () => ({
+      attachedResources: sharedT("attachedResources"),
+      toolCallFailed: sharedT("toolCallFailed"),
+    }),
+    [sharedT]
+  )
+
+  return useMemo(() => {
+    if (conversationId == null || timelineTurns.length === 0) {
+      return []
+    }
+
+    const allTurns = timelineTurns.map((item) => item.turn)
+    const streamingIndices = new Set<number>()
+
+    timelineTurns.forEach((item, index) => {
+      if (item.phase === "streaming") {
+        streamingIndices.add(index)
+      }
+    })
+
+    const adaptedTurns = adaptMessageTurns(
+      allTurns,
+      adapterText,
+      streamingIndices.size > 0 ? streamingIndices : undefined
+    )
+
+    const locatorRawTurns: SessionLocatorRawTurn[] = adaptedTurns.map(
+      (message, threadIndex) => ({
+        turnId: message.id,
+        role: message.role === "tool" ? "assistant" : message.role,
+        phase: timelineTurns[threadIndex]?.phase ?? "persisted",
+        threadIndex,
+        parts: message.content,
+        resourceCount: message.userResources?.length ?? 0,
+        imageCount: message.userImages?.length ?? 0,
+      })
+    )
+
+    return buildSessionLocatorItems(
+      locatorRawTurns.filter((turn) => {
+        if (turn.role === "system") return false
+        if (turn.phase === "streaming") return false
+        if (turn.phase === "optimistic") return turn.role === "user"
+        return true
+      })
+    )
+  }, [adapterText, conversationId, timelineTurns])
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "المحادثات",
+      "tabs": {
+        "directory": "الدليل"
+      },
       "locateActiveConversation": "تحديد المحادثة النشطة",
       "expandAllGroups": "توسيع كل المجموعات",
       "collapseAllGroups": "طي كل المجموعات",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "إكمال جميع جلسات المراجعة؟",
       "completeAllReviewDescription": "سيؤدي ذلك إلى وضع علامة مكتمل على جميع {count, plural, one {# جلسة} other {# جلسات}} في المراجعة.",
       "completing": "جارٍ الإكمال...",
+      "directory": {
+        "noConversation": "اختر محادثة لعرض دليلها.",
+        "loading": "جارٍ تحميل الدليل...",
+        "empty": "لا توجد عناصر دليل في هذه المحادثة."
+      },
       "toasts": {
         "importedSessions": "تم استيراد {imported, plural, one {# جلسة} other {# جلسات}}، وتم تخطي {skipped}",
         "noNewSessionsFound": "لم يتم العثور على جلسات جديدة (تم تخطي {skipped})",
@@ -1272,6 +1280,19 @@
           "low": "منخفض",
           "unknown": "غير معروف"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "محدد الجلسة",
+        "collapseAria": "طي محدد الجلسة",
+        "collapsedSummary": "المحدد {count}",
+        "userLabel": "المستخدم",
+        "assistantLabel": "AI",
+        "toolOnly": "استجابة أدوات فقط",
+        "attachmentOnly": "صور/مرفقات",
+        "pendingReply": "لا يوجد رد",
+        "emptyPreview": "لا تتوفر معاينة",
+        "jumpToUserAria": "الانتقال إلى رسالة المستخدم",
+        "jumpToAssistantAria": "الانتقال إلى رد AI"
       },
       "permissionDialog": {
         "subtitle": "يطلب الوكيل إذنًا لمتابعة هذا الدور.",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "Konversationen",
+      "tabs": {
+        "directory": "Verzeichnis"
+      },
       "locateActiveConversation": "Aktive Konversation finden",
       "expandAllGroups": "Alle Gruppen erweitern",
       "collapseAllGroups": "Alle Gruppen einklappen",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "Alle Review-Sitzungen abschließen?",
       "completeAllReviewDescription": "Dadurch werden alle {count, plural, one {# Sitzung} other {# Sitzungen}} im Review als abgeschlossen markiert.",
       "completing": "Abschließen...",
+      "directory": {
+        "noConversation": "Wähle eine Konversation aus, um ihr Verzeichnis anzuzeigen.",
+        "loading": "Verzeichnis wird geladen...",
+        "empty": "Für diese Konversation sind keine Verzeichniseinträge vorhanden."
+      },
       "toasts": {
         "importedSessions": "{imported, plural, one {# Sitzung} other {# Sitzungen}} importiert, {skipped} übersprungen",
         "noNewSessionsFound": "Keine neuen Sitzungen gefunden ({skipped} übersprungen)",
@@ -1272,6 +1280,19 @@
           "low": "Niedrig",
           "unknown": "Unbekannt"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "Sitzungsnavigator",
+        "collapseAria": "Sitzungsnavigator einklappen",
+        "collapsedSummary": "Navigator {count}",
+        "userLabel": "Benutzer",
+        "assistantLabel": "KI",
+        "toolOnly": "Nur Werkzeugausgabe",
+        "attachmentOnly": "Bilder/Anhänge",
+        "pendingReply": "Keine Antwort",
+        "emptyPreview": "Keine Vorschau verfügbar",
+        "jumpToUserAria": "Zur Benutzernachricht springen",
+        "jumpToAssistantAria": "Zur KI-Antwort springen"
       },
       "permissionDialog": {
         "subtitle": "Agent fordert Berechtigung an, um diesen Zug fortzusetzen.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "Conversations",
+      "tabs": {
+        "directory": "Directory"
+      },
       "locateActiveConversation": "Locate Active Conversation",
       "expandAllGroups": "Expand All Groups",
       "collapseAllGroups": "Collapse All Groups",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "Complete all review sessions?",
       "completeAllReviewDescription": "This will mark all {count, plural, one {# session} other {# sessions}} in Review as completed.",
       "completing": "Completing...",
+      "directory": {
+        "noConversation": "Select a conversation to view its directory.",
+        "loading": "Loading directory...",
+        "empty": "No directory items in this conversation."
+      },
       "toasts": {
         "importedSessions": "Imported {imported, plural, one {# session} other {# sessions}}, skipped {skipped}",
         "noNewSessionsFound": "No new sessions found (skipped {skipped})",
@@ -1272,6 +1280,19 @@
           "low": "Low",
           "unknown": "Unknown"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "Session Locator",
+        "collapseAria": "Collapse session locator",
+        "collapsedSummary": "Locator {count}",
+        "userLabel": "User",
+        "assistantLabel": "AI",
+        "toolOnly": "Tool-only response",
+        "attachmentOnly": "Images/attachments",
+        "pendingReply": "No reply",
+        "emptyPreview": "No preview available",
+        "jumpToUserAria": "Jump to user message",
+        "jumpToAssistantAria": "Jump to AI reply"
       },
       "permissionDialog": {
         "subtitle": "Agent requests permission to continue this turn.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "Conversaciones",
+      "tabs": {
+        "directory": "Directorio"
+      },
       "locateActiveConversation": "Ubicar conversación activa",
       "expandAllGroups": "Expandir todos los grupos",
       "collapseAllGroups": "Colapsar todos los grupos",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "¿Completar todas las sesiones en revisión?",
       "completeAllReviewDescription": "Esto marcará como completadas todas las {count, plural, one {# sesión} other {# sesiones}} en Revisión.",
       "completing": "Completando...",
+      "directory": {
+        "noConversation": "Selecciona una conversación para ver su directorio.",
+        "loading": "Cargando directorio...",
+        "empty": "No hay elementos de directorio en esta conversación."
+      },
       "toasts": {
         "importedSessions": "Se importaron {imported, plural, one {# sesión} other {# sesiones}}, se omitieron {skipped}",
         "noNewSessionsFound": "No se encontraron sesiones nuevas (omitidas {skipped})",
@@ -1272,6 +1280,19 @@
           "low": "Baja",
           "unknown": "Desconocida"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "Localizador de sesión",
+        "collapseAria": "Contraer localizador de sesión",
+        "collapsedSummary": "Localizador {count}",
+        "userLabel": "Usuario",
+        "assistantLabel": "IA",
+        "toolOnly": "Solo salida de herramientas",
+        "attachmentOnly": "Imágenes/adjuntos",
+        "pendingReply": "Sin respuesta",
+        "emptyPreview": "No hay vista previa disponible",
+        "jumpToUserAria": "Ir al mensaje del usuario",
+        "jumpToAssistantAria": "Ir a la respuesta de la IA"
       },
       "permissionDialog": {
         "subtitle": "El agente solicita permiso para continuar este turno.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "Discussions",
+      "tabs": {
+        "directory": "Plan"
+      },
       "locateActiveConversation": "Localiser la conversation active",
       "expandAllGroups": "Développer tous les groupes",
       "collapseAllGroups": "Réduire tous les groupes",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "Terminer toutes les sessions en revue ?",
       "completeAllReviewDescription": "Cela marquera comme terminées toutes les {count, plural, one {# session} other {# sessions}} en Revue.",
       "completing": "Finalisation...",
+      "directory": {
+        "noConversation": "Sélectionnez une conversation pour afficher son plan.",
+        "loading": "Chargement du plan...",
+        "empty": "Aucun élément de plan pour cette conversation."
+      },
       "toasts": {
         "importedSessions": "{imported, plural, one {# session} other {# sessions}} importée(s), {skipped} ignorée(s)",
         "noNewSessionsFound": "Aucune nouvelle session trouvée ({skipped} ignorée(s))",
@@ -1272,6 +1280,19 @@
           "low": "Basse",
           "unknown": "Inconnue"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "Localisateur de session",
+        "collapseAria": "Réduire le localisateur de session",
+        "collapsedSummary": "Repères {count}",
+        "userLabel": "Utilisateur",
+        "assistantLabel": "IA",
+        "toolOnly": "Réponse d’outil uniquement",
+        "attachmentOnly": "Images/pièces jointes",
+        "pendingReply": "Sans réponse",
+        "emptyPreview": "Aucun aperçu disponible",
+        "jumpToUserAria": "Aller au message de l’utilisateur",
+        "jumpToAssistantAria": "Aller à la réponse de l’IA"
       },
       "permissionDialog": {
         "subtitle": "L'agent demande une autorisation pour continuer ce tour.",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "会話",
+      "tabs": {
+        "directory": "目次"
+      },
       "locateActiveConversation": "アクティブな会話を表示",
       "expandAllGroups": "すべてのグループを展開",
       "collapseAllGroups": "すべてのグループを折りたたむ",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "すべてのレビューセッションを完了しますか？",
       "completeAllReviewDescription": "これにより、レビュー中の {count, plural, one {# 件のセッション} other {# 件のセッション}} が完了としてマークされます。",
       "completing": "完了処理中...",
+      "directory": {
+        "noConversation": "会話を選択すると目次を表示します。",
+        "loading": "目次を読み込み中...",
+        "empty": "この会話には目次項目がありません。"
+      },
       "toasts": {
         "importedSessions": "{imported, plural, one {# 件のセッション} other {# 件のセッション}} をインポートし、{skipped} 件をスキップしました",
         "noNewSessionsFound": "新しいセッションは見つかりませんでした（{skipped} 件をスキップ）",
@@ -1272,6 +1280,19 @@
           "low": "低",
           "unknown": "不明"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "セッションナビゲーター",
+        "collapseAria": "セッションナビゲーターを折りたたむ",
+        "collapsedSummary": "ナビ {count}",
+        "userLabel": "ユーザー",
+        "assistantLabel": "AI",
+        "toolOnly": "ツール出力のみ",
+        "attachmentOnly": "画像/添付ファイル",
+        "pendingReply": "返信なし",
+        "emptyPreview": "プレビューはありません",
+        "jumpToUserAria": "ユーザーメッセージへ移動",
+        "jumpToAssistantAria": "AI の返信へ移動"
       },
       "permissionDialog": {
         "subtitle": "エージェントがこのターンを続行するための許可を要求しています。",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "대화",
+      "tabs": {
+        "directory": "목차"
+      },
       "locateActiveConversation": "활성 대화 찾기",
       "expandAllGroups": "모든 그룹 펼치기",
       "collapseAllGroups": "모든 그룹 접기",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "모든 검토 세션을 완료 처리할까요?",
       "completeAllReviewDescription": "검토 상태의 {count, plural, one {#개 세션} other {#개 세션}}을 모두 완료로 표시합니다.",
       "completing": "완료 처리 중...",
+      "directory": {
+        "noConversation": "목차를 보려면 대화를 선택하세요.",
+        "loading": "목차를 불러오는 중...",
+        "empty": "이 대화에는 목차 항목이 없습니다."
+      },
       "toasts": {
         "importedSessions": "{imported, plural, one {#개 세션} other {#개 세션}}을 가져오고 {skipped}개를 건너뛰었습니다",
         "noNewSessionsFound": "새 세션이 없습니다 ({skipped}개 건너뜀)",
@@ -1272,6 +1280,19 @@
           "low": "낮음",
           "unknown": "알 수 없음"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "세션 위치",
+        "collapseAria": "세션 위치 접기",
+        "collapsedSummary": "위치 {count}",
+        "userLabel": "사용자",
+        "assistantLabel": "AI",
+        "toolOnly": "도구 출력만",
+        "attachmentOnly": "이미지/첨부파일",
+        "pendingReply": "응답 없음",
+        "emptyPreview": "미리보기가 없습니다",
+        "jumpToUserAria": "사용자 메시지로 이동",
+        "jumpToAssistantAria": "AI 응답으로 이동"
       },
       "permissionDialog": {
         "subtitle": "에이전트가 이 턴을 계속하기 위한 권한을 요청합니다.",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "Conversas",
+      "tabs": {
+        "directory": "Diretório"
+      },
       "locateActiveConversation": "Localizar conversa ativa",
       "expandAllGroups": "Expandir todos os grupos",
       "collapseAllGroups": "Recolher todos os grupos",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "Concluir todas as sessões em revisão?",
       "completeAllReviewDescription": "Isso marcará como concluídas todas as {count, plural, one {# sessão} other {# sessões}} em Revisão.",
       "completing": "Concluindo...",
+      "directory": {
+        "noConversation": "Selecione uma conversa para ver seu diretório.",
+        "loading": "Carregando diretório...",
+        "empty": "Não há itens de diretório nesta conversa."
+      },
       "toasts": {
         "importedSessions": "Importadas {imported, plural, one {# sessão} other {# sessões}}, ignoradas {skipped}",
         "noNewSessionsFound": "Nenhuma nova sessão encontrada (ignoradas {skipped})",
@@ -1272,6 +1280,19 @@
           "low": "Baixa",
           "unknown": "Desconhecida"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "Localizador da sessão",
+        "collapseAria": "Recolher localizador da sessão",
+        "collapsedSummary": "Localizador {count}",
+        "userLabel": "Usuário",
+        "assistantLabel": "IA",
+        "toolOnly": "Somente saída de ferramentas",
+        "attachmentOnly": "Imagens/anexos",
+        "pendingReply": "Sem resposta",
+        "emptyPreview": "Nenhuma prévia disponível",
+        "jumpToUserAria": "Ir para a mensagem do usuário",
+        "jumpToAssistantAria": "Ir para a resposta da IA"
       },
       "permissionDialog": {
         "subtitle": "O agente solicita permissão para continuar este turno.",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "会话",
+      "tabs": {
+        "directory": "目录"
+      },
       "locateActiveConversation": "定位当前会话",
       "expandAllGroups": "展开全部分组",
       "collapseAllGroups": "折叠全部分组",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "完成全部复查会话？",
       "completeAllReviewDescription": "这会将复查中的 {count} 个会话全部标记为已完成。",
       "completing": "处理中...",
+      "directory": {
+        "noConversation": "选择会话后显示目录",
+        "loading": "加载目录中...",
+        "empty": "当前会话暂无目录项"
+      },
       "toasts": {
         "importedSessions": "已导入 {imported} 个会话，跳过 {skipped} 个",
         "noNewSessionsFound": "没有新会话（已跳过 {skipped} 个）",
@@ -1272,6 +1280,19 @@
           "low": "低",
           "unknown": "未知"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "会话定位",
+        "collapseAria": "折叠会话定位",
+        "collapsedSummary": "定位 {count}",
+        "userLabel": "用户",
+        "assistantLabel": "AI",
+        "toolOnly": "仅工具调用",
+        "attachmentOnly": "图片/附件",
+        "pendingReply": "无回复",
+        "emptyPreview": "无可用摘要",
+        "jumpToUserAria": "跳转到用户消息",
+        "jumpToAssistantAria": "跳转到 AI 回复"
       },
       "permissionDialog": {
         "subtitle": "Agent 请求继续当前轮次的权限。",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -603,6 +603,9 @@
     },
     "sidebar": {
       "title": "會話",
+      "tabs": {
+        "directory": "目錄"
+      },
       "locateActiveConversation": "定位目前會話",
       "expandAllGroups": "展開全部分組",
       "collapseAllGroups": "折疊全部分組",
@@ -615,6 +618,11 @@
       "completeAllReviewTitle": "完成全部複查會話？",
       "completeAllReviewDescription": "這會將複查中的 {count} 個會話全部標記為已完成。",
       "completing": "處理中...",
+      "directory": {
+        "noConversation": "選擇會話後顯示目錄",
+        "loading": "載入目錄中...",
+        "empty": "目前會話暫無目錄項"
+      },
       "toasts": {
         "importedSessions": "已匯入 {imported} 個會話，跳過 {skipped} 個",
         "noNewSessionsFound": "沒有新會話（已跳過 {skipped} 個）",
@@ -1272,6 +1280,19 @@
           "low": "低",
           "unknown": "未知"
         }
+      },
+      "sessionLocatorOverlay": {
+        "title": "會話定位",
+        "collapseAria": "摺疊會話定位",
+        "collapsedSummary": "定位 {count}",
+        "userLabel": "使用者",
+        "assistantLabel": "AI",
+        "toolOnly": "僅工具呼叫",
+        "attachmentOnly": "圖片/附件",
+        "pendingReply": "無回覆",
+        "emptyPreview": "無可用摘要",
+        "jumpToUserAria": "跳轉到使用者訊息",
+        "jumpToAssistantAria": "跳轉到 AI 回覆"
       },
       "permissionDialog": {
         "subtitle": "Agent 請求繼續目前輪次的權限。",

--- a/src/lib/session-locator.ts
+++ b/src/lib/session-locator.ts
@@ -1,0 +1,198 @@
+import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+
+export type SessionLocatorPhase = "persisted" | "optimistic" | "streaming"
+
+export type LocatorRole = "user" | "assistant"
+
+export type LocatorPreviewKind =
+  | "text"
+  | "tool_only"
+  | "attachment_only"
+  | "pending_reply"
+  | "empty"
+
+export interface SessionLocatorRawTurn {
+  turnId: string
+  role: "user" | "assistant" | "system"
+  phase: SessionLocatorPhase
+  threadIndex: number
+  parts: AdaptedContentPart[]
+  resourceCount: number
+  imageCount: number
+}
+
+export interface SessionLocatorPreview {
+  text: string
+  kind: LocatorPreviewKind
+}
+
+export interface SessionLocatorTarget {
+  role: LocatorRole
+  turnId: string
+  threadIndex: number
+  partIndex: number | null
+  preview: SessionLocatorPreview
+}
+
+export interface SessionLocatorItem {
+  id: string
+  pairIndex: number
+  status: "complete" | "pending_reply"
+  user: SessionLocatorTarget
+  assistant: SessionLocatorTarget | null
+}
+
+function normalizePreviewText(text: string): string {
+  return text.replace(/\s+/g, " ").trim()
+}
+
+function extractTextParts(parts: AdaptedContentPart[]): string[] {
+  return parts
+    .flatMap((part) =>
+      part.type === "text" ? [normalizePreviewText(part.text)] : []
+    )
+    .filter((text) => text.length > 0)
+}
+
+function hasToolContent(parts: AdaptedContentPart[]): boolean {
+  return parts.some(
+    (part) => part.type === "tool-call" || part.type === "tool-result"
+  )
+}
+
+function getFirstTextPartIndex(parts: AdaptedContentPart[]): number | null {
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i]
+    if (part?.type === "text" && normalizePreviewText(part.text).length > 0) {
+      return i
+    }
+  }
+
+  return null
+}
+
+function getLastTextPartIndex(parts: AdaptedContentPart[]): number | null {
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i]
+    if (part?.type === "text" && normalizePreviewText(part.text).length > 0) {
+      return i
+    }
+  }
+
+  return null
+}
+
+function getLastRenderablePartIndex(
+  parts: AdaptedContentPart[]
+): number | null {
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i]
+    if (!part) continue
+
+    if (part.type === "text") {
+      if (normalizePreviewText(part.text).length > 0) {
+        return i
+      }
+      continue
+    }
+
+    return i
+  }
+
+  return null
+}
+
+export function extractUserPreview(
+  turn: SessionLocatorRawTurn
+): SessionLocatorPreview {
+  const [firstText] = extractTextParts(turn.parts)
+  if (firstText) {
+    return { text: firstText, kind: "text" }
+  }
+
+  if (turn.imageCount > 0 || turn.resourceCount > 0) {
+    return { text: "", kind: "attachment_only" }
+  }
+
+  return { text: "", kind: "empty" }
+}
+
+export function extractAssistantFinalPreview(
+  turn: SessionLocatorRawTurn
+): SessionLocatorPreview {
+  const textParts = extractTextParts(turn.parts)
+  const lastText = textParts[textParts.length - 1]
+  if (lastText) {
+    return { text: lastText, kind: "text" }
+  }
+
+  if (hasToolContent(turn.parts)) {
+    return { text: "", kind: "tool_only" }
+  }
+
+  return { text: "", kind: "empty" }
+}
+
+export function buildSessionLocatorItems(
+  turns: SessionLocatorRawTurn[]
+): SessionLocatorItem[] {
+  const items: SessionLocatorItem[] = []
+  let pendingUser: SessionLocatorTarget | null = null
+  let pairIndex = 0
+
+  const flushPendingUser = () => {
+    if (!pendingUser) return
+
+    items.push({
+      id: `${pendingUser.turnId}-pending-${pairIndex}`,
+      pairIndex,
+      status: "pending_reply",
+      user: pendingUser,
+      assistant: null,
+    })
+    pairIndex += 1
+    pendingUser = null
+  }
+
+  for (const turn of turns) {
+    if (turn.role === "system") continue
+
+    if (turn.role === "user") {
+      flushPendingUser()
+      pendingUser = {
+        role: "user",
+        turnId: turn.turnId,
+        threadIndex: turn.threadIndex,
+        partIndex: getFirstTextPartIndex(turn.parts),
+        preview: extractUserPreview(turn),
+      }
+      continue
+    }
+
+    if (!pendingUser) continue
+
+    const assistantTarget: SessionLocatorTarget = {
+      role: "assistant",
+      turnId: turn.turnId,
+      threadIndex: turn.threadIndex,
+      partIndex:
+        getLastTextPartIndex(turn.parts) ??
+        getLastRenderablePartIndex(turn.parts),
+      preview: extractAssistantFinalPreview(turn),
+    }
+
+    items.push({
+      id: `${pendingUser.turnId}-${turn.turnId}-${pairIndex}`,
+      pairIndex,
+      status: "complete",
+      user: pendingUser,
+      assistant: assistantTarget,
+    })
+    pairIndex += 1
+    pendingUser = null
+  }
+
+  flushPendingUser()
+
+  return items
+}


### PR DESCRIPTION

- add session locator into the sidebar directory view, preserve sidebar tab state when switching panes, and share navigation state between thread and sidebar
- localize the new session locator copy across supported languages

<img width="1093" height="527" alt="image" src="https://github.com/user-attachments/assets/24a60cf9-35ae-4b36-a050-5d3d1d467774" />
