### PR TITLE
Add directory locator navigation for conversation threads

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -523,3 +523,78 @@
     background-color: rgba(248, 81, 73, 0.35);
   }
 }
+
+@keyframes session-locator-highlight-fade {
+  0% {
+    opacity: 0;
+    border-color: color-mix(in srgb, var(--primary) 14%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+
+  10% {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--primary) 30%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+
+  40% {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--primary) 46%, transparent);
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--primary) 12%, transparent);
+  }
+
+  68% {
+    opacity: 1;
+    border-color: color-mix(in srgb, var(--primary) 26%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 6%, transparent);
+  }
+
+  100% {
+    opacity: 0;
+    border-color: color-mix(in srgb, var(--primary) 14%, transparent);
+    box-shadow: 0 0 0 10px color-mix(in srgb, var(--primary) 0%, transparent);
+  }
+}
+
+.session-locator-turn-highlight {
+  isolation: isolate;
+  position: relative;
+}
+
+.session-locator-turn-highlight::after {
+  content: "";
+  position: absolute;
+  inset: -10px;
+  pointer-events: none;
+  border-radius: calc(1rem + 10px);
+  border: 1px solid color-mix(in srgb, var(--primary) 28%, transparent);
+  background: transparent;
+  animation: session-locator-highlight-fade 1500ms
+    cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.session-locator-part-highlight {
+  isolation: isolate;
+  position: relative;
+}
+
+.session-locator-part-highlight::after {
+  content: "";
+  position: absolute;
+  inset-block: -8px;
+  inset-inline: -6px;
+  pointer-events: none;
+  border-radius: calc(0.75rem + 6px);
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  background: transparent;
+  animation: session-locator-highlight-fade 1500ms
+    cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-locator-turn-highlight::after,
+  .session-locator-part-highlight::after {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -56,9 +56,9 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex min-w-0 flex-col gap-2 overflow-hidden text-sm",
-      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:max-w-full group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
-      "group-[.is-assistant]:w-full group-[.is-assistant]:text-foreground",
+      "is-user:dark flex min-w-0 flex-col gap-2 text-sm",
+      "group-[.is-user]:ml-auto group-[.is-user]:w-fit group-[.is-user]:max-w-full group-[.is-user]:overflow-hidden group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-assistant]:w-full group-[.is-assistant]:overflow-visible group-[.is-assistant]:text-foreground",
       className
     )}
     {...props}

--- a/src/components/chat/agent-plan-overlay.tsx
+++ b/src/components/chat/agent-plan-overlay.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { memo, useMemo, useState } from "react"
+import { memo, useMemo, useState, type CSSProperties } from "react"
 import { useTranslations } from "next-intl"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -22,9 +22,12 @@ interface AgentPlanOverlayProps {
   planKey?: string | null
   visible?: boolean
   defaultExpanded?: boolean
+  className?: string
+  panelWidthPx?: number
+  panelMaxHeightPx?: number
 }
 
-function getLatestPlanEntries(message: LiveMessage | null): PlanEntryInfo[] {
+export function getLatestPlanEntries(message: LiveMessage | null): PlanEntryInfo[] {
   if (!message) return []
 
   for (let i = message.content.length - 1; i >= 0; i -= 1) {
@@ -106,6 +109,9 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
   planKey,
   visible = true,
   defaultExpanded = true,
+  className,
+  panelWidthPx,
+  panelMaxHeightPx,
 }: AgentPlanOverlayProps) {
   const t = useTranslations("Folder.chat.agentPlanOverlay")
   const liveEntries = useMemo(
@@ -136,6 +142,17 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
   const [collapsedByPlanKey, setCollapsedByPlanKey] = useState<
     Record<string, boolean>
   >({})
+  const panelStyle: CSSProperties | undefined = panelWidthPx
+    ? {
+        width: `${panelWidthPx}px`,
+        maxWidth: "100%",
+        ...(panelMaxHeightPx
+          ? { maxHeight: `${panelMaxHeightPx}px` }
+          : null),
+      }
+    : panelMaxHeightPx
+      ? { maxHeight: `${panelMaxHeightPx}px` }
+      : undefined
   const isExpanded = !(
     collapsedByPlanKey[currentPlanStateKey] ?? !resolvedDefaultExpanded
   )
@@ -146,12 +163,12 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
 
   if (!isExpanded) {
     return (
-      <div className="pointer-events-none absolute right-8 top-4 z-20 flex">
+      <div className={cn("pointer-events-auto flex", className)}>
         <Button
           type="button"
           variant="secondary"
           size="sm"
-          className="cursor-pointer pointer-events-auto shadow-md bg-secondary/70 hover:bg-secondary"
+          className="h-8 w-44 justify-between gap-2 cursor-pointer shadow-md bg-secondary/70 hover:bg-secondary"
           onClick={() =>
             setCollapsedByPlanKey((prev) => ({
               ...prev,
@@ -160,10 +177,12 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
           }
         >
           <ListTodoIcon className="h-4 w-4" />
-          {t("collapsedSummary", {
-            completed: completedCount,
-            total: resolvedEntries.length,
-          })}
+          <span className="min-w-0 flex-1 truncate text-center">
+            {t("collapsedSummary", {
+              completed: completedCount,
+              total: resolvedEntries.length,
+            })}
+          </span>
           <ChevronUpIcon className="h-4 w-4" />
         </Button>
       </div>
@@ -172,10 +191,11 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
 
   return (
     <div
-      className="pointer-events-none absolute right-8 top-4 z-20 flex max-w-[min(22rem,calc(100%-2rem))]"
+      className={cn("pointer-events-auto flex min-h-0 min-w-0 max-h-full", className)}
+      style={panelStyle}
       data-plan-key={currentPlanKey ?? undefined}
     >
-      <div className="pointer-events-auto w-72 max-w-full rounded-xl border bg-card/60 hover:bg-card/95 shadow-lg backdrop-blur transition-colors supports-[backdrop-filter]:bg-card/50 supports-[backdrop-filter]:hover:bg-card/85">
+      <div className="flex min-h-0 max-h-full w-full max-w-full flex-col rounded-xl border bg-card/60 shadow-lg backdrop-blur transition-colors hover:bg-card/95 supports-[backdrop-filter]:bg-card/50 supports-[backdrop-filter]:hover:bg-card/85">
         <div className="flex items-center justify-between border-b px-3 py-2">
           <div className="flex items-center gap-2 min-w-0">
             <ListTodoIcon className="h-4 w-4 text-muted-foreground" />
@@ -200,7 +220,7 @@ export const AgentPlanOverlay = memo(function AgentPlanOverlay({
           </Button>
         </div>
 
-        <div className="max-h-96 overflow-y-auto p-3 space-y-2">
+        <div className="min-h-0 flex-1 overflow-y-auto p-3 space-y-2">
           {resolvedEntries.map((entry, index) => (
             <div
               key={`${entry.content}-${index}`}

--- a/src/components/chat/message-navigator-overlay.tsx
+++ b/src/components/chat/message-navigator-overlay.tsx
@@ -1,0 +1,248 @@
+"use client"
+
+import { memo, useMemo, useState, type CSSProperties } from "react"
+import { useTranslations } from "next-intl"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import type {
+  SessionLocatorItem,
+  SessionLocatorPreview,
+  SessionLocatorTarget,
+} from "@/lib/session-locator"
+import { cn } from "@/lib/utils"
+import {
+  Bot,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  MapIcon,
+  User,
+} from "lucide-react"
+
+interface MessageNavigatorOverlayProps {
+  items: SessionLocatorItem[]
+  locatorKey?: string | null
+  visible?: boolean
+  defaultExpanded?: boolean
+  className?: string
+  panelWidthPx?: number
+  panelMaxHeightPx?: number
+  onJumpToTarget: (target: SessionLocatorTarget) => void
+}
+
+function getPreviewText(
+  preview: SessionLocatorPreview,
+  t: ReturnType<typeof useTranslations>
+): string {
+  switch (preview.kind) {
+    case "text":
+      return preview.text
+    case "tool_only":
+      return t("toolOnly")
+    case "attachment_only":
+      return t("attachmentOnly")
+    default:
+      return t("emptyPreview")
+  }
+}
+
+const NavigatorRow = memo(function NavigatorRow({
+  role,
+  preview,
+  ariaLabel,
+  onClick,
+  disabled = false,
+}: {
+  role: "user" | "assistant"
+  preview: string
+  ariaLabel?: string
+  onClick?: () => void
+  disabled?: boolean
+}) {
+  const rowClassName = cn(
+    "flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+    disabled
+      ? "cursor-default text-muted-foreground"
+      : "cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+  )
+
+  if (disabled) {
+    return (
+      <div className={rowClassName}>
+        <Badge
+          variant="outline"
+          className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center p-0"
+        >
+          {role === "user" ? (
+            <User className="h-3 w-3" />
+          ) : (
+            <Bot className="h-3 w-3" />
+          )}
+        </Badge>
+        <p className="min-w-0 flex-1 line-clamp-2 break-words text-sm leading-5 text-muted-foreground">
+          {preview}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <button type="button" className={rowClassName} onClick={onClick}>
+      {ariaLabel ? <span className="sr-only">{ariaLabel} </span> : null}
+      <Badge
+        variant="outline"
+        className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center p-0"
+      >
+        {role === "user" ? (
+          <User className="h-3 w-3" />
+        ) : (
+          <Bot className="h-3 w-3" />
+        )}
+      </Badge>
+      <p className="min-w-0 flex-1 line-clamp-2 break-words text-sm leading-5 text-foreground">
+        {preview}
+      </p>
+    </button>
+  )
+})
+
+export const MessageNavigatorOverlay = memo(function MessageNavigatorOverlay({
+  items,
+  locatorKey,
+  visible = true,
+  defaultExpanded = true,
+  className,
+  panelWidthPx,
+  panelMaxHeightPx,
+  onJumpToTarget,
+}: MessageNavigatorOverlayProps) {
+  const t = useTranslations("Folder.chat.messageNavigator")
+  const hasItems = visible && items.length > 0
+  const fallbackKey = useMemo(() => {
+    if (items.length === 0) return null
+    return items
+      .map((item) => `${item.id}:${item.status}:${item.user.turnId}`)
+      .join("|")
+  }, [items])
+  const currentLocatorKey = locatorKey ?? fallbackKey
+  const currentLocatorStateKey =
+    currentLocatorKey ?? "__message_navigator__default__"
+  const [collapsedByLocatorKey, setCollapsedByLocatorKey] = useState<
+    Record<string, boolean>
+  >({})
+  const hasStoredCollapsedState = Object.prototype.hasOwnProperty.call(
+    collapsedByLocatorKey,
+    currentLocatorStateKey
+  )
+
+  const panelStyle: CSSProperties | undefined = panelWidthPx
+    ? {
+        width: `${panelWidthPx}px`,
+        maxWidth: "100%",
+        ...(panelMaxHeightPx ? { maxHeight: `${panelMaxHeightPx}px` } : null),
+      }
+    : panelMaxHeightPx
+      ? { maxHeight: `${panelMaxHeightPx}px` }
+      : undefined
+  const isExpanded = hasStoredCollapsedState
+    ? !collapsedByLocatorKey[currentLocatorStateKey]
+    : defaultExpanded
+
+  if (!hasItems) {
+    return null
+  }
+
+  if (!isExpanded) {
+    return (
+      <div className={cn("pointer-events-auto flex", className)}>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="h-8 w-44 justify-between gap-2 cursor-pointer shadow-md bg-secondary/70 hover:bg-secondary"
+          onClick={() =>
+            setCollapsedByLocatorKey((prev) => ({
+              ...prev,
+              [currentLocatorStateKey]: false,
+            }))
+          }
+        >
+          <MapIcon className="h-4 w-4" />
+          <span className="min-w-0 flex-1 truncate text-center">
+            {t("collapsedSummary", { count: items.length })}
+          </span>
+          <ChevronUpIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto flex min-h-0 max-h-full min-w-0",
+        className
+      )}
+      style={panelStyle}
+      data-locator-key={currentLocatorKey ?? undefined}
+    >
+      <div className="flex min-h-0 max-h-full w-full flex-col rounded-xl border bg-card/60 shadow-lg backdrop-blur transition-colors hover:bg-card/95 supports-[backdrop-filter]:bg-card/50 supports-[backdrop-filter]:hover:bg-card/85">
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <MapIcon className="h-4 w-4 text-muted-foreground" />
+            <span className="truncate text-sm font-medium">{t("title")}</span>
+            <Badge variant="secondary" className="h-5">
+              {items.length}
+            </Badge>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={t("collapseAria")}
+            onClick={() =>
+              setCollapsedByLocatorKey((prev) => ({
+                ...prev,
+                [currentLocatorStateKey]: true,
+              }))
+            }
+          >
+            <ChevronRightIcon className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div
+          className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3"
+          role="navigation"
+          aria-label={t("title")}
+        >
+          {items.map((item) => {
+            const userPreview = getPreviewText(item.user.preview, t)
+            const assistantTarget = item.assistant
+
+            return (
+              <div
+                key={item.id}
+                className="rounded-lg border bg-transparent px-1.5 py-1.5"
+              >
+                <NavigatorRow
+                  role="user"
+                  preview={userPreview}
+                  ariaLabel={t("jumpToUserAria")}
+                  onClick={() => onJumpToTarget(item.user)}
+                />
+                {assistantTarget ? (
+                  <NavigatorRow
+                    role="assistant"
+                    preview={getPreviewText(assistantTarget.preview, t)}
+                    ariaLabel={t("jumpToAssistantAria")}
+                    onClick={() => onJumpToTarget(assistantTarget)}
+                  />
+                ) : null}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+})

--- a/src/components/message/content-parts-renderer.tsx
+++ b/src/components/message/content-parts-renderer.tsx
@@ -8,6 +8,7 @@ import {
   countUnifiedDiffLineChanges,
   estimateChangedLineStats,
 } from "@/lib/line-change-stats"
+import { cn } from "@/lib/utils"
 import { MessageResponse } from "@/components/ai-elements/message"
 import {
   Tool,
@@ -2300,37 +2301,81 @@ const ReasoningPart = memo(function ReasoningPart({
 interface ContentPartsRendererProps {
   parts: AdaptedContentPart[]
   role?: MessageRole
+  highlightedPartIndex?: number | null
+  highlightToken?: string | number
 }
 
 export const ContentPartsRenderer = memo(function ContentPartsRenderer({
   parts,
   role,
+  highlightedPartIndex = null,
+  highlightToken,
 }: ContentPartsRendererProps) {
+  const getPartClassName = (index: number) =>
+    cn(
+      "relative z-10 rounded-xl",
+      highlightedPartIndex === index &&
+        highlightToken !== undefined &&
+        "session-locator-part-highlight"
+    )
+
   return (
     <div className="space-y-2">
       {parts.map((part, i) => {
         if (part.type === "text") {
           return (
-            <TextPart
+            <div
               key={`text-${i}`}
-              text={part.text}
-              preserveNewlines={role === "user"}
-            />
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="text"
+              data-highlight-token={highlightToken}
+            >
+              <TextPart text={part.text} preserveNewlines={role === "user"} />
+            </div>
           )
         }
 
         if (part.type === "tool-call") {
-          return <ToolCallPart key={`tc-${part.toolCallId ?? i}`} part={part} />
+          return (
+            <div
+              key={`tc-${part.toolCallId ?? i}`}
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="tool-call"
+              data-highlight-token={highlightToken}
+            >
+              <ToolCallPart part={part} />
+            </div>
+          )
         }
 
         if (part.type === "tool-result") {
           return (
-            <ToolResultPart key={`tr-${part.toolCallId ?? i}`} part={part} />
+            <div
+              key={`tr-${part.toolCallId ?? i}`}
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="tool-result"
+              data-highlight-token={highlightToken}
+            >
+              <ToolResultPart part={part} />
+            </div>
           )
         }
 
         if (part.type === "reasoning") {
-          return <ReasoningPart key={`reasoning-${i}`} part={part} />
+          return (
+            <div
+              key={`reasoning-${i}`}
+              className={getPartClassName(i)}
+              data-content-part-index={i}
+              data-content-part-type="reasoning"
+              data-highlight-token={highlightToken}
+            >
+              <ReasoningPart part={part} />
+            </div>
+          )
         }
 
         return null

--- a/src/components/message/message-list-view.tsx
+++ b/src/components/message/message-list-view.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { memo, useCallback, useEffect, useMemo, useRef } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { StickToBottomContext } from "use-stick-to-bottom"
 import { useConversationRuntime } from "@/contexts/conversation-runtime-context"
 import { ContentPartsRenderer } from "./content-parts-renderer"
 import {
@@ -14,7 +15,11 @@ import { LiveTurnStats } from "./live-turn-stats"
 import { UserResourceLinks } from "./user-resource-links"
 import { UserImageAttachments } from "./user-image-attachments"
 import { useSessionStats } from "@/contexts/session-stats-context"
-import { AgentPlanOverlay } from "@/components/chat/agent-plan-overlay"
+import {
+  AgentPlanOverlay,
+  getLatestPlanEntries,
+} from "@/components/chat/agent-plan-overlay"
+import { MessageNavigatorOverlay } from "@/components/chat/message-navigator-overlay"
 import { MessageThread } from "@/components/ai-elements/message-thread"
 import { Message, MessageContent } from "@/components/ai-elements/message"
 import { Loader2 } from "lucide-react"
@@ -24,8 +29,37 @@ import {
   extractLatestPlanEntriesFromMessages,
 } from "@/lib/agent-plan"
 import type { AgentType, ConnectionStatus, SessionStats } from "@/lib/types"
-import { VirtualizedMessageThread } from "@/components/message/virtualized-message-thread"
+import {
+  VirtualizedMessageThread,
+  type VirtualizedMessageThreadHandle,
+} from "@/components/message/virtualized-message-thread"
+import { useSessionLocatorItems } from "@/hooks/use-session-locator-items"
+import { useTabContext } from "@/contexts/tab-context"
+import { useMessageHighlight } from "@/components/message/use-message-highlight"
+import { cn } from "@/lib/utils"
 import { useStickToBottomContext } from "use-stick-to-bottom"
+
+const MESSAGE_THREAD_MAX_WIDTH_PX = 768
+const MESSAGE_THREAD_CONTENT_SHELL_MAX_WIDTH_PX = 800
+const MESSAGE_NAVIGATOR_COLLAPSED_EXTRA_WIDTH_PX = 16
+const MESSAGE_NAVIGATOR_EXPANDED_EXTRA_WIDTH_PX = 96
+const MESSAGE_NAVIGATOR_COLLAPSED_THRESHOLD_PX =
+  MESSAGE_THREAD_MAX_WIDTH_PX + MESSAGE_NAVIGATOR_COLLAPSED_EXTRA_WIDTH_PX
+const MESSAGE_NAVIGATOR_EXPANDED_THRESHOLD_PX =
+  MESSAGE_THREAD_MAX_WIDTH_PX + MESSAGE_NAVIGATOR_EXPANDED_EXTRA_WIDTH_PX
+const OVERLAY_PANEL_MIN_WIDTH_PX = 288
+const OVERLAY_PANEL_MAX_WIDTH_PX = 448
+const OVERLAY_PANEL_GUTTER_PADDING_PX = 12
+const OVERLAY_PANEL_HORIZONTAL_INSET_PX = 32
+const OVERLAY_STACK_VERTICAL_PADDING_PX = 32
+const OVERLAY_STACK_GAP_PX = 12
+const SHIFTED_MESSAGE_MIN_WIDTH_PX = 640
+const SHIFTED_MESSAGE_MIN_LEFT_MARGIN_PX = 24
+const SHIFTED_MESSAGE_MAX_LEFT_SHIFT_PX = 141
+const OVERLAY_PANEL_TARGET_RIGHT_GAP_PX =
+  OVERLAY_PANEL_MAX_WIDTH_PX +
+  OVERLAY_PANEL_GUTTER_PADDING_PX +
+  OVERLAY_PANEL_HORIZONTAL_INSET_PX
 
 interface MessageListViewProps {
   conversationId: number
@@ -66,18 +100,39 @@ type ThreadRenderItem =
 const HistoricalMessageGroup = memo(function HistoricalMessageGroup({
   group,
   dimmed = false,
+  highlightedPartIndex = null,
+  highlightTurn = false,
+  highlightToken,
 }: {
   group: ResolvedMessageGroup
   dimmed?: boolean
+  highlightedPartIndex?: number | null
+  highlightTurn?: boolean
+  highlightToken?: number
 }) {
   return (
-    <div className={dimmed ? "opacity-70" : undefined}>
+    <div
+      className={cn(
+        "rounded-2xl",
+        dimmed && "opacity-70",
+        highlightTurn &&
+          highlightToken !== undefined &&
+          "session-locator-turn-highlight"
+      )}
+      data-turn-id={group.id}
+      data-highlight-token={highlightToken}
+    >
       <Message from={group.role}>
         {group.role === "user" && group.images.length > 0 ? (
           <UserImageAttachments images={group.images} className="self-end" />
         ) : null}
         <MessageContent>
-          <ContentPartsRenderer parts={group.parts} role={group.role} />
+          <ContentPartsRenderer
+            parts={group.parts}
+            role={group.role}
+            highlightedPartIndex={highlightedPartIndex}
+            highlightToken={highlightToken}
+          />
         </MessageContent>
         {group.role === "user" && group.resources.length > 0 ? (
           <UserResourceLinks resources={group.resources} className="self-end" />
@@ -152,6 +207,52 @@ export function MessageListView({
   const timelineTurns = getTimelineTurns(conversationId)
 
   const { setSessionStats } = useSessionStats()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const threadRef = useRef<VirtualizedMessageThreadHandle | null>(null)
+  const stickToBottomContextRef = useRef<StickToBottomContext | null>(null)
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
+  const { isTileMode, tabs } = useTabContext()
+  const sessionLocatorItems = useSessionLocatorItems(conversationId)
+  const { highlightedTarget, jumpToTarget } = useMessageHighlight({
+    rootRef,
+    threadRef,
+    stopAutoStick: () => stickToBottomContextRef.current?.stopScroll(),
+  })
+
+  useEffect(() => {
+    const container = rootRef.current
+    if (!container) return
+
+    const updateSize = (nextWidth: number, nextHeight: number) => {
+      setContainerSize((prev) => {
+        if (
+          Math.abs(prev.width - nextWidth) < 1 &&
+          Math.abs(prev.height - nextHeight) < 1
+        ) {
+          return prev
+        }
+
+        return {
+          width: nextWidth,
+          height: nextHeight,
+        }
+      })
+    }
+
+    updateSize(container.clientWidth, container.clientHeight)
+
+    const observer = new ResizeObserver((entries) => {
+      updateSize(
+        entries[0]?.contentRect.width ?? container.clientWidth,
+        entries[0]?.contentRect.height ?? container.clientHeight
+      )
+    })
+
+    observer.observe(container)
+    return () => {
+      observer.disconnect()
+    }
+  }, [detailError, detailLoading, liveMessage, timelineTurns.length])
 
   useEffect(() => {
     if (isActive) {
@@ -233,22 +334,41 @@ export function MessageListView({
     () => buildPlanKey(historicalPlanEntries),
     [historicalPlanEntries]
   )
+  const livePlanEntries = useMemo(
+    () => getLatestPlanEntries(liveMessage ?? null),
+    [liveMessage]
+  )
 
-  const renderThreadItem = useCallback((item: ThreadRenderItem) => {
-    switch (item.kind) {
-      case "turn":
-        return (
-          <HistoricalMessageGroup
-            group={item.group}
-            dimmed={item.phase === "optimistic"}
-          />
-        )
-      case "typing":
-        return <PendingTypingIndicator />
-      default:
-        return null
-    }
-  }, [])
+  const renderThreadItem = useCallback(
+    (item: ThreadRenderItem) => {
+      switch (item.kind) {
+        case "turn": {
+          const isHighlightedTurn = highlightedTarget?.turnId === item.group.id
+          const highlightedPartIndex = isHighlightedTurn
+            ? highlightedTarget.partIndex
+            : null
+          const shouldHighlightWholeTurn =
+            isHighlightedTurn && highlightedPartIndex === null
+          return (
+            <HistoricalMessageGroup
+              group={item.group}
+              dimmed={item.phase === "optimistic"}
+              highlightedPartIndex={highlightedPartIndex}
+              highlightTurn={shouldHighlightWholeTurn}
+              highlightToken={
+                isHighlightedTurn ? highlightedTarget.token : undefined
+              }
+            />
+          )
+        }
+        case "typing":
+          return <PendingTypingIndicator />
+        default:
+          return null
+      }
+    },
+    [highlightedTarget]
+  )
 
   const emptyState = useMemo(
     () =>
@@ -263,8 +383,111 @@ export function MessageListView({
   )
 
   const agentPlanOverlayKey = liveMessage?.id ?? `history-${conversationId}`
-
   const hasRenderableContent = threadItems.length > 0 || Boolean(liveMessage)
+  const hasAgentPlanOverlay =
+    livePlanEntries.length > 0 || historicalPlanEntries.length > 0
+  const isEffectivelyTiled = isTileMode && tabs.length > 1
+  const containerWidth = containerSize.width
+  const containerHeight = containerSize.height
+  const shiftedThreadLayout = useMemo(() => {
+    if (containerWidth <= 0) {
+      return {
+        overlayPanelWidthPx: OVERLAY_PANEL_MAX_WIDTH_PX,
+        rowStyle: undefined,
+      }
+    }
+
+    const contentShellWidth = Math.min(
+      containerWidth,
+      MESSAGE_THREAD_CONTENT_SHELL_MAX_WIDTH_PX
+    )
+    const centeredGap = Math.max(0, (containerWidth - contentShellWidth) / 2)
+    const requiredExtraRightGap = Math.max(
+      0,
+      OVERLAY_PANEL_TARGET_RIGHT_GAP_PX - centeredGap
+    )
+    const leftShiftBudget = Math.min(
+      SHIFTED_MESSAGE_MAX_LEFT_SHIFT_PX,
+      Math.max(0, centeredGap - SHIFTED_MESSAGE_MIN_LEFT_MARGIN_PX)
+    )
+    const leftShift = Math.floor(
+      Math.min(leftShiftBudget, requiredExtraRightGap)
+    )
+    const remainingExtraRightGap = Math.max(
+      0,
+      requiredExtraRightGap - leftShift
+    )
+    const widthReduction = Math.floor(
+      Math.min(
+        Math.max(0, contentShellWidth - SHIFTED_MESSAGE_MIN_WIDTH_PX),
+        remainingExtraRightGap
+      )
+    )
+    const targetWidth = Math.max(
+      SHIFTED_MESSAGE_MIN_WIDTH_PX,
+      Math.floor(contentShellWidth - widthReduction)
+    )
+    const marginLeft = Math.max(
+      SHIFTED_MESSAGE_MIN_LEFT_MARGIN_PX,
+      Math.floor(centeredGap - leftShift)
+    )
+    const renderedTargetWidth = Math.min(containerWidth, targetWidth)
+    const rightGap = Math.max(
+      0,
+      containerWidth - marginLeft - renderedTargetWidth
+    )
+    const overlayPanelWidthPx = Math.max(
+      OVERLAY_PANEL_MIN_WIDTH_PX,
+      Math.min(
+        OVERLAY_PANEL_MAX_WIDTH_PX,
+        Math.floor(
+          rightGap -
+            OVERLAY_PANEL_GUTTER_PADDING_PX -
+            OVERLAY_PANEL_HORIZONTAL_INSET_PX
+        )
+      )
+    )
+    const shouldApplyShiftedLayout = leftShift > 0 || widthReduction > 0
+
+    return {
+      overlayPanelWidthPx,
+      rowStyle: shouldApplyShiftedLayout
+        ? {
+            width: `${targetWidth}px`,
+            maxWidth: "100%",
+            marginLeft: `${marginLeft}px`,
+            marginRight: "auto",
+          }
+        : undefined,
+    }
+  }, [containerWidth])
+  const overlayPanelWidthPx = shiftedThreadLayout.overlayPanelWidthPx
+  const shiftedThreadRowStyle = shiftedThreadLayout.rowStyle
+  const overlayAvailableHeightPx = useMemo(
+    () =>
+      Math.max(
+        0,
+        containerHeight -
+          OVERLAY_STACK_VERTICAL_PADDING_PX -
+          OVERLAY_STACK_GAP_PX
+      ),
+    [containerHeight]
+  )
+  const canShowNavigatorCollapsed =
+    sessionLocatorItems.length > 0 &&
+    (isEffectivelyTiled ||
+      containerWidth >= MESSAGE_NAVIGATOR_COLLAPSED_THRESHOLD_PX)
+  const showMessageNavigator = canShowNavigatorCollapsed
+  const expandMessageNavigatorByDefault =
+    !hasAgentPlanOverlay &&
+    containerWidth >= MESSAGE_NAVIGATOR_EXPANDED_THRESHOLD_PX
+  const splitOverlayHeights = hasAgentPlanOverlay && showMessageNavigator
+  const planPanelMaxHeightPx = splitOverlayHeights
+    ? Math.floor(overlayAvailableHeightPx * 0.4)
+    : overlayAvailableHeightPx || undefined
+  const navigatorPanelMaxHeightPx = splitOverlayHeights
+    ? Math.floor(overlayAvailableHeightPx * 0.6)
+    : overlayAvailableHeightPx || undefined
 
   if (detailLoading && !hasRenderableContent) {
     return (
@@ -290,19 +513,22 @@ export function MessageListView({
   }
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col">
+    <div ref={rootRef} className="relative flex h-full min-h-0 flex-col">
       <MessageThread
         className="flex-1 min-h-0"
+        contextRef={stickToBottomContextRef}
         resize={shouldUseSmoothResize ? "smooth" : undefined}
       >
         <AutoScrollOnSend signal={sendSignal} />
         <VirtualizedMessageThread
+          ref={threadRef}
           items={threadItems}
           getItemKey={(item) => item.key}
           renderItem={renderThreadItem}
           emptyState={emptyState}
           estimateSize={180}
           overscan={10}
+          rowContainerStyle={shiftedThreadRowStyle}
         />
       </MessageThread>
       {liveMessage && connStatus === "prompting" && (
@@ -312,13 +538,36 @@ export function MessageListView({
           isStreaming={connStatus === "prompting"}
         />
       )}
-      <AgentPlanOverlay
-        key={agentPlanOverlayKey}
-        message={liveMessage ?? null}
-        entries={historicalPlanEntries}
-        planKey={historicalPlanKey}
-        defaultExpanded={connStatus === "prompting"}
-      />
+      {(hasAgentPlanOverlay || sessionLocatorItems.length > 0) && (
+        <div className="pointer-events-none absolute inset-x-0 top-4 bottom-4 z-20 px-4 sm:px-8">
+          <div className="flex h-full min-h-0 flex-col items-end gap-3">
+            {hasAgentPlanOverlay && (
+              <AgentPlanOverlay
+                key={agentPlanOverlayKey}
+                className="max-w-full"
+                message={liveMessage ?? null}
+                entries={historicalPlanEntries}
+                planKey={historicalPlanKey}
+                defaultExpanded={connStatus === "prompting"}
+                panelWidthPx={overlayPanelWidthPx}
+                panelMaxHeightPx={planPanelMaxHeightPx}
+              />
+            )}
+            {sessionLocatorItems.length > 0 && (
+              <MessageNavigatorOverlay
+                className="max-w-full"
+                items={sessionLocatorItems}
+                locatorKey={`conversation-${conversationId}`}
+                visible={showMessageNavigator}
+                onJumpToTarget={jumpToTarget}
+                defaultExpanded={expandMessageNavigatorByDefault}
+                panelWidthPx={overlayPanelWidthPx}
+                panelMaxHeightPx={navigatorPanelMaxHeightPx}
+              />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/message/use-message-highlight.ts
+++ b/src/components/message/use-message-highlight.ts
@@ -1,0 +1,172 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
+import type { SessionLocatorTarget } from "@/lib/session-locator"
+import type { VirtualizedMessageThreadHandle } from "./virtualized-message-thread"
+
+export interface HighlightedMessageTarget {
+  turnId: string
+  partIndex: number | null
+  token: number
+}
+
+interface UseMessageHighlightOptions {
+  rootRef: RefObject<HTMLElement | null>
+  threadRef: RefObject<VirtualizedMessageThreadHandle | null>
+  stopAutoStick?: () => void
+}
+
+const HIGHLIGHT_ANIMATION_DURATION_MS = 1800
+const HIGHLIGHT_STATE_RESET_DELAY_MS = HIGHLIGHT_ANIMATION_DURATION_MS + 300
+const TARGET_TOP_OFFSET_PX = 88
+const TARGET_ALIGNMENT_TOLERANCE_PX = 12
+const TARGET_VISIBILITY_PADDING_PX = 24
+const TARGET_MAX_ALIGNMENT_ATTEMPTS = 36
+const ALIGNMENT_FRAME_DELAY = 2
+
+function scheduleFrameDelay(frameDelay: number, callback: () => void) {
+  let remainingFrames = frameDelay
+
+  const tick = () => {
+    if (remainingFrames <= 0) {
+      callback()
+      return
+    }
+
+    remainingFrames -= 1
+    requestAnimationFrame(tick)
+  }
+
+  requestAnimationFrame(tick)
+}
+
+export function useMessageHighlight({
+  rootRef,
+  threadRef,
+  stopAutoStick,
+}: UseMessageHighlightOptions) {
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const jumpTokenRef = useRef(0)
+  const [highlightedTarget, setHighlightedTarget] =
+    useState<HighlightedMessageTarget | null>(null)
+
+  const clearHighlightTimeout = useCallback(() => {
+    if (highlightTimeoutRef.current) {
+      clearTimeout(highlightTimeoutRef.current)
+      highlightTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => clearHighlightTimeout, [clearHighlightTimeout])
+
+  const jumpToTarget = useCallback(
+    (target: SessionLocatorTarget) => {
+      jumpTokenRef.current += 1
+      const activeJumpToken = jumpTokenRef.current
+
+      stopAutoStick?.()
+
+      const nextHighlight: HighlightedMessageTarget = {
+        turnId: target.turnId,
+        partIndex: target.partIndex,
+        token: Date.now(),
+      }
+
+      clearHighlightTimeout()
+      setHighlightedTarget(null)
+
+      threadRef.current?.scrollToIndex(target.threadIndex, {
+        align: "start",
+        behavior: "auto",
+      })
+
+      let attempts = 0
+
+      const finalizeHighlight = () => {
+        if (jumpTokenRef.current !== activeJumpToken) return
+
+        setHighlightedTarget(nextHighlight)
+        clearHighlightTimeout()
+        highlightTimeoutRef.current = setTimeout(() => {
+          setHighlightedTarget((current) =>
+            current?.token === nextHighlight.token ? null : current
+          )
+          highlightTimeoutRef.current = null
+        }, HIGHLIGHT_STATE_RESET_DELAY_MS)
+      }
+
+      const alignTarget = () => {
+        if (jumpTokenRef.current !== activeJumpToken) return
+
+        const root = rootRef.current
+        const scrollElement = threadRef.current?.getScrollElement()
+        if (!root || !scrollElement) {
+          finalizeHighlight()
+          return
+        }
+
+        const turnElement = Array.from(
+          root.querySelectorAll<HTMLElement>("[data-turn-id]")
+        ).find((element) => element.dataset.turnId === target.turnId)
+
+        const targetElement =
+          target.partIndex === null
+            ? turnElement
+            : (turnElement?.querySelector<HTMLElement>(
+                `[data-content-part-index="${target.partIndex}"]`
+              ) ?? turnElement)
+
+        if (targetElement) {
+          const scrollRect = scrollElement.getBoundingClientRect()
+          const targetRect = targetElement.getBoundingClientRect()
+          const nextTop =
+            scrollElement.scrollTop +
+            (targetRect.top - scrollRect.top) -
+            TARGET_TOP_OFFSET_PX
+          const anchorTop = scrollRect.top + TARGET_TOP_OFFSET_PX
+          const distanceFromAnchor = targetRect.top - anchorTop
+          const isVisible =
+            targetRect.bottom >=
+              scrollRect.top + TARGET_VISIBILITY_PADDING_PX &&
+            targetRect.top <= scrollRect.bottom - TARGET_VISIBILITY_PADDING_PX
+          const isAligned =
+            Math.abs(distanceFromAnchor) <= TARGET_ALIGNMENT_TOLERANCE_PX
+
+          if (isVisible && isAligned) {
+            finalizeHighlight()
+            return
+          }
+
+          scrollElement.scrollTo({
+            top: Math.max(0, nextTop),
+            behavior: "auto",
+          })
+        }
+
+        attempts += 1
+        if (attempts < TARGET_MAX_ALIGNMENT_ATTEMPTS) {
+          scheduleFrameDelay(ALIGNMENT_FRAME_DELAY, alignTarget)
+          return
+        }
+
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[session-locator] Unable to fully align jump target", {
+            partIndex: target.partIndex,
+            threadIndex: target.threadIndex,
+            turnId: target.turnId,
+          })
+        }
+
+        finalizeHighlight()
+      }
+
+      scheduleFrameDelay(ALIGNMENT_FRAME_DELAY, alignTarget)
+    },
+    [clearHighlightTimeout, rootRef, stopAutoStick, threadRef]
+  )
+
+  return {
+    highlightedTarget,
+    jumpToTarget,
+  }
+}

--- a/src/components/message/virtualized-message-thread.tsx
+++ b/src/components/message/virtualized-message-thread.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useCallback } from "react"
-import type { ReactNode } from "react"
+import { useCallback, useImperativeHandle } from "react"
+import type { CSSProperties, ReactNode, Ref } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { useStickToBottomContext } from "use-stick-to-bottom"
 import {
@@ -9,6 +9,17 @@ import {
   type MessageThreadContentProps,
 } from "@/components/ai-elements/message-thread"
 import { cn } from "@/lib/utils"
+
+export interface VirtualizedMessageThreadHandle {
+  scrollToIndex: (
+    index: number,
+    options?: {
+      align?: "start" | "center" | "end" | "auto"
+      behavior?: "auto" | "smooth"
+    }
+  ) => void
+  getScrollElement: () => HTMLElement | null
+}
 
 interface VirtualizedMessageThreadProps<T> {
   items: T[]
@@ -18,8 +29,10 @@ interface VirtualizedMessageThreadProps<T> {
   estimateSize?: number
   overscan?: number
   className?: string
+  rowContainerStyle?: CSSProperties
   contentClassName?: string
   contentProps?: Omit<MessageThreadContentProps, "children" | "className">
+  ref?: Ref<VirtualizedMessageThreadHandle>
 }
 
 export function VirtualizedMessageThread<T>({
@@ -30,8 +43,10 @@ export function VirtualizedMessageThread<T>({
   estimateSize = 160,
   overscan = 8,
   className,
+  rowContainerStyle,
   contentClassName,
   contentProps,
+  ref,
 }: VirtualizedMessageThreadProps<T>) {
   const { scrollRef } = useStickToBottomContext()
 
@@ -52,6 +67,19 @@ export function VirtualizedMessageThread<T>({
     },
   })
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToIndex(index, options) {
+        virtualizer.scrollToIndex(index, options)
+      },
+      getScrollElement() {
+        return scrollRef.current
+      },
+    }),
+    [scrollRef, virtualizer]
+  )
+
   const renderVirtualRow = useCallback(
     (virtualItem: ReturnType<typeof virtualizer.getVirtualItems>[number]) => {
       const item = items[virtualItem.index]
@@ -68,13 +96,16 @@ export function VirtualizedMessageThread<T>({
             willChange: "transform",
           }}
         >
-          <div className={cn("mx-auto max-w-3xl px-4", className)}>
+          <div
+            className={cn("mx-auto max-w-3xl px-4", className)}
+            style={rowContainerStyle}
+          >
             {renderItem(item, virtualItem.index)}
           </div>
         </div>
       )
     },
-    [className, items, renderItem, virtualizer]
+    [className, items, renderItem, rowContainerStyle, virtualizer]
   )
 
   return (

--- a/src/hooks/use-session-locator-items.ts
+++ b/src/hooks/use-session-locator-items.ts
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo } from "react"
+import { useTranslations } from "next-intl"
+import { useConversationRuntime } from "@/contexts/conversation-runtime-context"
+import { adaptMessageTurns } from "@/lib/adapters/ai-elements-adapter"
+import {
+  buildSessionLocatorItems,
+  type SessionLocatorItem,
+  type SessionLocatorRawTurn,
+} from "@/lib/session-locator"
+
+export function useSessionLocatorItems(
+  conversationId: number | null
+): SessionLocatorItem[] {
+  const sharedT = useTranslations("Folder.chat.shared")
+  const { getTimelineTurns } = useConversationRuntime()
+  const resolvedConversationId = conversationId ?? -1
+  const timelineTurns = getTimelineTurns(resolvedConversationId)
+
+  const adapterText = useMemo(
+    () => ({
+      attachedResources: sharedT("attachedResources"),
+      toolCallFailed: sharedT("toolCallFailed"),
+    }),
+    [sharedT]
+  )
+
+  return useMemo(() => {
+    if (conversationId == null || timelineTurns.length === 0) {
+      return []
+    }
+
+    const allTurns = timelineTurns.map((item) => item.turn)
+    const streamingIndices = new Set<number>()
+
+    timelineTurns.forEach((item, index) => {
+      if (item.phase === "streaming") {
+        streamingIndices.add(index)
+      }
+    })
+
+    const adaptedTurns = adaptMessageTurns(
+      allTurns,
+      adapterText,
+      streamingIndices.size > 0 ? streamingIndices : undefined
+    )
+
+    const locatorRawTurns: SessionLocatorRawTurn[] = adaptedTurns.map(
+      (message, threadIndex) => ({
+        turnId: message.id,
+        role: message.role === "tool" ? "assistant" : message.role,
+        phase: timelineTurns[threadIndex]?.phase ?? "persisted",
+        threadIndex,
+        parts: message.content,
+        resourceCount: message.userResources?.length ?? 0,
+        imageCount: message.userImages?.length ?? 0,
+      })
+    )
+
+    return buildSessionLocatorItems(
+      locatorRawTurns.filter((turn) => {
+        if (turn.role === "system") return false
+        if (turn.phase === "streaming") return false
+        if (turn.phase === "optimistic") return turn.role === "user"
+        return true
+      })
+    )
+  }, [adapterText, conversationId, timelineTurns])
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1279,6 +1279,16 @@
           "unknown": "غير معروف"
         }
       },
+      "messageNavigator": {
+        "title": "مستكشف الرسائل",
+        "collapseAria": "طي مستكشف الرسائل",
+        "collapsedSummary": "المستكشف {count}",
+        "toolOnly": "استجابة أدوات فقط",
+        "attachmentOnly": "صور/مرفقات",
+        "emptyPreview": "لا تتوفر معاينة",
+        "jumpToUserAria": "الانتقال إلى رسالة المستخدم",
+        "jumpToAssistantAria": "الانتقال إلى رد AI"
+      },
       "permissionDialog": {
         "subtitle": "يطلب الوكيل إذنًا لمتابعة هذا الدور.",
         "kindFallbackTool": "أداة",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1279,6 +1279,16 @@
           "unknown": "Unbekannt"
         }
       },
+      "messageNavigator": {
+        "title": "Nachrichtennavigator",
+        "collapseAria": "Nachrichtennavigator einklappen",
+        "collapsedSummary": "Navigator {count}",
+        "toolOnly": "Nur Werkzeugausgabe",
+        "attachmentOnly": "Bilder/Anhänge",
+        "emptyPreview": "Keine Vorschau verfügbar",
+        "jumpToUserAria": "Zur Benutzernachricht springen",
+        "jumpToAssistantAria": "Zur KI-Antwort springen"
+      },
       "permissionDialog": {
         "subtitle": "Agent fordert Berechtigung an, um diesen Zug fortzusetzen.",
         "kindFallbackTool": "Tool",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1279,6 +1279,16 @@
           "unknown": "Unknown"
         }
       },
+      "messageNavigator": {
+        "title": "Message Navigator",
+        "collapseAria": "Collapse message navigator",
+        "collapsedSummary": "Navigator {count}",
+        "toolOnly": "Tool-only response",
+        "attachmentOnly": "Images/attachments",
+        "emptyPreview": "No preview available",
+        "jumpToUserAria": "Jump to user message",
+        "jumpToAssistantAria": "Jump to AI reply"
+      },
       "permissionDialog": {
         "subtitle": "Agent requests permission to continue this turn.",
         "kindFallbackTool": "tool",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1279,6 +1279,16 @@
           "unknown": "Desconocida"
         }
       },
+      "messageNavigator": {
+        "title": "Navegador de mensajes",
+        "collapseAria": "Contraer navegador de mensajes",
+        "collapsedSummary": "Navegador {count}",
+        "toolOnly": "Solo salida de herramientas",
+        "attachmentOnly": "Imágenes/adjuntos",
+        "emptyPreview": "No hay vista previa disponible",
+        "jumpToUserAria": "Ir al mensaje del usuario",
+        "jumpToAssistantAria": "Ir a la respuesta de la IA"
+      },
       "permissionDialog": {
         "subtitle": "El agente solicita permiso para continuar este turno.",
         "kindFallbackTool": "herramienta",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1279,6 +1279,16 @@
           "unknown": "Inconnue"
         }
       },
+      "messageNavigator": {
+        "title": "Navigateur de messages",
+        "collapseAria": "Réduire le navigateur de messages",
+        "collapsedSummary": "Navigateur {count}",
+        "toolOnly": "Réponse d’outil uniquement",
+        "attachmentOnly": "Images/pièces jointes",
+        "emptyPreview": "Aucun aperçu disponible",
+        "jumpToUserAria": "Aller au message de l’utilisateur",
+        "jumpToAssistantAria": "Aller à la réponse de l’IA"
+      },
       "permissionDialog": {
         "subtitle": "L'agent demande une autorisation pour continuer ce tour.",
         "kindFallbackTool": "outil",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1279,6 +1279,16 @@
           "unknown": "不明"
         }
       },
+      "messageNavigator": {
+        "title": "メッセージナビゲーター",
+        "collapseAria": "メッセージナビゲーターを折りたたむ",
+        "collapsedSummary": "ナビ {count}",
+        "toolOnly": "ツール出力のみ",
+        "attachmentOnly": "画像/添付ファイル",
+        "emptyPreview": "プレビューはありません",
+        "jumpToUserAria": "ユーザーメッセージへ移動",
+        "jumpToAssistantAria": "AI の返信へ移動"
+      },
       "permissionDialog": {
         "subtitle": "エージェントがこのターンを続行するための許可を要求しています。",
         "kindFallbackTool": "ツール",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1279,6 +1279,16 @@
           "unknown": "알 수 없음"
         }
       },
+      "messageNavigator": {
+        "title": "메시지 내비게이터",
+        "collapseAria": "메시지 내비게이터 접기",
+        "collapsedSummary": "내비게이터 {count}",
+        "toolOnly": "도구 출력만",
+        "attachmentOnly": "이미지/첨부파일",
+        "emptyPreview": "미리보기가 없습니다",
+        "jumpToUserAria": "사용자 메시지로 이동",
+        "jumpToAssistantAria": "AI 응답으로 이동"
+      },
       "permissionDialog": {
         "subtitle": "에이전트가 이 턴을 계속하기 위한 권한을 요청합니다.",
         "kindFallbackTool": "도구",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1279,6 +1279,16 @@
           "unknown": "Desconhecida"
         }
       },
+      "messageNavigator": {
+        "title": "Navegador de mensagens",
+        "collapseAria": "Recolher navegador de mensagens",
+        "collapsedSummary": "Navegador {count}",
+        "toolOnly": "Somente saída de ferramentas",
+        "attachmentOnly": "Imagens/anexos",
+        "emptyPreview": "Nenhuma prévia disponível",
+        "jumpToUserAria": "Ir para a mensagem do usuário",
+        "jumpToAssistantAria": "Ir para a resposta da IA"
+      },
       "permissionDialog": {
         "subtitle": "O agente solicita permissão para continuar este turno.",
         "kindFallbackTool": "ferramenta",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1279,6 +1279,16 @@
           "unknown": "未知"
         }
       },
+      "messageNavigator": {
+        "title": "消息导航",
+        "collapseAria": "折叠消息导航",
+        "collapsedSummary": "导航 {count}",
+        "toolOnly": "仅工具调用",
+        "attachmentOnly": "图片/附件",
+        "emptyPreview": "无可用摘要",
+        "jumpToUserAria": "跳转到用户消息",
+        "jumpToAssistantAria": "跳转到 AI 回复"
+      },
       "permissionDialog": {
         "subtitle": "Agent 请求继续当前轮次的权限。",
         "kindFallbackTool": "工具",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1279,6 +1279,16 @@
           "unknown": "未知"
         }
       },
+      "messageNavigator": {
+        "title": "訊息導航",
+        "collapseAria": "摺疊訊息導航",
+        "collapsedSummary": "導航 {count}",
+        "toolOnly": "僅工具呼叫",
+        "attachmentOnly": "圖片/附件",
+        "emptyPreview": "無可用摘要",
+        "jumpToUserAria": "跳轉到使用者訊息",
+        "jumpToAssistantAria": "跳轉到 AI 回覆"
+      },
       "permissionDialog": {
         "subtitle": "Agent 請求繼續目前輪次的權限。",
         "kindFallbackTool": "工具",

--- a/src/lib/session-locator.ts
+++ b/src/lib/session-locator.ts
@@ -1,0 +1,197 @@
+import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+
+export type SessionLocatorPhase = "persisted" | "optimistic" | "streaming"
+
+export type LocatorRole = "user" | "assistant"
+
+export type LocatorPreviewKind =
+  | "text"
+  | "tool_only"
+  | "attachment_only"
+  | "empty"
+
+export interface SessionLocatorRawTurn {
+  turnId: string
+  role: "user" | "assistant" | "system"
+  phase: SessionLocatorPhase
+  threadIndex: number
+  parts: AdaptedContentPart[]
+  resourceCount: number
+  imageCount: number
+}
+
+export interface SessionLocatorPreview {
+  text: string
+  kind: LocatorPreviewKind
+}
+
+export interface SessionLocatorTarget {
+  role: LocatorRole
+  turnId: string
+  threadIndex: number
+  partIndex: number | null
+  preview: SessionLocatorPreview
+}
+
+export interface SessionLocatorItem {
+  id: string
+  pairIndex: number
+  status: "complete" | "pending_reply"
+  user: SessionLocatorTarget
+  assistant: SessionLocatorTarget | null
+}
+
+function normalizePreviewText(text: string): string {
+  return text.replace(/\s+/g, " ").trim()
+}
+
+function extractTextParts(parts: AdaptedContentPart[]): string[] {
+  return parts
+    .flatMap((part) =>
+      part.type === "text" ? [normalizePreviewText(part.text)] : []
+    )
+    .filter((text) => text.length > 0)
+}
+
+function hasToolContent(parts: AdaptedContentPart[]): boolean {
+  return parts.some(
+    (part) => part.type === "tool-call" || part.type === "tool-result"
+  )
+}
+
+function getFirstTextPartIndex(parts: AdaptedContentPart[]): number | null {
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i]
+    if (part?.type === "text" && normalizePreviewText(part.text).length > 0) {
+      return i
+    }
+  }
+
+  return null
+}
+
+function getLastTextPartIndex(parts: AdaptedContentPart[]): number | null {
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i]
+    if (part?.type === "text" && normalizePreviewText(part.text).length > 0) {
+      return i
+    }
+  }
+
+  return null
+}
+
+function getLastRenderablePartIndex(
+  parts: AdaptedContentPart[]
+): number | null {
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i]
+    if (!part) continue
+
+    if (part.type === "text") {
+      if (normalizePreviewText(part.text).length > 0) {
+        return i
+      }
+      continue
+    }
+
+    return i
+  }
+
+  return null
+}
+
+export function extractUserPreview(
+  turn: SessionLocatorRawTurn
+): SessionLocatorPreview {
+  const [firstText] = extractTextParts(turn.parts)
+  if (firstText) {
+    return { text: firstText, kind: "text" }
+  }
+
+  if (turn.imageCount > 0 || turn.resourceCount > 0) {
+    return { text: "", kind: "attachment_only" }
+  }
+
+  return { text: "", kind: "empty" }
+}
+
+export function extractAssistantFinalPreview(
+  turn: SessionLocatorRawTurn
+): SessionLocatorPreview {
+  const textParts = extractTextParts(turn.parts)
+  const lastText = textParts[textParts.length - 1]
+  if (lastText) {
+    return { text: lastText, kind: "text" }
+  }
+
+  if (hasToolContent(turn.parts)) {
+    return { text: "", kind: "tool_only" }
+  }
+
+  return { text: "", kind: "empty" }
+}
+
+export function buildSessionLocatorItems(
+  turns: SessionLocatorRawTurn[]
+): SessionLocatorItem[] {
+  const items: SessionLocatorItem[] = []
+  let pendingUser: SessionLocatorTarget | null = null
+  let pairIndex = 0
+
+  const flushPendingUser = () => {
+    if (!pendingUser) return
+
+    items.push({
+      id: `${pendingUser.turnId}-pending-${pairIndex}`,
+      pairIndex,
+      status: "pending_reply",
+      user: pendingUser,
+      assistant: null,
+    })
+    pairIndex += 1
+    pendingUser = null
+  }
+
+  for (const turn of turns) {
+    if (turn.role === "system") continue
+
+    if (turn.role === "user") {
+      flushPendingUser()
+      pendingUser = {
+        role: "user",
+        turnId: turn.turnId,
+        threadIndex: turn.threadIndex,
+        partIndex: getFirstTextPartIndex(turn.parts),
+        preview: extractUserPreview(turn),
+      }
+      continue
+    }
+
+    if (!pendingUser) continue
+
+    const assistantTarget: SessionLocatorTarget = {
+      role: "assistant",
+      turnId: turn.turnId,
+      threadIndex: turn.threadIndex,
+      partIndex:
+        getLastTextPartIndex(turn.parts) ??
+        getLastRenderablePartIndex(turn.parts),
+      preview: extractAssistantFinalPreview(turn),
+    }
+
+    items.push({
+      id: `${pendingUser.turnId}-${turn.turnId}-${pairIndex}`,
+      pairIndex,
+      status: "complete",
+      user: pendingUser,
+      assistant: assistantTarget,
+    })
+    pairIndex += 1
+    pendingUser = null
+  }
+
+  flushPendingUser()
+
+  return items
+}


### PR DESCRIPTION
- add session locator utilities to the sidebar directory view so long conversations can jump between user turns and assistant replies
- keep directory navigation synchronized with the active conversation tab, message highlighting, and preserved sidebar tab state
- localize the directory locator copy across supported languages and remove the unused overlay implementation

<img width="1093" height="527" alt="20260316_165630_707" src="https://github.com/user-attachments/assets/163c967b-bf21-4920-9a80-df17314fd5f4" />
