### PR TITLE
fix(acp): dedupe slash command results

### DIFF
--- a/src/contexts/acp-connections-context.tsx
+++ b/src/contexts/acp-connections-context.tsx
@@ -551,6 +551,26 @@ function sameCommands(
   return true
 }
 
+function dedupeCommandsByName(
+  commands: AvailableCommandInfo[]
+): AvailableCommandInfo[] {
+  const seen = new Set<string>()
+  let deduped: AvailableCommandInfo[] | null = null
+
+  for (let i = 0; i < commands.length; i += 1) {
+    const command = commands[i]
+    if (seen.has(command.name)) {
+      deduped ??= commands.slice(0, i)
+      continue
+    }
+
+    seen.add(command.name)
+    deduped?.push(command)
+  }
+
+  return deduped ?? commands
+}
+
 function applyStreamingAction(
   conn: ConnectionState,
   action: StreamingAction
@@ -1194,11 +1214,12 @@ function connectionsReducer(
     case "AVAILABLE_COMMANDS": {
       const conn = state.get(action.contextKey)
       if (!conn) return state
-      if (sameCommands(conn.availableCommands, action.commands)) return state
+      const commands = dedupeCommandsByName(action.commands)
+      if (sameCommands(conn.availableCommands, commands)) return state
       const next = new Map(state)
       next.set(action.contextKey, {
         ...conn,
-        availableCommands: action.commands,
+        availableCommands: commands,
       })
       return next
     }


### PR DESCRIPTION
## Summary
- Deduplicate ACP slash command records by command name before UI consumers render them.
- Preserve existing fuzzy search behavior and first-occurrence ordering.

## Test plan
- pnpm eslint .
- pnpm build
<img width="507" height="387" alt="image" src="https://github.com/user-attachments/assets/8f8f0ad2-7d56-4e2a-9511-1a3a98447ef4" />
<img width="447" height="245" alt="image" src="https://github.com/user-attachments/assets/7ab2fdcb-fa3f-4b83-9af1-6658bcd9d576" />
