### PR TITLE
feat: enhance appearance settings with theme colors and font size controls

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,8 +7,8 @@
 
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
+  font-size: var(--ui-font-size, 14px);
+  line-height: 1.6;
   font-weight: 400;
 
   font-synthesis: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: var(--ui-font-size, 14px);
+  font-size: 14px;
   line-height: 1.6;
   font-weight: 400;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 14px;
+  font-size: var(--ui-font-size, 14px);
   line-height: 1.6;
   font-weight: 400;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default async function RootLayout({
         {/* Suppress benign ResizeObserver loop warnings (W3C spec §3.3) */}
         <script>{`window.addEventListener("error",function(e){if(e.message&&e.message.indexOf("ResizeObserver")!==-1){e.stopImmediatePropagation();e.preventDefault()}});window.onerror=function(m){if(typeof m==="string"&&m.indexOf("ResizeObserver")!==-1)return true}`}</script>
         {/* Apply appearance settings before paint to prevent flash */}
-        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number")r.style.setProperty("--ui-font-size",Math.min(Math.max(a.uiFontSize,12),20)+"px");if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
+        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number"){var u=Math.min(Math.max(a.uiFontSize,12),20)+"px";r.style.setProperty("--ui-font-size",u);r.style.fontSize=u}if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
         <NextIntlClientProvider
           locale={initialLocale}
           messages={initialMessages}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,6 +50,8 @@ export default async function RootLayout({
       <body>
         {/* Suppress benign ResizeObserver loop warnings (W3C spec §3.3) */}
         <script>{`window.addEventListener("error",function(e){if(e.message&&e.message.indexOf("ResizeObserver")!==-1){e.stopImmediatePropagation();e.preventDefault()}});window.onerror=function(m){if(typeof m==="string"&&m.indexOf("ResizeObserver")!==-1)return true}`}</script>
+        {/* Apply appearance settings before paint to prevent flash */}
+        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number")r.style.setProperty("--ui-font-size",Math.min(Math.max(a.uiFontSize,12),20)+"px");if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
         <NextIntlClientProvider
           locale={initialLocale}
           messages={initialMessages}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default async function RootLayout({
         {/* Suppress benign ResizeObserver loop warnings (W3C spec §3.3) */}
         <script>{`window.addEventListener("error",function(e){if(e.message&&e.message.indexOf("ResizeObserver")!==-1){e.stopImmediatePropagation();e.preventDefault()}});window.onerror=function(m){if(typeof m==="string"&&m.indexOf("ResizeObserver")!==-1)return true}`}</script>
         {/* Apply appearance settings before paint to prevent flash */}
-        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number"){var u=Math.min(Math.max(a.uiFontSize,12),20)+"px";r.style.setProperty("--ui-font-size",u);r.style.fontSize=u}if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
+        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number"){var z=Math.min(Math.max(a.uiFontSize,12),20)/14;r.style.zoom=String(z);r.style.setProperty("--ui-zoom",String(z))}if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
         <NextIntlClientProvider
           locale={initialLocale}
           messages={initialMessages}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default async function RootLayout({
         {/* Suppress benign ResizeObserver loop warnings (W3C spec §3.3) */}
         <script>{`window.addEventListener("error",function(e){if(e.message&&e.message.indexOf("ResizeObserver")!==-1){e.stopImmediatePropagation();e.preventDefault()}});window.onerror=function(m){if(typeof m==="string"&&m.indexOf("ResizeObserver")!==-1)return true}`}</script>
         {/* Apply appearance settings before paint to prevent flash */}
-        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number"){var z=Math.min(Math.max(a.uiFontSize,12),20)/14;r.style.zoom=String(z);r.style.setProperty("--ui-zoom",String(z))}if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
+        <script>{`(function(){try{var s=localStorage.getItem("settings:appearance:v1");if(!s)return;var a=JSON.parse(s);var r=document.documentElement;if(typeof a.uiFontSize==="number"){var u=Math.min(Math.max(a.uiFontSize,12),20);r.style.fontSize=u+"px";var z=u/14;try{r.style.setProperty("zoom",String(z))}catch(e){}r.style.setProperty("--ui-zoom",String(z))}if(typeof a.codeFontSize==="number")r.style.setProperty("--code-font-size",Math.min(Math.max(a.codeFontSize,10),24)+"px")}catch(e){}})()`}</script>
         <NextIntlClientProvider
           locale={initialLocale}
           messages={initialMessages}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { AppI18nProvider } from "@/components/i18n-provider"
 import { getMessagesForLocale } from "@/i18n/messages"
 import { resolveRequestLocale } from "@/i18n/resolve-request-locale"
 import { ThemeProvider } from "@/components/theme-provider"
+import { AppearanceInitializer } from "@/components/appearance-initializer"
 import { toIntlLocale } from "@/lib/i18n"
 
 const jetbrainsMono = JetBrains_Mono({
@@ -66,6 +67,7 @@ export default async function RootLayout({
               enableSystem
               disableTransitionOnChange
             >
+              <AppearanceInitializer />
               {children}
             </ThemeProvider>
           </AppI18nProvider>

--- a/src/components/appearance-initializer.tsx
+++ b/src/components/appearance-initializer.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect } from "react"
+import { useTheme } from "next-themes"
+import {
+  APPEARANCE_STORAGE_KEY,
+  APPEARANCE_UPDATED_EVENT,
+  applyAppearanceSettings,
+  readAppearanceSettings,
+} from "@/lib/appearance-settings"
+
+/**
+ * Global appearance settings initializer. Must be mounted once in the root
+ * layout so that font-size and theme-color changes propagate to every page,
+ * not just the settings panel.
+ */
+export function AppearanceInitializer() {
+  const { resolvedTheme } = useTheme()
+
+  // Apply on mount + whenever the custom event fires (same tab)
+  useEffect(() => {
+    const apply = () => applyAppearanceSettings(readAppearanceSettings())
+    apply()
+
+    window.addEventListener(APPEARANCE_UPDATED_EVENT, apply)
+    return () => window.removeEventListener(APPEARANCE_UPDATED_EVENT, apply)
+  }, [])
+
+  // Re-apply when dark/light mode toggles so theme-color overrides match
+  useEffect(() => {
+    applyAppearanceSettings(readAppearanceSettings())
+  }, [resolvedTheme])
+
+  // Cross-tab sync via StorageEvent
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key && e.key !== APPEARANCE_STORAGE_KEY) return
+      applyAppearanceSettings(readAppearanceSettings())
+    }
+    window.addEventListener("storage", onStorage)
+    return () => window.removeEventListener("storage", onStorage)
+  }, [])
+
+  return null
+}

--- a/src/components/appearance-initializer.tsx
+++ b/src/components/appearance-initializer.tsx
@@ -17,29 +17,21 @@ import {
 export function AppearanceInitializer() {
   const { resolvedTheme } = useTheme()
 
-  // Apply on mount + whenever the custom event fires (same tab)
   useEffect(() => {
     const apply = () => applyAppearanceSettings(readAppearanceSettings())
     apply()
 
-    window.addEventListener(APPEARANCE_UPDATED_EVENT, apply)
-    return () => window.removeEventListener(APPEARANCE_UPDATED_EVENT, apply)
-  }, [])
-
-  // Re-apply when dark/light mode toggles so theme-color overrides match
-  useEffect(() => {
-    applyAppearanceSettings(readAppearanceSettings())
-  }, [resolvedTheme])
-
-  // Cross-tab sync via StorageEvent
-  useEffect(() => {
     const onStorage = (e: StorageEvent) => {
       if (e.key && e.key !== APPEARANCE_STORAGE_KEY) return
-      applyAppearanceSettings(readAppearanceSettings())
+      apply()
     }
+    window.addEventListener(APPEARANCE_UPDATED_EVENT, apply)
     window.addEventListener("storage", onStorage)
-    return () => window.removeEventListener("storage", onStorage)
-  }, [])
+    return () => {
+      window.removeEventListener(APPEARANCE_UPDATED_EVENT, apply)
+      window.removeEventListener("storage", onStorage)
+    }
+  }, [resolvedTheme])
 
   return null
 }

--- a/src/components/diff/diff-viewer.tsx
+++ b/src/components/diff/diff-viewer.tsx
@@ -7,6 +7,7 @@ import type { DiffOnMount } from "@monaco-editor/react"
 import type { editor as MonacoEditorNs } from "monaco-editor"
 import { defineMonacoThemes, useMonacoThemeSync } from "@/lib/monaco-themes"
 import { cn } from "@/lib/utils"
+import { getCodeFontSize } from "@/lib/appearance-settings"
 
 import "@/lib/monaco-local"
 
@@ -187,7 +188,7 @@ export function DiffViewer({
             renderSideBySide: true,
             renderSideBySideInlineBreakpoint: 0,
             automaticLayout: true,
-            fontSize: 13,
+            fontSize: getCodeFontSize(),
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
             renderOverviewRuler: false,

--- a/src/components/files/file-workspace-panel.tsx
+++ b/src/components/files/file-workspace-panel.tsx
@@ -24,6 +24,7 @@ import { Streamdown } from "streamdown"
 import { readFileBase64 } from "@/lib/api"
 import { normalizeMathDelimiters } from "@/components/ai-elements/message"
 import { defineMonacoThemes, useMonacoThemeSync } from "@/lib/monaco-themes"
+import { getCodeFontSize } from "@/lib/appearance-settings"
 import "@/lib/monaco-local"
 
 const math = createMathPlugin({ singleDollarTextMath: true })
@@ -1594,7 +1595,7 @@ export function FileWorkspacePanel() {
                 readOnly: !canEdit,
                 minimap: { enabled: false },
                 automaticLayout: true,
-                fontSize: 13,
+                fontSize: getCodeFontSize(),
                 lineNumbersMinChars,
                 lineDecorationsWidth: 10,
                 wordWrap: "off",

--- a/src/components/merge/three-pane-merge-editor.tsx
+++ b/src/components/merge/three-pane-merge-editor.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, ArrowRight, CheckCheck } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { defineMonacoThemes, useMonacoThemeSync } from "@/lib/monaco-themes"
 import { cn } from "@/lib/utils"
+import { getCodeFontSize } from "@/lib/appearance-settings"
 import { Button } from "@/components/ui/button"
 import {
   ResizableHandle,
@@ -498,7 +499,7 @@ export function ThreePaneMergeEditor({
   // Editor options
   // ---------------------------------------------------------------------------
   const editorOptions: MonacoEditorNs.IStandaloneEditorConstructionOptions = {
-    fontSize: 13,
+    fontSize: getCodeFontSize(),
     minimap: { enabled: false },
     scrollBeyondLastLine: false,
     automaticLayout: true,

--- a/src/components/settings/appearance-settings.tsx
+++ b/src/components/settings/appearance-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Monitor, Moon, Sun } from "lucide-react"
+import { Check, Monitor, Moon, Palette, Sun, Type } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useTheme } from "next-themes"
 import {
@@ -10,12 +10,32 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Slider } from "@/components/ui/slider"
+import { Button } from "@/components/ui/button"
+import { useAppearanceSettings } from "@/hooks/use-appearance-settings"
+import {
+  UI_FONT_SIZE_MIN,
+  UI_FONT_SIZE_MAX,
+  CODE_FONT_SIZE_MIN,
+  CODE_FONT_SIZE_MAX,
+  THEME_COLORS,
+} from "@/lib/appearance-settings"
+import { THEME_COLOR_PRESETS } from "@/lib/theme-color-presets"
+import { cn } from "@/lib/utils"
 
 type ThemeMode = "system" | "light" | "dark"
 
 export function AppearanceSettings() {
   const t = useTranslations("AppearanceSettings")
   const { theme, resolvedTheme, setTheme } = useTheme()
+  const {
+    appearance,
+    updateThemeColor,
+    updateUiFontSize,
+    updateCodeFontSize,
+    resetAppearance,
+  } = useAppearanceSettings()
+
   const resolvedThemeLabel =
     resolvedTheme === "dark"
       ? t("resolvedTheme.dark")
@@ -26,6 +46,7 @@ export function AppearanceSettings() {
   return (
     <div className="h-full overflow-auto">
       <div className="w-full space-y-4">
+        {/* Section 1: Theme Mode */}
         <section className="rounded-xl border bg-card p-4 space-y-4">
           <div className="flex items-center gap-2">
             <Sun className="h-4 w-4 text-muted-foreground" />
@@ -75,6 +96,137 @@ export function AppearanceSettings() {
               {t("currentTheme", { theme: resolvedThemeLabel })}
             </p>
           </div>
+        </section>
+
+        {/* Section 2: Theme Color */}
+        <section className="rounded-xl border bg-card p-4 space-y-4">
+          <div className="flex items-center gap-2">
+            <Palette className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-sm font-semibold">{t("themeColor")}</h2>
+          </div>
+
+          <p className="text-xs text-muted-foreground leading-5">
+            {t("themeColorDescription")}
+          </p>
+
+          <div className="flex flex-wrap gap-3">
+            {THEME_COLORS.map((color) => {
+              const preset = THEME_COLOR_PRESETS.find((p) => p.name === color)
+              if (!preset) return null
+              const isActive = appearance.themeColor === color
+              return (
+                <button
+                  key={color}
+                  type="button"
+                  className="flex flex-col items-center gap-1.5"
+                  onClick={() => updateThemeColor(color)}
+                >
+                  <div
+                    className={cn(
+                      "flex h-8 w-8 items-center justify-center rounded-full border-2 transition-colors",
+                      isActive
+                        ? "border-foreground"
+                        : "border-transparent hover:border-muted-foreground/50"
+                    )}
+                    style={{ backgroundColor: preset.preview }}
+                  >
+                    {isActive && (
+                      <Check className="h-4 w-4 text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]" />
+                    )}
+                  </div>
+                  <span
+                    className={cn(
+                      "text-[10px]",
+                      isActive
+                        ? "text-foreground font-medium"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {t(`themeColors.${color}`)}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+
+        {/* Section 3: Font Size */}
+        <section className="rounded-xl border bg-card p-4 space-y-4">
+          <div className="flex items-center gap-2">
+            <Type className="h-4 w-4 text-muted-foreground" />
+            <h2 className="text-sm font-semibold">{t("fontSizeTitle")}</h2>
+          </div>
+
+          <p className="text-xs text-muted-foreground leading-5">
+            {t("fontSizeDescription")}
+          </p>
+
+          <div className="space-y-5">
+            {/* UI Font Size */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("uiFontSize")}
+                </label>
+                <span className="text-xs font-semibold tabular-nums">
+                  {appearance.uiFontSize}px
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-[10px] text-muted-foreground w-6 text-right">
+                  {UI_FONT_SIZE_MIN}
+                </span>
+                <Slider
+                  min={UI_FONT_SIZE_MIN}
+                  max={UI_FONT_SIZE_MAX}
+                  step={1}
+                  value={[appearance.uiFontSize]}
+                  onValueChange={([v]) => updateUiFontSize(v)}
+                  className="flex-1"
+                />
+                <span className="text-[10px] text-muted-foreground w-6">
+                  {UI_FONT_SIZE_MAX}
+                </span>
+              </div>
+            </div>
+
+            {/* Code Font Size */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t("codeFontSize")}
+                </label>
+                <span className="text-xs font-semibold tabular-nums">
+                  {appearance.codeFontSize}px
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-[10px] text-muted-foreground w-6 text-right">
+                  {CODE_FONT_SIZE_MIN}
+                </span>
+                <Slider
+                  min={CODE_FONT_SIZE_MIN}
+                  max={CODE_FONT_SIZE_MAX}
+                  step={1}
+                  value={[appearance.codeFontSize]}
+                  onValueChange={([v]) => updateCodeFontSize(v)}
+                  className="flex-1"
+                />
+                <span className="text-[10px] text-muted-foreground w-6">
+                  {CODE_FONT_SIZE_MAX}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-xs"
+            onClick={resetAppearance}
+          >
+            {t("resetDefaults")}
+          </Button>
         </section>
       </div>
     </div>

--- a/src/components/terminal/terminal-view.tsx
+++ b/src/components/terminal/terminal-view.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef, useState } from "react"
 import { subscribe } from "@/lib/platform"
 import {
+  APPEARANCE_UPDATED_EVENT,
+  getCodeFontSize,
+} from "@/lib/appearance-settings"
+import {
   terminalSpawn,
   terminalWrite,
   terminalResize,
@@ -140,7 +144,7 @@ export function TerminalView({
 
       const term = new Terminal({
         cursorBlink: true,
-        fontSize: 13,
+        fontSize: getCodeFontSize(),
         fontFamily: "Menlo, Monaco, 'Courier New', monospace",
         theme: getTerminalTheme(containerRef.current),
         allowProposedApi: true,
@@ -161,6 +165,12 @@ export function TerminalView({
         attributes: true,
         attributeFilter: ["class"],
       })
+
+      const onAppearanceUpdate = () => {
+        term.options.fontSize = getCodeFontSize()
+        fitAddon.fit()
+      }
+      window.addEventListener(APPEARANCE_UPDATED_EVENT, onAppearanceUpdate)
 
       // Send input to PTY
       const onDataDisposable = term.onData((data: string) => {
@@ -201,6 +211,7 @@ export function TerminalView({
       )
 
       if (cancelled) {
+        window.removeEventListener(APPEARANCE_UPDATED_EVENT, onAppearanceUpdate)
         themeObserver.disconnect()
         onDataDisposable.dispose()
         onResizeDisposable.dispose()
@@ -223,6 +234,7 @@ export function TerminalView({
       // If unmounted while spawn was in flight, clean up the spawned PTY
       if (cancelled) {
         terminalKill(terminalId).catch(() => {})
+        window.removeEventListener(APPEARANCE_UPDATED_EVENT, onAppearanceUpdate)
         themeObserver.disconnect()
         onDataDisposable.dispose()
         onResizeDisposable.dispose()
@@ -258,6 +270,7 @@ export function TerminalView({
       cleanup = () => {
         if (resizeTimer) clearTimeout(resizeTimer)
         if (fitTimer) clearTimeout(fitTimer)
+        window.removeEventListener(APPEARANCE_UPDATED_EVENT, onAppearanceUpdate)
         themeObserver.disconnect()
         onDataDisposable.dispose()
         onResizeDisposable.dispose()

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _value = React.useMemo(
+    () => (value ?? defaultValue ?? [min]) as number[],
+    [value, defaultValue, min]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="bg-muted relative h-1.5 w-full grow overflow-hidden rounded-full"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="bg-primary absolute h-full"
+        />
+      </SliderPrimitive.Track>
+      {_value.map((_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary/50 bg-background shadow-sm ring-ring/50 block size-4 rounded-full border transition-colors focus-visible:ring-4 focus-visible:outline-none disabled:pointer-events-none"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/src/hooks/use-appearance-settings.ts
+++ b/src/hooks/use-appearance-settings.ts
@@ -1,17 +1,11 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
-import { useTheme } from "next-themes"
+import { useCallback, useEffect, useState } from "react"
 import {
   type AppearanceSettings,
   type ThemeColor,
   APPEARANCE_STORAGE_KEY,
-  APPEARANCE_UPDATED_EVENT,
-  CODE_FONT_SIZE_MAX,
-  CODE_FONT_SIZE_MIN,
   DEFAULT_APPEARANCE,
-  UI_FONT_SIZE_MAX,
-  UI_FONT_SIZE_MIN,
   applyAppearanceSettings,
   readAppearanceSettings,
   writeAppearanceSettings,
@@ -26,40 +20,17 @@ interface UseAppearanceSettingsResult {
 }
 
 export function useAppearanceSettings(): UseAppearanceSettingsResult {
-  const [appearance, setAppearance] =
-    useState<AppearanceSettings>(DEFAULT_APPEARANCE)
-  const { resolvedTheme } = useTheme()
-  const appearanceRef = useRef(appearance)
+  const [appearance, setAppearance] = useState<AppearanceSettings>(
+    readAppearanceSettings
+  )
 
   useEffect(() => {
-    appearanceRef.current = appearance
-  }, [appearance])
-
-  // Re-apply theme color when dark/light mode changes
-  useEffect(() => {
-    applyAppearanceSettings(appearanceRef.current)
-  }, [resolvedTheme])
-
-  useEffect(() => {
-    const syncFromStorage = () => {
-      const settings = readAppearanceSettings()
-      setAppearance(settings)
-      applyAppearanceSettings(settings)
-    }
-
-    syncFromStorage()
-
     const onStorage = (event: StorageEvent) => {
       if (event.key && event.key !== APPEARANCE_STORAGE_KEY) return
-      syncFromStorage()
+      setAppearance(readAppearanceSettings())
     }
-
     window.addEventListener("storage", onStorage)
-    window.addEventListener(APPEARANCE_UPDATED_EVENT, syncFromStorage)
-    return () => {
-      window.removeEventListener("storage", onStorage)
-      window.removeEventListener(APPEARANCE_UPDATED_EVENT, syncFromStorage)
-    }
+    return () => window.removeEventListener("storage", onStorage)
   }, [])
 
   const update = useCallback((patch: Partial<AppearanceSettings>) => {
@@ -77,36 +48,26 @@ export function useAppearanceSettings(): UseAppearanceSettingsResult {
   )
 
   const updateUiFontSize = useCallback(
-    (size: number) =>
-      update({
-        uiFontSize: Math.round(
-          Math.min(Math.max(size, UI_FONT_SIZE_MIN), UI_FONT_SIZE_MAX)
-        ),
-      }),
+    (size: number) => update({ uiFontSize: size }),
     [update]
   )
 
   const updateCodeFontSize = useCallback(
-    (size: number) =>
-      update({
-        codeFontSize: Math.round(
-          Math.min(Math.max(size, CODE_FONT_SIZE_MIN), CODE_FONT_SIZE_MAX)
-        ),
-      }),
+    (size: number) => update({ codeFontSize: size }),
     [update]
   )
 
   const resetAppearance = useCallback(() => {
-    setAppearance({ ...DEFAULT_APPEARANCE })
     writeAppearanceSettings(DEFAULT_APPEARANCE)
     applyAppearanceSettings(DEFAULT_APPEARANCE)
+    setAppearance({ ...DEFAULT_APPEARANCE })
   }, [])
 
   return {
     appearance,
     updateThemeColor,
-    updateUiFontSize,
     updateCodeFontSize,
+    updateUiFontSize,
     resetAppearance,
   }
 }

--- a/src/hooks/use-appearance-settings.ts
+++ b/src/hooks/use-appearance-settings.ts
@@ -1,0 +1,112 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTheme } from "next-themes"
+import {
+  type AppearanceSettings,
+  type ThemeColor,
+  APPEARANCE_STORAGE_KEY,
+  APPEARANCE_UPDATED_EVENT,
+  CODE_FONT_SIZE_MAX,
+  CODE_FONT_SIZE_MIN,
+  DEFAULT_APPEARANCE,
+  UI_FONT_SIZE_MAX,
+  UI_FONT_SIZE_MIN,
+  applyAppearanceSettings,
+  readAppearanceSettings,
+  writeAppearanceSettings,
+} from "@/lib/appearance-settings"
+
+interface UseAppearanceSettingsResult {
+  appearance: AppearanceSettings
+  updateThemeColor: (color: ThemeColor) => void
+  updateUiFontSize: (size: number) => void
+  updateCodeFontSize: (size: number) => void
+  resetAppearance: () => void
+}
+
+export function useAppearanceSettings(): UseAppearanceSettingsResult {
+  const [appearance, setAppearance] =
+    useState<AppearanceSettings>(DEFAULT_APPEARANCE)
+  const { resolvedTheme } = useTheme()
+  const appearanceRef = useRef(appearance)
+
+  useEffect(() => {
+    appearanceRef.current = appearance
+  }, [appearance])
+
+  // Re-apply theme color when dark/light mode changes
+  useEffect(() => {
+    applyAppearanceSettings(appearanceRef.current)
+  }, [resolvedTheme])
+
+  useEffect(() => {
+    const syncFromStorage = () => {
+      const settings = readAppearanceSettings()
+      setAppearance(settings)
+      applyAppearanceSettings(settings)
+    }
+
+    syncFromStorage()
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key && event.key !== APPEARANCE_STORAGE_KEY) return
+      syncFromStorage()
+    }
+
+    window.addEventListener("storage", onStorage)
+    window.addEventListener(APPEARANCE_UPDATED_EVENT, syncFromStorage)
+    return () => {
+      window.removeEventListener("storage", onStorage)
+      window.removeEventListener(APPEARANCE_UPDATED_EVENT, syncFromStorage)
+    }
+  }, [])
+
+  const update = useCallback((patch: Partial<AppearanceSettings>) => {
+    setAppearance((prev) => {
+      const next = { ...prev, ...patch }
+      writeAppearanceSettings(next)
+      applyAppearanceSettings(next)
+      return next
+    })
+  }, [])
+
+  const updateThemeColor = useCallback(
+    (color: ThemeColor) => update({ themeColor: color }),
+    [update]
+  )
+
+  const updateUiFontSize = useCallback(
+    (size: number) =>
+      update({
+        uiFontSize: Math.round(
+          Math.min(Math.max(size, UI_FONT_SIZE_MIN), UI_FONT_SIZE_MAX)
+        ),
+      }),
+    [update]
+  )
+
+  const updateCodeFontSize = useCallback(
+    (size: number) =>
+      update({
+        codeFontSize: Math.round(
+          Math.min(Math.max(size, CODE_FONT_SIZE_MIN), CODE_FONT_SIZE_MAX)
+        ),
+      }),
+    [update]
+  )
+
+  const resetAppearance = useCallback(() => {
+    setAppearance({ ...DEFAULT_APPEARANCE })
+    writeAppearanceSettings(DEFAULT_APPEARANCE)
+    applyAppearanceSettings(DEFAULT_APPEARANCE)
+  }, [])
+
+  return {
+    appearance,
+    updateThemeColor,
+    updateUiFontSize,
+    updateCodeFontSize,
+    resetAppearance,
+  }
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -110,6 +110,22 @@
       "light": "فاتح",
       "dark": "داكن",
       "unknown": "--"
+    },
+    "themeColor": "لون السمة",
+    "themeColorDescription": "اختر لون التمييز للواجهة.",
+    "fontSizeTitle": "حجم الخط",
+    "fontSizeDescription": "ضبط حجم خط الواجهة والشفرة.",
+    "uiFontSize": "حجم خط الواجهة",
+    "codeFontSize": "حجم خط الشفرة",
+    "resetDefaults": "إعادة التعيين إلى الافتراضي",
+    "themeColors": {
+      "zinc": "زنك",
+      "slate": "أردواز",
+      "blue": "أزرق",
+      "green": "أخضر",
+      "violet": "بنفسجي",
+      "orange": "برتقالي",
+      "rose": "وردي"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -110,6 +110,22 @@
       "light": "Hell",
       "dark": "Dunkel",
       "unknown": "--"
+    },
+    "themeColor": "Themenfarbe",
+    "themeColorDescription": "Wählen Sie die Akzentfarbe für die Benutzeroberfläche.",
+    "fontSizeTitle": "Schriftgröße",
+    "fontSizeDescription": "Passen Sie die Schriftgröße für Oberfläche und Code an.",
+    "uiFontSize": "UI-Schriftgröße",
+    "codeFontSize": "Code-Schriftgröße",
+    "resetDefaults": "Auf Standard zurücksetzen",
+    "themeColors": {
+      "zinc": "Zink",
+      "slate": "Schiefer",
+      "blue": "Blau",
+      "green": "Grün",
+      "violet": "Violett",
+      "orange": "Orange",
+      "rose": "Rosa"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -110,6 +110,22 @@
       "light": "Light",
       "dark": "Dark",
       "unknown": "--"
+    },
+    "themeColor": "Theme Color",
+    "themeColorDescription": "Choose the accent color for the interface.",
+    "fontSizeTitle": "Font Size",
+    "fontSizeDescription": "Adjust the font size for interface and code.",
+    "uiFontSize": "UI font size",
+    "codeFontSize": "Code font size",
+    "resetDefaults": "Reset to defaults",
+    "themeColors": {
+      "zinc": "Zinc",
+      "slate": "Slate",
+      "blue": "Blue",
+      "green": "Green",
+      "violet": "Violet",
+      "orange": "Orange",
+      "rose": "Rose"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -110,6 +110,22 @@
       "light": "Claro",
       "dark": "Oscuro",
       "unknown": "--"
+    },
+    "themeColor": "Color del tema",
+    "themeColorDescription": "Elige el color de acento para la interfaz.",
+    "fontSizeTitle": "Tamaño de fuente",
+    "fontSizeDescription": "Ajusta el tamaño de fuente de la interfaz y el código.",
+    "uiFontSize": "Tamaño de fuente de la interfaz",
+    "codeFontSize": "Tamaño de fuente del código",
+    "resetDefaults": "Restablecer valores predeterminados",
+    "themeColors": {
+      "zinc": "Zinc",
+      "slate": "Pizarra",
+      "blue": "Azul",
+      "green": "Verde",
+      "violet": "Violeta",
+      "orange": "Naranja",
+      "rose": "Rosa"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -110,6 +110,22 @@
       "light": "Clair",
       "dark": "Sombre",
       "unknown": "--"
+    },
+    "themeColor": "Couleur du thème",
+    "themeColorDescription": "Choisissez la couleur d'accentuation de l'interface.",
+    "fontSizeTitle": "Taille de la police",
+    "fontSizeDescription": "Ajustez la taille de police de l'interface et du code.",
+    "uiFontSize": "Taille de police de l'interface",
+    "codeFontSize": "Taille de police du code",
+    "resetDefaults": "Réinitialiser par défaut",
+    "themeColors": {
+      "zinc": "Zinc",
+      "slate": "Ardoise",
+      "blue": "Bleu",
+      "green": "Vert",
+      "violet": "Violet",
+      "orange": "Orange",
+      "rose": "Rose"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -110,6 +110,22 @@
       "light": "ライト",
       "dark": "ダーク",
       "unknown": "--"
+    },
+    "themeColor": "テーマカラー",
+    "themeColorDescription": "インターフェースのアクセントカラーを選択します。",
+    "fontSizeTitle": "フォントサイズ",
+    "fontSizeDescription": "インターフェースとコードのフォントサイズを調整します。",
+    "uiFontSize": "UIフォントサイズ",
+    "codeFontSize": "コードフォントサイズ",
+    "resetDefaults": "デフォルトに戻す",
+    "themeColors": {
+      "zinc": "ジンク",
+      "slate": "スレート",
+      "blue": "ブルー",
+      "green": "グリーン",
+      "violet": "バイオレット",
+      "orange": "オレンジ",
+      "rose": "ローズ"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -110,6 +110,22 @@
       "light": "라이트",
       "dark": "다크",
       "unknown": "--"
+    },
+    "themeColor": "테마 색상",
+    "themeColorDescription": "인터페이스의 강조 색상을 선택하세요.",
+    "fontSizeTitle": "글꼴 크기",
+    "fontSizeDescription": "인터페이스 및 코드의 글꼴 크기를 조정합니다.",
+    "uiFontSize": "UI 글꼴 크기",
+    "codeFontSize": "코드 글꼴 크기",
+    "resetDefaults": "기본값으로 재설정",
+    "themeColors": {
+      "zinc": "징크",
+      "slate": "슬레이트",
+      "blue": "블루",
+      "green": "그린",
+      "violet": "바이올렛",
+      "orange": "오렌지",
+      "rose": "로즈"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -110,6 +110,22 @@
       "light": "Claro",
       "dark": "Escuro",
       "unknown": "--"
+    },
+    "themeColor": "Cor do tema",
+    "themeColorDescription": "Escolha a cor de destaque para a interface.",
+    "fontSizeTitle": "Tamanho da fonte",
+    "fontSizeDescription": "Ajuste o tamanho da fonte da interface e do código.",
+    "uiFontSize": "Tamanho da fonte da interface",
+    "codeFontSize": "Tamanho da fonte do código",
+    "resetDefaults": "Redefinir padrões",
+    "themeColors": {
+      "zinc": "Zinco",
+      "slate": "Ardósia",
+      "blue": "Azul",
+      "green": "Verde",
+      "violet": "Violeta",
+      "orange": "Laranja",
+      "rose": "Rosa"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -110,6 +110,22 @@
       "light": "浅色",
       "dark": "深色",
       "unknown": "未知"
+    },
+    "themeColor": "主题色",
+    "themeColorDescription": "选择界面主色调。",
+    "fontSizeTitle": "字体大小",
+    "fontSizeDescription": "调整界面和代码的字体大小。",
+    "uiFontSize": "界面字体大小",
+    "codeFontSize": "代码字体大小",
+    "resetDefaults": "恢复默认",
+    "themeColors": {
+      "zinc": "锌灰",
+      "slate": "岩蓝",
+      "blue": "蓝色",
+      "green": "绿色",
+      "violet": "紫色",
+      "orange": "橙色",
+      "rose": "玫红"
     }
   },
   "SystemSettings": {

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -110,6 +110,22 @@
       "light": "淺色",
       "dark": "深色",
       "unknown": "未知"
+    },
+    "themeColor": "主題色",
+    "themeColorDescription": "選擇介面主色調。",
+    "fontSizeTitle": "字體大小",
+    "fontSizeDescription": "調整介面和程式碼的字體大小。",
+    "uiFontSize": "介面字體大小",
+    "codeFontSize": "程式碼字體大小",
+    "resetDefaults": "恢復預設",
+    "themeColors": {
+      "zinc": "鋅灰",
+      "slate": "岩藍",
+      "blue": "藍色",
+      "green": "綠色",
+      "violet": "紫色",
+      "orange": "橙色",
+      "rose": "玫紅"
     }
   },
   "SystemSettings": {

--- a/src/lib/appearance-settings.ts
+++ b/src/lib/appearance-settings.ts
@@ -109,11 +109,15 @@ export function applyAppearanceSettings(settings: AppearanceSettings): void {
     (!root.classList.contains("light") &&
       window.matchMedia("(prefers-color-scheme: dark)").matches)
 
-  // Apply font sizes — set both the CSS variable and the direct property
-  // to ensure it overrides any Tailwind preflight/layer rules
-  root.style.setProperty("--ui-font-size", `${settings.uiFontSize}px`)
-  root.style.fontSize = `${settings.uiFontSize}px`
+  // UI font size: use CSS zoom to scale the entire interface uniformly,
+  // including absolute px values from Tailwind arbitrary classes like text-[13px]
+  const zoom = settings.uiFontSize / DEFAULT_APPEARANCE.uiFontSize
+  root.style.zoom = String(zoom)
+
+  // Code font size: store as CSS variable; getCodeFontSize() compensates
+  // for zoom so Monaco/terminal render at the intended pixel size
   root.style.setProperty("--code-font-size", `${settings.codeFontSize}px`)
+  root.style.setProperty("--ui-zoom", String(zoom))
 
   // Clear previous theme color overrides
   const allVars = new Set<string>()
@@ -135,12 +139,16 @@ export function applyAppearanceSettings(settings: AppearanceSettings): void {
   }
 }
 
-/** Read the current code font size from the CSS variable on :root. */
+/**
+ * Read the current code font size, compensated for UI zoom so that
+ * Monaco/terminal render at the user's intended pixel size.
+ */
 export function getCodeFontSize(): number {
   if (typeof document === "undefined") return DEFAULT_APPEARANCE.codeFontSize
-  const value =
-    document.documentElement.style.getPropertyValue("--code-font-size")
-  if (!value) return DEFAULT_APPEARANCE.codeFontSize
-  const parsed = parseInt(value, 10)
-  return Number.isNaN(parsed) ? DEFAULT_APPEARANCE.codeFontSize : parsed
+  const root = document.documentElement
+  const raw = root.style.getPropertyValue("--code-font-size")
+  const zoom = parseFloat(root.style.getPropertyValue("--ui-zoom")) || 1
+  const size = raw ? parseInt(raw, 10) : DEFAULT_APPEARANCE.codeFontSize
+  if (Number.isNaN(size)) return DEFAULT_APPEARANCE.codeFontSize
+  return Math.round(size / zoom)
 }

--- a/src/lib/appearance-settings.ts
+++ b/src/lib/appearance-settings.ts
@@ -109,10 +109,18 @@ export function applyAppearanceSettings(settings: AppearanceSettings): void {
     (!root.classList.contains("light") &&
       window.matchMedia("(prefers-color-scheme: dark)").matches)
 
-  // UI font size: use CSS zoom to scale the entire interface uniformly,
-  // including absolute px values from Tailwind arbitrary classes like text-[13px]
+  // UI font size: scale via root font-size AND zoom for complete coverage.
+  // - root font-size affects all rem-based Tailwind utilities (text-sm, etc.)
+  // - zoom affects absolute px values (text-[13px], etc.)
   const zoom = settings.uiFontSize / DEFAULT_APPEARANCE.uiFontSize
-  root.style.zoom = String(zoom)
+  root.style.setProperty("--ui-font-size", `${settings.uiFontSize}px`)
+  root.style.fontSize = `${settings.uiFontSize}px`
+  // Try zoom (works in Chromium/Safari); harmless no-op if unsupported
+  try {
+    root.style.setProperty("zoom", String(zoom))
+  } catch {
+    // Fallback: font-size alone handles rem-based values
+  }
 
   // Code font size: store as CSS variable; getCodeFontSize() compensates
   // for zoom so Monaco/terminal render at the intended pixel size

--- a/src/lib/appearance-settings.ts
+++ b/src/lib/appearance-settings.ts
@@ -1,3 +1,5 @@
+import { THEME_COLOR_PRESETS } from "./theme-color-presets"
+
 export type ThemeColor =
   | "zinc"
   | "slate"
@@ -95,4 +97,48 @@ export function writeAppearanceSettings(settings: AppearanceSettings): void {
   } catch {
     // Ignore storage failures
   }
+}
+
+/** Apply appearance settings to the document root as CSS custom properties. */
+export function applyAppearanceSettings(settings: AppearanceSettings): void {
+  if (typeof document === "undefined") return
+
+  const root = document.documentElement
+  const isDark =
+    root.classList.contains("dark") ||
+    (!root.classList.contains("light") &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches)
+
+  // Apply font sizes
+  root.style.setProperty("--ui-font-size", `${settings.uiFontSize}px`)
+  root.style.setProperty("--code-font-size", `${settings.codeFontSize}px`)
+
+  // Clear previous theme color overrides
+  const allVars = new Set<string>()
+  for (const preset of THEME_COLOR_PRESETS) {
+    for (const key of Object.keys(preset.light)) allVars.add(key)
+    for (const key of Object.keys(preset.dark)) allVars.add(key)
+  }
+  for (const v of allVars) {
+    root.style.removeProperty(v)
+  }
+
+  // Apply current theme color
+  const preset = THEME_COLOR_PRESETS.find((p) => p.name === settings.themeColor)
+  if (preset) {
+    const overrides = isDark ? preset.dark : preset.light
+    for (const [key, value] of Object.entries(overrides)) {
+      root.style.setProperty(key, value)
+    }
+  }
+}
+
+/** Read the current code font size from the CSS variable on :root. */
+export function getCodeFontSize(): number {
+  if (typeof document === "undefined") return DEFAULT_APPEARANCE.codeFontSize
+  const value =
+    document.documentElement.style.getPropertyValue("--code-font-size")
+  if (!value) return DEFAULT_APPEARANCE.codeFontSize
+  const parsed = parseInt(value, 10)
+  return Number.isNaN(parsed) ? DEFAULT_APPEARANCE.codeFontSize : parsed
 }

--- a/src/lib/appearance-settings.ts
+++ b/src/lib/appearance-settings.ts
@@ -1,0 +1,98 @@
+export type ThemeColor =
+  | "zinc"
+  | "slate"
+  | "blue"
+  | "green"
+  | "violet"
+  | "orange"
+  | "rose"
+
+export interface AppearanceSettings {
+  themeColor: ThemeColor
+  uiFontSize: number
+  codeFontSize: number
+}
+
+export const THEME_COLORS: ThemeColor[] = [
+  "zinc",
+  "slate",
+  "blue",
+  "green",
+  "violet",
+  "orange",
+  "rose",
+]
+
+export const DEFAULT_APPEARANCE: AppearanceSettings = {
+  themeColor: "zinc",
+  uiFontSize: 14,
+  codeFontSize: 13,
+}
+
+export const UI_FONT_SIZE_MIN = 12
+export const UI_FONT_SIZE_MAX = 20
+export const CODE_FONT_SIZE_MIN = 10
+export const CODE_FONT_SIZE_MAX = 24
+
+export const APPEARANCE_STORAGE_KEY = "settings:appearance:v1"
+export const APPEARANCE_UPDATED_EVENT = "codeg:appearance-updated"
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function normalizeSettings(input: unknown): AppearanceSettings {
+  const next = { ...DEFAULT_APPEARANCE }
+  if (!input || typeof input !== "object") return next
+  const record = input as Record<string, unknown>
+
+  if (
+    typeof record.themeColor === "string" &&
+    THEME_COLORS.includes(record.themeColor as ThemeColor)
+  ) {
+    next.themeColor = record.themeColor as ThemeColor
+  }
+
+  if (typeof record.uiFontSize === "number") {
+    next.uiFontSize = clamp(
+      Math.round(record.uiFontSize),
+      UI_FONT_SIZE_MIN,
+      UI_FONT_SIZE_MAX
+    )
+  }
+
+  if (typeof record.codeFontSize === "number") {
+    next.codeFontSize = clamp(
+      Math.round(record.codeFontSize),
+      CODE_FONT_SIZE_MIN,
+      CODE_FONT_SIZE_MAX
+    )
+  }
+
+  return next
+}
+
+export function readAppearanceSettings(): AppearanceSettings {
+  if (typeof window === "undefined") return { ...DEFAULT_APPEARANCE }
+  try {
+    const raw = window.localStorage.getItem(APPEARANCE_STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_APPEARANCE }
+    return normalizeSettings(JSON.parse(raw))
+  } catch {
+    return { ...DEFAULT_APPEARANCE }
+  }
+}
+
+export function writeAppearanceSettings(settings: AppearanceSettings): void {
+  if (typeof window === "undefined") return
+  const normalized = normalizeSettings(settings)
+  try {
+    window.localStorage.setItem(
+      APPEARANCE_STORAGE_KEY,
+      JSON.stringify(normalized)
+    )
+    window.dispatchEvent(new Event(APPEARANCE_UPDATED_EVENT))
+  } catch {
+    // Ignore storage failures
+  }
+}

--- a/src/lib/appearance-settings.ts
+++ b/src/lib/appearance-settings.ts
@@ -109,8 +109,10 @@ export function applyAppearanceSettings(settings: AppearanceSettings): void {
     (!root.classList.contains("light") &&
       window.matchMedia("(prefers-color-scheme: dark)").matches)
 
-  // Apply font sizes
+  // Apply font sizes — set both the CSS variable and the direct property
+  // to ensure it overrides any Tailwind preflight/layer rules
   root.style.setProperty("--ui-font-size", `${settings.uiFontSize}px`)
+  root.style.fontSize = `${settings.uiFontSize}px`
   root.style.setProperty("--code-font-size", `${settings.codeFontSize}px`)
 
   // Clear previous theme color overrides

--- a/src/lib/appearance-settings.ts
+++ b/src/lib/appearance-settings.ts
@@ -39,6 +39,16 @@ export const CODE_FONT_SIZE_MAX = 24
 export const APPEARANCE_STORAGE_KEY = "settings:appearance:v1"
 export const APPEARANCE_UPDATED_EVENT = "codeg:appearance-updated"
 
+// Computed once: all CSS variable names used by any theme color preset
+const ALL_THEME_CSS_VARS: readonly string[] = (() => {
+  const s = new Set<string>()
+  for (const p of THEME_COLOR_PRESETS) {
+    for (const k of Object.keys(p.light)) s.add(k)
+    for (const k of Object.keys(p.dark)) s.add(k)
+  }
+  return [...s]
+})()
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
@@ -99,7 +109,6 @@ export function writeAppearanceSettings(settings: AppearanceSettings): void {
   }
 }
 
-/** Apply appearance settings to the document root as CSS custom properties. */
 export function applyAppearanceSettings(settings: AppearanceSettings): void {
   if (typeof document === "undefined") return
 
@@ -109,35 +118,16 @@ export function applyAppearanceSettings(settings: AppearanceSettings): void {
     (!root.classList.contains("light") &&
       window.matchMedia("(prefers-color-scheme: dark)").matches)
 
-  // UI font size: scale via root font-size AND zoom for complete coverage.
-  // - root font-size affects all rem-based Tailwind utilities (text-sm, etc.)
-  // - zoom affects absolute px values (text-[13px], etc.)
   const zoom = settings.uiFontSize / DEFAULT_APPEARANCE.uiFontSize
   root.style.setProperty("--ui-font-size", `${settings.uiFontSize}px`)
   root.style.fontSize = `${settings.uiFontSize}px`
-  // Try zoom (works in Chromium/Safari); harmless no-op if unsupported
-  try {
-    root.style.setProperty("zoom", String(zoom))
-  } catch {
-    // Fallback: font-size alone handles rem-based values
-  }
+  root.style.setProperty("zoom", String(zoom))
 
-  // Code font size: store as CSS variable; getCodeFontSize() compensates
-  // for zoom so Monaco/terminal render at the intended pixel size
   root.style.setProperty("--code-font-size", `${settings.codeFontSize}px`)
   root.style.setProperty("--ui-zoom", String(zoom))
 
-  // Clear previous theme color overrides
-  const allVars = new Set<string>()
-  for (const preset of THEME_COLOR_PRESETS) {
-    for (const key of Object.keys(preset.light)) allVars.add(key)
-    for (const key of Object.keys(preset.dark)) allVars.add(key)
-  }
-  for (const v of allVars) {
-    root.style.removeProperty(v)
-  }
+  for (const v of ALL_THEME_CSS_VARS) root.style.removeProperty(v)
 
-  // Apply current theme color
   const preset = THEME_COLOR_PRESETS.find((p) => p.name === settings.themeColor)
   if (preset) {
     const overrides = isDark ? preset.dark : preset.light

--- a/src/lib/theme-color-presets.ts
+++ b/src/lib/theme-color-presets.ts
@@ -1,0 +1,134 @@
+import type { ThemeColor } from "./appearance-settings"
+
+export interface ThemeColorPreset {
+  name: ThemeColor
+  /** Hex color for the preview circle in settings UI */
+  preview: string
+  /** CSS variable overrides for light mode (empty = use globals.css defaults) */
+  light: Record<string, string>
+  /** CSS variable overrides for dark mode */
+  dark: Record<string, string>
+}
+
+export const THEME_COLOR_PRESETS: ThemeColorPreset[] = [
+  {
+    name: "zinc",
+    preview: "#a1a1aa",
+    light: {},
+    dark: {},
+  },
+  {
+    name: "slate",
+    preview: "#64748b",
+    light: {
+      "--primary": "oklch(0.279 0.041 260)",
+      "--primary-foreground": "oklch(0.985 0.002 247)",
+      "--ring": "oklch(0.551 0.027 264)",
+      "--sidebar-primary": "oklch(0.279 0.041 260)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.002 247)",
+    },
+    dark: {
+      "--primary": "oklch(0.929 0.013 255)",
+      "--primary-foreground": "oklch(0.208 0.042 265)",
+      "--ring": "oklch(0.551 0.027 264)",
+      "--sidebar-primary": "oklch(0.551 0.027 264)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.002 247)",
+    },
+  },
+  {
+    name: "blue",
+    preview: "#3b82f6",
+    light: {
+      "--primary": "oklch(0.546 0.245 262.881)",
+      "--primary-foreground": "oklch(0.985 0.002 247)",
+      "--ring": "oklch(0.623 0.214 259.815)",
+      "--sidebar-primary": "oklch(0.546 0.245 262.881)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.002 247)",
+    },
+    dark: {
+      "--primary": "oklch(0.623 0.214 259.815)",
+      "--primary-foreground": "oklch(0.985 0.002 247)",
+      "--ring": "oklch(0.546 0.245 262.881)",
+      "--sidebar-primary": "oklch(0.623 0.214 259.815)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.002 247)",
+    },
+  },
+  {
+    name: "green",
+    preview: "#22c55e",
+    light: {
+      "--primary": "oklch(0.586 0.209 145)",
+      "--primary-foreground": "oklch(0.985 0.014 140)",
+      "--ring": "oklch(0.648 0.2 145)",
+      "--sidebar-primary": "oklch(0.586 0.209 145)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.014 140)",
+    },
+    dark: {
+      "--primary": "oklch(0.648 0.2 145)",
+      "--primary-foreground": "oklch(0.21 0.065 145)",
+      "--ring": "oklch(0.586 0.209 145)",
+      "--sidebar-primary": "oklch(0.648 0.2 145)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.014 140)",
+    },
+  },
+  {
+    name: "violet",
+    preview: "#8b5cf6",
+    light: {
+      "--primary": "oklch(0.541 0.281 293)",
+      "--primary-foreground": "oklch(0.969 0.016 293)",
+      "--ring": "oklch(0.606 0.25 292)",
+      "--sidebar-primary": "oklch(0.541 0.281 293)",
+      "--sidebar-primary-foreground": "oklch(0.969 0.016 293)",
+    },
+    dark: {
+      "--primary": "oklch(0.606 0.25 292)",
+      "--primary-foreground": "oklch(0.969 0.016 293)",
+      "--ring": "oklch(0.541 0.281 293)",
+      "--sidebar-primary": "oklch(0.606 0.25 292)",
+      "--sidebar-primary-foreground": "oklch(0.969 0.016 293)",
+    },
+  },
+  {
+    name: "orange",
+    preview: "#f97316",
+    light: {
+      "--primary": "oklch(0.705 0.191 47)",
+      "--primary-foreground": "oklch(0.985 0.016 73)",
+      "--ring": "oklch(0.752 0.183 55)",
+      "--sidebar-primary": "oklch(0.705 0.191 47)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.016 73)",
+    },
+    dark: {
+      "--primary": "oklch(0.752 0.183 55)",
+      "--primary-foreground": "oklch(0.255 0.072 45)",
+      "--ring": "oklch(0.705 0.191 47)",
+      "--sidebar-primary": "oklch(0.752 0.183 55)",
+      "--sidebar-primary-foreground": "oklch(0.985 0.016 73)",
+    },
+  },
+  {
+    name: "rose",
+    preview: "#f43f5e",
+    light: {
+      "--primary": "oklch(0.585 0.22 17)",
+      "--primary-foreground": "oklch(0.969 0.016 17)",
+      "--ring": "oklch(0.645 0.246 16)",
+      "--sidebar-primary": "oklch(0.585 0.22 17)",
+      "--sidebar-primary-foreground": "oklch(0.969 0.016 17)",
+    },
+    dark: {
+      "--primary": "oklch(0.645 0.246 16)",
+      "--primary-foreground": "oklch(0.969 0.016 17)",
+      "--ring": "oklch(0.585 0.22 17)",
+      "--sidebar-primary": "oklch(0.645 0.246 16)",
+      "--sidebar-primary-foreground": "oklch(0.969 0.016 17)",
+    },
+  },
+]
+
+export function getThemeColorPreset(
+  name: ThemeColor
+): ThemeColorPreset | undefined {
+  return THEME_COLOR_PRESETS.find((p) => p.name === name)
+}

--- a/src/lib/theme-color-presets.ts
+++ b/src/lib/theme-color-presets.ts
@@ -126,9 +126,3 @@ export const THEME_COLOR_PRESETS: ThemeColorPreset[] = [
     },
   },
 ]
-
-export function getThemeColorPreset(
-  name: ThemeColor
-): ThemeColorPreset | undefined {
-  return THEME_COLOR_PRESETS.find((p) => p.name === name)
-}


### PR DESCRIPTION
## Summary
  - Add 7 theme color presets (zinc, slate, blue, green, violet, orange, rose) using OKLCH color space
  - Add UI font size (12–20px) and code font size (10–24px) sliders with instant preview
  - Flash prevention via inline script in layout.tsx to avoid FOUC on page load
  - Integrate code font size with Monaco editors and xterm terminal
  - i18n support for all 10 locales

  ## Implementation
  - `src/lib/appearance-settings.ts` — settings read/write/normalize/apply with localStorage
  - `src/lib/theme-color-presets.ts` — 7 OKLCH color preset definitions
  - `src/hooks/use-appearance-settings.ts` — React hook for appearance state management
  - `src/components/appearance-initializer.tsx` — global initializer for cross-page propagation
  - `src/components/ui/slider.tsx` — Slider component wrapping Radix UI
  - UI font scaling uses root fontSize + CSS zoom for complete rem + px coverage