### PR TITLE
feat(squad): full squad orchestration pipeline + auto turn capture + reducer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,11 @@ jobs:
 
       - name: cargo clippy (server mode)
         working-directory: src-tauri
-        run: cargo clippy --bin codeg-server --no-default-features --all-targets -- -D warnings
+        # Cannot use --all-targets here: the desktop `codeg` bin re-exports
+        # `tauri_app::run` which is cfg-gated to the tauri-runtime feature,
+        # so building it without the feature fails. We lint the lib + the
+        # explicit server bin instead.
+        run: cargo clippy --lib --bin codeg-server --no-default-features -- -D warnings
 
   backend-desktop:
     name: Backend (Tauri desktop)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  frontend:
+    name: Frontend (TS + ESLint + i18n)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: i18n parity
+        run: pnpm check:i18n
+
+  backend-server:
+    name: Backend (codeg-server, no default features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: cargo fmt
+        working-directory: src-tauri
+        run: cargo fmt --all -- --check
+
+      - name: cargo check (server mode)
+        working-directory: src-tauri
+        run: cargo check --bin codeg-server --no-default-features
+
+      - name: cargo clippy (server mode)
+        working-directory: src-tauri
+        run: cargo clippy --bin codeg-server --no-default-features --all-targets -- -D warnings
+
+  backend-desktop:
+    name: Backend (Tauri desktop)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Tauri system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: cargo check (desktop)
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: cargo clippy (desktop)
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:manifest": "node scripts/write-build-manifest.mjs",
     "build": "pnpm build:web && pnpm build:manifest",
     "lint": "eslint",
+    "check:i18n": "node scripts/check-i18n-parity.mjs",
     "release:standalone": "node scripts/release.mjs",
     "tauri": "tauri",
     "server:build": "cd src-tauri && cargo build --release --bin codeg-server --no-default-features",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "version": "0.10.0",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build:web": "next build",
+    "build:manifest": "node scripts/write-build-manifest.mjs",
+    "build": "pnpm build:web && pnpm build:manifest",
     "lint": "eslint",
+    "release:standalone": "node scripts/release.mjs",
     "tauri": "tauri",
     "server:build": "cd src-tauri && cargo build --release --bin codeg-server --no-default-features",
     "server:dev": "cd src-tauri && cargo run --bin codeg-server --no-default-features",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build:manifest": "node scripts/write-build-manifest.mjs",
     "build": "pnpm build:web && pnpm build:manifest",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "check:i18n": "node scripts/check-i18n-parity.mjs",
     "release:standalone": "node scripts/release.mjs",
     "tauri": "tauri",
@@ -77,12 +79,15 @@
     "@types/node": "25.2.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
+    "happy-dom": "^20.9.0",
     "prettier": "^3.8.1",
     "tw-animate-css": "^1.4.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.2.3(@types/react@19.2.13)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -186,6 +189,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -195,6 +201,9 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(msw@2.12.9(@types/node@25.2.2)(typescript@5.8.3))(vite@8.0.10(@types/node@25.2.2)(jiti@2.6.1))
 
 packages:
 
@@ -439,6 +448,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
@@ -495,14 +508,23 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emoji-mart/data@1.2.1':
     resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
@@ -973,6 +995,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
 
@@ -1071,6 +1099,9 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -2199,6 +2230,104 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2559,6 +2688,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -2655,6 +2787,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2716,6 +2851,12 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.54.0':
     resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
@@ -2897,6 +3038,44 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -3035,6 +3214,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   assign-symbols@1.0.0:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
@@ -3045,6 +3228,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -3132,6 +3318,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3624,6 +3814,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -3646,6 +3840,9 @@ packages:
   es-iterator-helpers@1.2.2:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3872,6 +4069,10 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   express-rate-limit@8.2.1:
     resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
     engines: {node: '>= 16'}
@@ -4008,6 +4209,11 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -4112,6 +4318,10 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -4199,6 +4409,9 @@ packages:
   hono@4.11.9:
     resolution: {integrity: sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
@@ -4494,6 +4707,18 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -4508,6 +4733,9 @@ packages:
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4612,8 +4840,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -4624,8 +4864,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -4636,8 +4888,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -4650,8 +4915,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -4664,8 +4943,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -4676,8 +4968,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -4742,6 +5044,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -5190,6 +5499,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-change@4.0.2:
     resolution: {integrity: sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5324,6 +5636,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -5354,6 +5670,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -5763,6 +6083,11 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -5896,6 +6221,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5942,12 +6270,18 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -6096,6 +6430,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -6103,6 +6440,14 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.22:
     resolution: {integrity: sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==}
@@ -6367,6 +6712,90 @@ packages:
       vue:
         optional: true
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -6394,6 +6823,10 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -6420,6 +6853,11 @@ packages:
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -6434,6 +6872,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -6816,6 +7266,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.13
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@braintree/sanitize-url@7.1.2': {}
 
   '@chevrotain/cst-dts-gen@11.1.2':
@@ -6883,9 +7335,20 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -6895,6 +7358,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7492,6 +7960,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.1.6': {}
 
   '@next/eslint-plugin-next@16.1.6':
@@ -7554,6 +8029,8 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@oxc-project/types@0.127.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -8773,6 +9250,57 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@schummar/icu-type-parser@1.21.5': {}
@@ -9097,6 +9625,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -9218,6 +9751,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -9269,6 +9804,12 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.2.2
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
@@ -9435,6 +9976,62 @@ snapshots:
       react: 19.2.4
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(msw@2.12.9(@types/node@25.2.2)(typescript@5.8.3))(vite@8.0.10(@types/node@25.2.2)(jiti@2.6.1))
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(msw@2.12.9(@types/node@25.2.2)(typescript@5.8.3))(vite@8.0.10(@types/node@25.2.2)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.9(@types/node@25.2.2)(typescript@5.8.3)
+      vite: 8.0.10(@types/node@25.2.2)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@xterm/addon-fit@0.11.0': {}
 
@@ -9671,6 +10268,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   assign-symbols@1.0.0: {}
 
   ast-types-flow@0.0.8: {}
@@ -9678,6 +10277,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astring@1.9.0: {}
 
@@ -9768,6 +10373,8 @@ snapshots:
   caniuse-lite@1.0.30001769: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -10239,6 +10846,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.4:
@@ -10324,6 +10933,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -10658,6 +11269,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expect-type@1.3.0: {}
+
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -10741,6 +11354,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -10818,6 +11435,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -10913,6 +11533,18 @@ snapshots:
   graphql@16.12.0: {}
 
   hachure-fill@0.5.2: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.2.2
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-bigints@1.1.0: {}
 
@@ -11096,6 +11728,8 @@ snapshots:
       react-is: 16.13.1
 
   hono@4.11.9: {}
+
+  html-escaper@2.0.2: {}
 
   html-to-image@1.11.13: {}
 
@@ -11353,6 +11987,19 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -11367,6 +12014,8 @@ snapshots:
   jose@6.1.3: {}
 
   js-cookie@3.0.5: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -11472,34 +12121,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -11517,6 +12199,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -11582,6 +12280,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   markdown-extensions@2.0.0: {}
 
@@ -12353,6 +13061,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   on-change@4.0.2: {}
 
   on-finished@2.4.1:
@@ -12495,6 +13205,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
@@ -12524,6 +13236,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -13099,6 +13817,27 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -13353,6 +14092,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -13382,9 +14123,13 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   state-local@1.0.7: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -13557,12 +14302,21 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.22: {}
 
@@ -13851,6 +14605,48 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  vite@8.0.10(@types/node@25.2.2)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.2.2
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.2)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(msw@2.12.9(@types/node@25.2.2)(typescript@5.8.3))(vite@8.0.10(@types/node@25.2.2)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.9(@types/node@25.2.2)(typescript@5.8.3))(vite@8.0.10(@types/node@25.2.2)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.2.2)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.2.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -13871,6 +14667,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -13921,6 +14719,11 @@ snapshots:
     dependencies:
       isexe: 3.1.4
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@6.2.0:
@@ -13936,6 +14739,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/scripts/check-i18n-parity.mjs
+++ b/scripts/check-i18n-parity.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Validates that all locale files under src/i18n/messages/ share the
+ * exact same set of message keys as en.json (the source of truth).
+ *
+ * Exits non-zero with a diff-style report if any locale is missing keys
+ * or carries stale extras. Designed to be wired into CI / lint flows.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import url from "node:url"
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const MESSAGES_DIR = path.resolve(__dirname, "..", "src", "i18n", "messages")
+const SOURCE_LOCALE = "en.json"
+
+function flatten(obj, prefix = "") {
+  const out = new Set()
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      for (const inner of flatten(v, key)) out.add(inner)
+    } else {
+      out.add(key)
+    }
+  }
+  return out
+}
+
+function main() {
+  if (!fs.existsSync(MESSAGES_DIR)) {
+    console.error(`[i18n-parity] missing dir: ${MESSAGES_DIR}`)
+    process.exit(2)
+  }
+  const sourcePath = path.join(MESSAGES_DIR, SOURCE_LOCALE)
+  if (!fs.existsSync(sourcePath)) {
+    console.error(`[i18n-parity] source locale not found: ${sourcePath}`)
+    process.exit(2)
+  }
+
+  const source = JSON.parse(fs.readFileSync(sourcePath, "utf8"))
+  const sourceKeys = flatten(source)
+
+  let failed = false
+  const files = fs
+    .readdirSync(MESSAGES_DIR)
+    .filter((f) => f.endsWith(".json") && f !== SOURCE_LOCALE)
+    .sort()
+
+  for (const fn of files) {
+    const data = JSON.parse(
+      fs.readFileSync(path.join(MESSAGES_DIR, fn), "utf8")
+    )
+    const keys = flatten(data)
+    const missing = [...sourceKeys].filter((k) => !keys.has(k))
+    const extra = [...keys].filter((k) => !sourceKeys.has(k))
+    if (missing.length || extra.length) {
+      failed = true
+      console.error(
+        `\n[i18n-parity] ${fn}: -${missing.length} +${extra.length}`
+      )
+      for (const k of missing.slice(0, 20)) console.error(`  missing: ${k}`)
+      for (const k of extra.slice(0, 20)) console.error(`  extra:   ${k}`)
+      if (missing.length > 20)
+        console.error(`  …and ${missing.length - 20} more missing`)
+      if (extra.length > 20)
+        console.error(`  …and ${extra.length - 20} more extra`)
+    }
+  }
+
+  if (failed) {
+    console.error("\n[i18n-parity] FAIL")
+    process.exit(1)
+  }
+  console.log(
+    `[i18n-parity] OK — ${files.length} locales × ${sourceKeys.size} keys`
+  )
+}
+
+main()

--- a/scripts/ops/codeg-server-healthcheck.sh
+++ b/scripts/ops/codeg-server-healthcheck.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${CODEG_ENV_FILE:-/etc/codeg-server.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+SERVICE_NAME="${CODEG_SYSTEMD_SERVICE:-codeg-server.service}"
+PORT="${CODEG_PORT:-3080}"
+HEALTH_URL="${CODEG_HEALTH_URL:-http://127.0.0.1:${PORT}/api/health}"
+
+if ! systemctl is-active --quiet "$SERVICE_NAME"; then
+  logger -t codeg-server-healthcheck "service inactive, starting ${SERVICE_NAME}"
+  exec systemctl restart "$SERVICE_NAME"
+fi
+
+if curl --fail --silent --show-error --max-time 10 -X POST "$HEALTH_URL" | grep -q '"status":"ok"'; then
+  exit 0
+fi
+
+logger -t codeg-server-healthcheck "healthcheck failed for ${HEALTH_URL}, restarting ${SERVICE_NAME}"
+exec systemctl restart "$SERVICE_NAME"

--- a/scripts/ops/run-codeg-server.sh
+++ b/scripts/ops/run-codeg-server.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${CODEG_ENV_FILE:-/etc/codeg-server.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+REPO_DIR="${CODEG_REPO_DIR:-/home/bob/codeg}"
+HOST="${CODEG_HOST:-0.0.0.0}"
+PORT="${CODEG_PORT:-3080}"
+DATA_DIR="${CODEG_DATA_DIR:-/home/bob/.local/share/codeg}"
+STATIC_DIR="${CODEG_STATIC_DIR:-$REPO_DIR/out}"
+DISABLE_AUTH="${CODEG_DISABLE_AUTH:-1}"
+
+if [[ -n "${CODEG_BINARY:-}" ]]; then
+  BINARY="$CODEG_BINARY"
+elif [[ -x "$REPO_DIR/src-tauri/target/release/codeg-server" ]]; then
+  BINARY="$REPO_DIR/src-tauri/target/release/codeg-server"
+elif [[ -x "$REPO_DIR/src-tauri/target/debug/codeg-server" ]]; then
+  BINARY="$REPO_DIR/src-tauri/target/debug/codeg-server"
+else
+  echo "[codeg-server] no executable binary found under $REPO_DIR/src-tauri/target/{release,debug}" >&2
+  exit 1
+fi
+
+if [[ ! -d "$STATIC_DIR" ]]; then
+  echo "[codeg-server] static directory missing: $STATIC_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$DATA_DIR"
+cd "$REPO_DIR"
+
+for user_bin_dir in "$HOME/.npm-global/bin" "$HOME/.local/bin" "$HOME/bin"; do
+  if [[ -d "$user_bin_dir" && ":$PATH:" != *":$user_bin_dir:"* ]]; then
+    PATH="$user_bin_dir:$PATH"
+  fi
+done
+
+export CODEG_HOST="$HOST"
+export CODEG_PORT="$PORT"
+export CODEG_DATA_DIR="$DATA_DIR"
+export CODEG_STATIC_DIR="$STATIC_DIR"
+export CODEG_DISABLE_AUTH="$DISABLE_AUTH"
+export PATH
+
+exec "$BINARY"

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,17 @@
+import { spawnSync } from "node:child_process"
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    ...options,
+  })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+run("pnpm", ["build"])
+run("cargo", ["build", "--release", "--bin", "codeg-server", "--no-default-features"], {
+  cwd: "src-tauri",
+})

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -12,6 +12,10 @@ function run(cmd, args, options = {}) {
 }
 
 run("pnpm", ["build"])
-run("cargo", ["build", "--release", "--bin", "codeg-server", "--no-default-features"], {
-  cwd: "src-tauri",
-})
+run(
+  "cargo",
+  ["build", "--release", "--bin", "codeg-server", "--no-default-features"],
+  {
+    cwd: "src-tauri",
+  }
+)

--- a/scripts/write-build-manifest.mjs
+++ b/scripts/write-build-manifest.mjs
@@ -1,0 +1,33 @@
+import { execFileSync } from "node:child_process"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+
+function tryGitCommit() {
+  try {
+    return execFileSync("git", ["rev-parse", "--short=12", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+)
+const outPath = join(process.cwd(), "out", "codeg-build.json")
+
+mkdirSync(dirname(outPath), { recursive: true })
+writeFileSync(
+  outPath,
+  `${JSON.stringify(
+    {
+      version: pkg.version,
+      git_commit: tryGitCommit(),
+      built_at: new Date().toISOString(),
+    },
+    null,
+    2
+  )}\n`
+)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tar",
  "tauri",
  "tauri-build",
@@ -898,6 +899,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",
+ "tokio-util",
  "toml 0.8.2",
  "tower-http",
  "urlencoding",
@@ -6892,6 +6894,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,7 +73,7 @@ toml = "0.8"
 notify = "6"
 base64 = "0.22"
 agent-client-protocol-schema = { version = "0.11", features = ["unstable_session_usage", "unstable_session_fork"] }
-kill_tree = { version = "0.2", features = ["tokio"] }
+kill_tree = { version = "0.2", features = ["tokio", "blocking"] }
 which = "7"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"], optional = true }
 axum = { version = "0.8", features = ["ws"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -102,6 +102,9 @@ mac-notification-sys = "0.6"
 windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
 junction = "1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [patch.crates-io]
 sacp-tokio = { path = "vendor/sacp-tokio" }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -86,6 +86,8 @@ qrcode = "0.14"
 image = { version = "0.25", default-features = false, features = ["png"] }
 include_dir = "0.7"
 sha2 = "0.10"
+subtle = "2"
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-window-state = { version = "2", optional = true }
@@ -102,3 +104,10 @@ junction = "1"
 
 [patch.crates-io]
 sacp-tokio = { path = "vendor/sacp-tokio" }
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
+opt-level = 3

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,25 @@
 fn main() {
     #[cfg(feature = "tauri-runtime")]
     tauri_build::build();
+
+    if let Ok(profile) = std::env::var("PROFILE") {
+        println!("cargo:rustc-env=CODEG_BUILD_PROFILE={profile}");
+    }
+
+    if let Some(commit) = git_output(&["rev-parse", "--short=12", "HEAD"]) {
+        println!("cargo:rustc-env=CODEG_BUILD_GIT_COMMIT={commit}");
+    }
+
+    if let Ok(now) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        println!("cargo:rustc-env=CODEG_BUILD_TIMESTAMP={}", now.as_secs());
+    }
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -21,5 +21,9 @@ fn git_output(args: &[&str]) -> Option<String> {
         return None;
     }
     let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if value.is_empty() { None } else { Some(value) }
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
 }

--- a/src-tauri/src/acp/binary_cache.rs
+++ b/src-tauri/src/acp/binary_cache.rs
@@ -93,7 +93,9 @@ pub fn inventory_agent_caches() -> Result<AcpCacheInventory, AcpError> {
         let dir = root.join(&agent_id);
         let (size_bytes, file_count) = directory_usage(&dir)?;
         let mut versions = match &meta.distribution {
-            registry::AgentDistribution::Binary { cmd, .. } => installed_version_labels(&agent_id, cmd)?,
+            registry::AgentDistribution::Binary { cmd, .. } => {
+                installed_version_labels(&agent_id, cmd)?
+            }
             _ => Vec::new(),
         };
         versions.sort_by(|left, right| version_cmp(left, right));
@@ -265,13 +267,11 @@ fn directory_usage(path: &Path) -> Result<(u64, usize), AcpError> {
     let mut file_count = 0usize;
 
     for entry in walkdir::WalkDir::new(path) {
-        let entry = entry
-            .map_err(|error| AcpError::DownloadFailed(format!("failed to scan cache dir: {error}")))?;
+        let entry = entry.map_err(|error| {
+            AcpError::DownloadFailed(format!("failed to scan cache dir: {error}"))
+        })?;
         if entry.file_type().is_file() {
-            let size = entry
-                .metadata()
-                .map(|metadata| metadata.len())
-                .unwrap_or(0);
+            let size = entry.metadata().map(|metadata| metadata.len()).unwrap_or(0);
             total_size = total_size.saturating_add(size);
             file_count += 1;
         }
@@ -417,11 +417,19 @@ async fn download_file_with_progress(
 ) -> Result<(), AcpError> {
     use futures_util::StreamExt;
 
-    let response = reqwest::Client::new()
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| AcpError::DownloadFailed(format!("HTTP request failed: {e}")))?;
+    // Binary downloads can be tens of MB; use a generous total timeout. The
+    // factory still injects user proxy settings so air-gapped corp networks
+    // route through their internal mirror.
+    let response = crate::network::http_client::build_client_with(
+        crate::network::http_client::ClientConfig::with_timeouts(
+            std::time::Duration::from_secs(15),
+            std::time::Duration::from_secs(600),
+        ),
+    )
+    .get(url)
+    .send()
+    .await
+    .map_err(|e| AcpError::DownloadFailed(format!("HTTP request failed: {e}")))?;
 
     if !response.status().is_success() {
         return Err(AcpError::DownloadFailed(format!(

--- a/src-tauri/src/acp/binary_cache.rs
+++ b/src-tauri/src/acp/binary_cache.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use serde::Serialize;
+
 use crate::acp::error::AcpError;
 use crate::acp::registry;
 use crate::models::agent::AgentType;
@@ -50,6 +52,72 @@ pub fn clear_agent_cache(agent_type: AgentType) -> Result<(), AcpError> {
             .map_err(|e| AcpError::DownloadFailed(format!("failed to clear cache: {e}")))?;
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AcpCacheEntry {
+    pub agent_type: AgentType,
+    pub label: String,
+    pub path: String,
+    pub size_bytes: u64,
+    pub file_count: usize,
+    pub versions: Vec<String>,
+    pub installed_version: Option<String>,
+    pub recommended_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AcpCacheInventory {
+    pub generated_at: String,
+    pub root_path: String,
+    pub total_size_bytes: u64,
+    pub entries: Vec<AcpCacheEntry>,
+}
+
+pub fn inventory_agent_caches() -> Result<AcpCacheInventory, AcpError> {
+    let root = cache_dir()?;
+    let mut entries = Vec::new();
+    let mut total_size_bytes = 0u64;
+
+    for agent_type in AgentType::all() {
+        let meta = registry::get_agent_meta(agent_type);
+        let recommended_version = match &meta.distribution {
+            registry::AgentDistribution::Binary { version, .. } => Some((*version).to_string()),
+            _ => None,
+        };
+        if recommended_version.is_none() {
+            continue;
+        }
+
+        let agent_id = agent_cache_key(agent_type);
+        let dir = root.join(&agent_id);
+        let (size_bytes, file_count) = directory_usage(&dir)?;
+        let mut versions = match &meta.distribution {
+            registry::AgentDistribution::Binary { cmd, .. } => installed_version_labels(&agent_id, cmd)?,
+            _ => Vec::new(),
+        };
+        versions.sort_by(|left, right| version_cmp(left, right));
+        let installed_version = versions.last().cloned();
+
+        total_size_bytes = total_size_bytes.saturating_add(size_bytes);
+        entries.push(AcpCacheEntry {
+            agent_type,
+            label: meta.name.to_string(),
+            path: dir.to_string_lossy().to_string(),
+            size_bytes,
+            file_count,
+            versions,
+            installed_version,
+            recommended_version,
+        });
+    }
+
+    Ok(AcpCacheInventory {
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        root_path: root.to_string_lossy().to_string(),
+        total_size_bytes,
+        entries,
+    })
 }
 
 fn installed_binary_path(agent_id: &str, version: &str, cmd_name: &str) -> Option<PathBuf> {
@@ -186,6 +254,30 @@ fn parse_version_parts(input: &str) -> Vec<u32> {
             numeric.parse::<u32>().unwrap_or(0)
         })
         .collect()
+}
+
+fn directory_usage(path: &Path) -> Result<(u64, usize), AcpError> {
+    if !path.exists() {
+        return Ok((0, 0));
+    }
+
+    let mut total_size = 0u64;
+    let mut file_count = 0usize;
+
+    for entry in walkdir::WalkDir::new(path) {
+        let entry = entry
+            .map_err(|error| AcpError::DownloadFailed(format!("failed to scan cache dir: {error}")))?;
+        if entry.file_type().is_file() {
+            let size = entry
+                .metadata()
+                .map(|metadata| metadata.len())
+                .unwrap_or(0);
+            total_size = total_size.saturating_add(size);
+            file_count += 1;
+        }
+    }
+
+    Ok((total_size, file_count))
 }
 
 /// Same as `ensure_binary_for_agent` but calls `on_progress` with human-readable

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use sacp::schema::McpServerStdio;
 use sacp::schema::{
     BlobResourceContents, CancelNotification, ClientCapabilities, ContentBlock, ContentChunk,
@@ -29,6 +30,7 @@ use tokio::sync::mpsc;
 
 use crate::acp::error::AcpError;
 use crate::acp::file_system_runtime::{FileSystemRuntime, FileSystemRuntimeError};
+use crate::acp::manager::ConnectionManager;
 use crate::acp::registry::{self, AgentDistribution};
 use crate::acp::terminal_runtime::{TerminalRuntime, TerminalRuntimeError};
 use crate::acp::types::{
@@ -129,22 +131,135 @@ impl Drop for ConnectionCleanupGuard {
 }
 
 /// Represents a single active ACP agent connection.
+#[derive(Debug, Clone)]
+pub struct AgentConnectionMetadata {
+    pub status: ConnectionStatus,
+    pub working_dir: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub session_id: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone)]
 pub struct AgentConnection {
     pub id: String,
     pub agent_type: AgentType,
-    pub status: ConnectionStatus,
     pub owner_window_label: String,
     pub cmd_tx: mpsc::Sender<ConnectionCommand>,
+    pub metadata: Arc<tokio::sync::RwLock<AgentConnectionMetadata>>,
 }
 
 impl AgentConnection {
-    pub fn info(&self) -> ConnectionInfo {
+    pub async fn info(&self) -> ConnectionInfo {
+        let metadata = self.metadata.read().await;
         ConnectionInfo {
             id: self.id.clone(),
             agent_type: self.agent_type,
-            status: self.status.clone(),
+            status: metadata.status.clone(),
+            owner_window_label: self.owner_window_label.clone(),
+            working_dir: metadata.working_dir.clone(),
+            created_at: metadata.created_at,
+            updated_at: metadata.updated_at,
+            session_id: metadata.session_id.clone(),
+            last_error: metadata.last_error.clone(),
         }
     }
+}
+
+async fn with_connection_metadata<F>(
+    connections: &Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
+    connection_id: &str,
+    update: F,
+) where
+    F: FnOnce(&mut AgentConnectionMetadata),
+{
+    let metadata = {
+        let connections = connections.lock().await;
+        connections
+            .get(connection_id)
+            .map(|connection| connection.metadata.clone())
+    };
+
+    if let Some(metadata) = metadata {
+        let mut metadata = metadata.write().await;
+        update(&mut metadata);
+        metadata.updated_at = Utc::now();
+    }
+}
+
+async fn emit_status_changed(
+    connections: &Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
+    emitter: &EventEmitter,
+    connection_id: &str,
+    status: ConnectionStatus,
+) {
+    let metadata_status = status.clone();
+    with_connection_metadata(connections, connection_id, move |metadata| {
+        metadata.status = metadata_status.clone();
+        if metadata_status != ConnectionStatus::Error {
+            metadata.last_error = None;
+        }
+    })
+    .await;
+
+    crate::web::event_bridge::emit_event(
+        emitter,
+        "acp://event",
+        AcpEvent::StatusChanged {
+            connection_id: connection_id.to_string(),
+            status,
+        },
+    );
+}
+
+async fn emit_connection_error(
+    connections: &Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
+    emitter: &EventEmitter,
+    connection_id: &str,
+    agent_type: AgentType,
+    message: String,
+    code: Option<String>,
+) {
+    let metadata_message = message.clone();
+    with_connection_metadata(connections, connection_id, move |metadata| {
+        metadata.status = ConnectionStatus::Error;
+        metadata.last_error = Some(metadata_message.clone());
+    })
+    .await;
+
+    crate::web::event_bridge::emit_event(
+        emitter,
+        "acp://event",
+        AcpEvent::Error {
+            connection_id: connection_id.to_string(),
+            message,
+            agent_type: agent_type.to_string(),
+            code,
+        },
+    );
+}
+
+async fn emit_session_started(
+    connections: &Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
+    emitter: &EventEmitter,
+    connection_id: &str,
+    session_id: &str,
+) {
+    let session_id_string = session_id.to_string();
+    with_connection_metadata(connections, connection_id, move |metadata| {
+        metadata.session_id = Some(session_id_string.clone());
+    })
+    .await;
+
+    crate::web::event_bridge::emit_event(
+        emitter,
+        "acp://event",
+        AcpEvent::SessionStarted {
+            connection_id: connection_id.to_string(),
+            session_id: session_id.to_string(),
+        },
+    );
 }
 
 /// Build an AcpAgent from registry metadata.
@@ -174,27 +289,24 @@ async fn build_agent(
             for a in args {
                 parts.push((*a).into());
             }
-            // Translate OpenClaw-specific env vars to CLI flags
-            if agent_type == AgentType::OpenClaw {
+            // Translate Generic-specific env vars to CLI flags
+            if agent_type == AgentType::Generic {
                 if let Some(url) = runtime_env
-                    .get("OPENCLAW_GATEWAY_URL")
+                    .get("GENERIC_GATEWAY_URL")
                     .filter(|v| !v.is_empty())
                 {
                     parts.push("--url".into());
                     parts.push(url.clone());
                 }
                 if let Some(key) = runtime_env
-                    .get("OPENCLAW_SESSION_KEY")
+                    .get("GENERIC_SESSION_KEY")
                     .filter(|v| !v.is_empty())
                 {
                     parts.push("--session".into());
                     parts.push(key.clone());
                 }
-                // When creating a new conversation (no session_id to resume),
-                // pass --reset-session so OpenClaw mints a fresh transcript
-                // instead of appending to the previous one.
                 if runtime_env
-                    .get("OPENCLAW_RESET_SESSION")
+                    .get("GENERIC_RESET_SESSION")
                     .is_some_and(|v| v == "1")
                 {
                     parts.push("--reset-session".into());
@@ -351,6 +463,7 @@ async fn build_agent(
 /// leaks stale entries after a connection tears down.
 #[allow(clippy::too_many_arguments)]
 pub async fn spawn_agent_connection(
+    manager: ConnectionManager,
     connection_id: String,
     agent_type: AgentType,
     working_dir: Option<String>,
@@ -358,8 +471,9 @@ pub async fn spawn_agent_connection(
     runtime_env: BTreeMap<String, String>,
     owner_window_label: String,
     emitter: EventEmitter,
-    connections: Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
 ) -> Result<(), AcpError> {
+    let connections = manager.connections_arc();
+
     crate::web::event_bridge::emit_event(
         &emitter,
         "acp://event",
@@ -375,7 +489,12 @@ pub async fn spawn_agent_connection(
     let conn_id = connection_id.clone();
     let emitter_clone = emitter.clone();
     let cleanup_connections = connections.clone();
+    let event_connections = connections.clone();
+    let run_connections = connections.clone();
     let cleanup_connection_id = connection_id.clone();
+    let manager_clone = manager.clone_ref();
+    let working_dir_for_metadata = working_dir.clone();
+    let owner_window_label_for_log = owner_window_label.clone();
 
     // Insert the entry BEFORE spawning the background task so that a
     // fast-failing `run_connection` can never remove it before it was
@@ -385,9 +504,16 @@ pub async fn spawn_agent_connection(
         AgentConnection {
             id: connection_id,
             agent_type,
-            status: ConnectionStatus::Connecting,
             owner_window_label,
             cmd_tx,
+            metadata: Arc::new(tokio::sync::RwLock::new(AgentConnectionMetadata {
+                status: ConnectionStatus::Connecting,
+                working_dir: working_dir_for_metadata,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                session_id: None,
+                last_error: None,
+            })),
         },
     );
 
@@ -406,31 +532,42 @@ pub async fn spawn_agent_connection(
             working_dir,
             session_id,
             cmd_rx,
+            run_connections,
             emitter_clone.clone(),
         )
         .await;
 
         if let Err(e) = result {
             let code = e.code().map(String::from);
-            crate::web::event_bridge::emit_event(
+            manager_clone
+                .record_failure(agent_type, &e.to_string(), Some(&conn_id))
+                .await;
+            emit_connection_error(
+                &event_connections,
                 &emitter_clone,
-                "acp://event",
-                AcpEvent::Error {
-                    connection_id: conn_id.clone(),
-                    message: e.to_string(),
-                    agent_type: agent_type.to_string(),
-                    code,
-                },
-            );
+                &conn_id,
+                agent_type,
+                e.to_string(),
+                code,
+            )
+            .await;
         }
 
-        crate::web::event_bridge::emit_event(
+        emit_status_changed(
+            &event_connections,
             &emitter_clone,
-            "acp://event",
-            AcpEvent::StatusChanged {
-                connection_id: conn_id,
-                status: ConnectionStatus::Disconnected,
-            },
+            &conn_id,
+            ConnectionStatus::Disconnected,
+        )
+        .await;
+        manager_clone.log_runtime(
+            "info",
+            "acp",
+            format!(
+                "connection {} closed for {} ({})",
+                conn_id, agent_type, owner_window_label_for_log
+            ),
+            None,
         );
         // `_cleanup` is dropped here — removes the connection entry from
         // the manager map. Same drop semantics apply on panic unwinding.
@@ -733,6 +870,7 @@ async fn run_connection(
     working_dir: Option<String>,
     session_id: Option<String>,
     mut cmd_rx: mpsc::Receiver<ConnectionCommand>,
+    connections: Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
     emitter: EventEmitter,
 ) -> Result<(), AcpError> {
     let pending_perms: PendingPermissions = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
@@ -942,14 +1080,13 @@ async fn run_connection(
             // selectors and enable sending while the session initialises.
             // Prompts sent before run_conversation_loop are buffered in
             // the cmd_rx channel and processed as soon as the loop starts.
-            crate::web::event_bridge::emit_event(
+            emit_status_changed(
+                &connections,
                 &emitter_clone,
-                "acp://event",
-                AcpEvent::StatusChanged {
-                    connection_id: conn_id.clone(),
-                    status: ConnectionStatus::Connected,
-                },
-            );
+                &conn_id,
+                ConnectionStatus::Connected,
+            )
+            .await;
 
             if let Some(sid) = session_id {
                 // Load existing session via session/load
@@ -1008,14 +1145,7 @@ async fn run_connection(
                             eprintln!("[ACP] Drained {drained} historical replay notifications");
                         }
 
-                        crate::web::event_bridge::emit_event(
-                            &emitter_clone,
-                            "acp://event",
-                            AcpEvent::SessionStarted {
-                                connection_id: conn_id.clone(),
-                                session_id: sid.clone(),
-                            },
-                        );
+                        emit_session_started(&connections, &emitter_clone, &conn_id, &sid).await;
                         emit_session_modes(&conn_id, &emitter_clone, session.modes());
                         emit_session_config_options(
                             &conn_id,
@@ -1028,6 +1158,7 @@ async fn run_connection(
                         let loop_result = run_conversation_loop(
                             &mut session,
                             &conn_id,
+                            &connections,
                             &emitter_clone,
                             agent_type,
                             &perms,
@@ -1042,6 +1173,7 @@ async fn run_connection(
                         handle_fork_or_exit(
                             loop_result,
                             &conn_id,
+                            &connections,
                             &emitter_clone,
                             agent_type,
                             &perms,
@@ -1071,16 +1203,15 @@ async fn run_connection(
                             return Ok(());
                         }
                         if !err_str.contains("Method not found") {
-                            crate::web::event_bridge::emit_event(
+                            emit_connection_error(
+                                &connections,
                                 &emitter_clone,
-                                "acp://event",
-                                AcpEvent::Error {
-                                    connection_id: conn_id.clone(),
-                                    message: format!("Failed to load session, starting new: {e}"),
-                                    agent_type: agent_type.to_string(),
-                                    code: None,
-                                },
-                            );
+                                &conn_id,
+                                agent_type,
+                                format!("Failed to load session, starting new: {e}"),
+                                None,
+                            )
+                            .await;
                         }
                         let new_resp = cx
                             .send_request_to(Agent, build_new_session_request(agent_type, &cwd))
@@ -1089,14 +1220,13 @@ async fn run_connection(
                         let fallback_sid = new_resp.session_id.0.to_string();
                         let initial_config_options = new_resp.config_options.clone();
                         let mut session = cx.attach_session(new_resp, Default::default())?;
-                        crate::web::event_bridge::emit_event(
+                        emit_session_started(
+                            &connections,
                             &emitter_clone,
-                            "acp://event",
-                            AcpEvent::SessionStarted {
-                                connection_id: conn_id.clone(),
-                                session_id: fallback_sid.clone(),
-                            },
-                        );
+                            &conn_id,
+                            &fallback_sid,
+                        )
+                        .await;
                         emit_session_modes(&conn_id, &emitter_clone, session.modes());
                         emit_session_config_options(
                             &conn_id,
@@ -1109,6 +1239,7 @@ async fn run_connection(
                         let loop_result = run_conversation_loop(
                             &mut session,
                             &conn_id,
+                            &connections,
                             &emitter_clone,
                             agent_type,
                             &perms,
@@ -1125,6 +1256,7 @@ async fn run_connection(
                         handle_fork_or_exit(
                             loop_result,
                             &conn_id,
+                            &connections,
                             &emitter_clone,
                             agent_type,
                             &perms,
@@ -1145,14 +1277,7 @@ async fn run_connection(
                 let sid = new_resp.session_id.0.to_string();
                 let initial_config_options = new_resp.config_options.clone();
                 let mut session = cx.attach_session(new_resp, Default::default())?;
-                crate::web::event_bridge::emit_event(
-                    &emitter_clone,
-                    "acp://event",
-                    AcpEvent::SessionStarted {
-                        connection_id: conn_id.clone(),
-                        session_id: sid.clone(),
-                    },
-                );
+                emit_session_started(&connections, &emitter_clone, &conn_id, &sid).await;
                 emit_session_modes(&conn_id, &emitter_clone, session.modes());
                 emit_session_config_options(
                     &conn_id,
@@ -1165,6 +1290,7 @@ async fn run_connection(
                 let loop_result = run_conversation_loop(
                     &mut session,
                     &conn_id,
+                    &connections,
                     &emitter_clone,
                     agent_type,
                     &perms,
@@ -1179,6 +1305,7 @@ async fn run_connection(
                 handle_fork_or_exit(
                     loop_result,
                     &conn_id,
+                    &connections,
                     &emitter_clone,
                     agent_type,
                     &perms,
@@ -1345,6 +1472,30 @@ async fn set_session_config_option(
 
 const TERMINAL_POLL_INTERVAL_MS: u64 = 200;
 const TERMINAL_POLL_MISSING_LIMIT: u8 = 10;
+
+/// Maximum time a turn may go without ANY observable signal from the agent
+/// (notification, tool poll tick, prompt response, parse warning, etc.)
+/// before we consider it stuck. Auto-compaction can take a while, so this
+/// is intentionally generous; the watchdog is reset by every event,
+/// including compaction markers.
+const TURN_IDLE_TIMEOUT_MS: u64 = 180_000;
+
+/// Emit a non-fatal stream warning to the UI. Used when we have to
+/// `continue` past a parse error inside the streaming loop — the UI must
+/// have *some* signal that something went sideways instead of a silent
+/// hang.
+fn emit_stream_warning(connection_id: &str, emitter: &EventEmitter, message: impl Into<String>) {
+    let message = message.into();
+    eprintln!("[ACP] stream warning ({connection_id}): {message}");
+    crate::web::event_bridge::emit_event(
+        emitter,
+        "acp://event",
+        AcpEvent::StreamWarning {
+            connection_id: connection_id.to_string(),
+            message,
+        },
+    );
+}
 
 #[derive(Debug, Default)]
 struct TrackedTerminalToolCall {
@@ -1711,6 +1862,7 @@ struct ForkExitInfo {
 async fn handle_fork_or_exit(
     loop_result: Result<Option<ForkExitInfo>, sacp::Error>,
     conn_id: &str,
+    connections: &Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
     emitter: &EventEmitter,
     agent_type: AgentType,
     perms: &PendingPermissions,
@@ -1749,14 +1901,7 @@ async fn handle_fork_or_exit(
         .meta(fork_resp.meta);
     let mut session = cx.attach_session(new_resp, Default::default())?;
 
-    crate::web::event_bridge::emit_event(
-        emitter,
-        "acp://event",
-        AcpEvent::SessionStarted {
-            connection_id: conn_id.to_string(),
-            session_id: new_sid.clone(),
-        },
-    );
+    emit_session_started(connections, emitter, conn_id, &new_sid).await;
     emit_session_modes(conn_id, emitter, session.modes());
     emit_session_config_options(conn_id, emitter, agent_type, &initial_config_options);
     emit_selectors_ready(conn_id, emitter);
@@ -1764,6 +1909,7 @@ async fn handle_fork_or_exit(
     let loop_result = run_conversation_loop(
         &mut session,
         conn_id,
+        connections,
         emitter,
         agent_type,
         perms,
@@ -1780,6 +1926,7 @@ async fn handle_fork_or_exit(
     Box::pin(handle_fork_or_exit(
         loop_result,
         conn_id,
+        connections,
         emitter,
         agent_type,
         perms,
@@ -1799,6 +1946,7 @@ async fn handle_fork_or_exit(
 async fn run_conversation_loop<'a>(
     session: &mut sacp::ActiveSession<'a, Agent>,
     conn_id: &str,
+    connections: &Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
     emitter: &EventEmitter,
     agent_type: AgentType,
     perms: &PendingPermissions,
@@ -1836,7 +1984,11 @@ async fn run_conversation_loop<'a>(
                         }
                         Ok(_) => {}
                         Err(e) => {
-                            eprintln!("[ACP] Ignoring unrecognized session update in idle loop: {e}");
+                            emit_stream_warning(
+                                conn_id,
+                                emitter,
+                                format!("idle stream parse error: {e}"),
+                            );
                         }
                     }
                 }
@@ -1846,27 +1998,20 @@ async fn run_conversation_loop<'a>(
             Some(ConnectionCommand::Prompt { blocks }) => {
                 let prompt_blocks = map_prompt_blocks(blocks);
                 if prompt_blocks.is_empty() {
-                    crate::web::event_bridge::emit_event(
+                    emit_connection_error(
+                        connections,
                         emitter,
-                        "acp://event",
-                        AcpEvent::Error {
-                            connection_id: conn_id.into(),
-                            message: "Prompt must contain at least one content block".into(),
-                            agent_type: agent_type.to_string(),
-                            code: None,
-                        },
-                    );
+                        conn_id,
+                        agent_type,
+                        "Prompt must contain at least one content block".into(),
+                        None,
+                    )
+                    .await;
                     continue;
                 }
 
-                crate::web::event_bridge::emit_event(
-                    emitter,
-                    "acp://event",
-                    AcpEvent::StatusChanged {
-                        connection_id: conn_id.into(),
-                        status: ConnectionStatus::Prompting,
-                    },
-                );
+                emit_status_changed(connections, emitter, conn_id, ConnectionStatus::Prompting)
+                    .await;
 
                 // Clone connection and session ID before entering the
                 // select loop so we can send CancelNotification without
@@ -1890,16 +2035,45 @@ async fn run_conversation_loop<'a>(
                     .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 let mut disconnect_requested = false;
 
+                // Idle watchdog: if nothing is heard from the agent for
+                // TURN_IDLE_TIMEOUT_MS, abort the turn so the UI is not
+                // stuck in "prompting" forever. Reset by every observable
+                // signal (stream notification, parse warning, terminal
+                // poll tick, command, prompt response).
+                let idle_deadline = tokio::time::sleep(std::time::Duration::from_millis(
+                    TURN_IDLE_TIMEOUT_MS,
+                ));
+                tokio::pin!(idle_deadline);
+                // Helper macro: every active branch resets the deadline.
+                // Using a macro instead of a closure avoids re-borrowing
+                // the pinned future across an await point.
+                macro_rules! reset_idle {
+                    () => {
+                        idle_deadline.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + std::time::Duration::from_millis(TURN_IDLE_TIMEOUT_MS),
+                        );
+                    };
+                }
+
                 // Read updates until turn completes.
                 // We must also listen for commands (e.g. RespondPermission)
                 // to avoid deadlocking when the agent awaits a permission response.
                 loop {
                     tokio::select! {
                         update = session.read_update() => {
+                            // Any signal — even a parse error — proves the
+                            // agent process is still alive and producing
+                            // output, so reset the idle watchdog.
+                            reset_idle!();
                             let update = match update {
                                 Ok(u) => u,
                                 Err(e) => {
-                                    eprintln!("[ACP] Ignoring unrecognized session update: {e}");
+                                    emit_stream_warning(
+                                        conn_id,
+                                        emitter,
+                                        format!("unrecognized session update: {e}"),
+                                    );
                                     continue;
                                 }
                             };
@@ -1939,7 +2113,11 @@ async fn run_conversation_loop<'a>(
                                         })
                                         .await
                                     {
-                                        eprintln!("[ACP] Ignoring dispatch parse error: {e}");
+                                        emit_stream_warning(
+                                            conn_id,
+                                            emitter,
+                                            format!("dispatch parse error: {e}"),
+                                        );
                                     }
                                 }
                                 SessionMessage::StopReason(reason) => {
@@ -2003,6 +2181,9 @@ async fn run_conversation_loop<'a>(
                             break;
                         }
                         _ = terminal_poll_interval.tick(), if !tracked_terminal_tool_calls.is_empty() => {
+                            // Active tool polling counts as "we're still
+                            // doing work" — keep the watchdog at bay.
+                            reset_idle!();
                             poll_tracked_terminal_tool_calls(
                                 terminal_runtime.as_ref(),
                                 &sid,
@@ -2012,7 +2193,66 @@ async fn run_conversation_loop<'a>(
                             )
                             .await;
                         }
+                        _ = &mut idle_deadline => {
+                            // No event from the agent for the whole
+                            // TURN_IDLE_TIMEOUT_MS window. The turn is
+                            // wedged (often because an SDK message we
+                            // don't understand killed the stream silently
+                            // or because the child process hung after
+                            // auto-compaction). Cancel and surface a
+                            // synthetic TurnIdleTimeout + TurnComplete so
+                            // the UI exits "prompting" cleanly.
+                            eprintln!(
+                                "[ACP] turn idle timeout after {}ms; cancelling. connection_id={conn_id}",
+                                TURN_IDLE_TIMEOUT_MS
+                            );
+                            let _ = cx.send_notification_to(
+                                Agent,
+                                CancelNotification::new(sid.clone()),
+                            );
+                            terminal_runtime
+                                .release_all_for_session(sid.0.as_ref())
+                                .await;
+                            tracked_terminal_tool_calls.clear();
+                            let mut locked = perms.lock().await;
+                            for (_, responder) in locked.drain() {
+                                let _ = responder.respond(RequestPermissionResponse::new(
+                                    RequestPermissionOutcome::Cancelled,
+                                ));
+                            }
+                            drop(locked);
+                            crate::web::event_bridge::emit_event(
+                                emitter,
+                                "acp://event",
+                                AcpEvent::TurnIdleTimeout {
+                                    connection_id: conn_id.into(),
+                                    session_id: sid.0.to_string(),
+                                    agent_type: agent_type.to_string(),
+                                    idle_ms: TURN_IDLE_TIMEOUT_MS,
+                                },
+                            );
+                            crate::web::event_bridge::emit_event(
+                                emitter,
+                                "acp://event",
+                                AcpEvent::TurnComplete {
+                                    connection_id: conn_id.into(),
+                                    session_id: sid.0.to_string(),
+                                    stop_reason: "idle_timeout".into(),
+                                    agent_type: agent_type.to_string(),
+                                },
+                            );
+                            // Drain prompt_response in the background;
+                            // the agent may still respond eventually.
+                            tokio::spawn(async move {
+                                let _ = prompt_response.await;
+                            });
+                            break;
+                        }
                         cmd = cmd_rx.recv() => {
+                            // User-initiated commands (cancel, permission
+                            // response, etc.) are also activity and reset
+                            // the watchdog.
+                            reset_idle!();
                             match cmd {
                                 Some(ConnectionCommand::RespondPermission {
                                     request_id,
@@ -2039,16 +2279,15 @@ async fn run_conversation_loop<'a>(
                                             );
                                         }
                                         Err(e) => {
-                                            crate::web::event_bridge::emit_event(
+                                            emit_connection_error(
+                                                connections,
                                                 emitter,
-                                                "acp://event",
-                                                AcpEvent::Error {
-                                                    connection_id: conn_id.into(),
-                                                    message: format!("Failed to set mode: {e}"),
-                                                    agent_type: agent_type.to_string(),
-                                                    code: None,
-                                                },
-                                            );
+                                                conn_id,
+                                                agent_type,
+                                                format!("Failed to set mode: {e}"),
+                                                None,
+                                            )
+                                            .await;
                                         }
                                     }
                                 }
@@ -2067,16 +2306,15 @@ async fn run_conversation_loop<'a>(
                                     )
                                     .await
                                     {
-                                        crate::web::event_bridge::emit_event(
+                                        emit_connection_error(
+                                            connections,
                                             emitter,
-                                            "acp://event",
-                                            AcpEvent::Error {
-                                                connection_id: conn_id.into(),
-                                                message: format!("Failed to set config option: {e}"),
-                                                agent_type: agent_type.to_string(),
-                                                code: None,
-                                            },
-                                        );
+                                            conn_id,
+                                            agent_type,
+                                            format!("Failed to set config option: {e}"),
+                                            None,
+                                        )
+                                        .await;
                                     }
                                 }
                                 Some(ConnectionCommand::Cancel) => {
@@ -2155,14 +2393,8 @@ async fn run_conversation_loop<'a>(
                     break;
                 }
 
-                crate::web::event_bridge::emit_event(
-                    emitter,
-                    "acp://event",
-                    AcpEvent::StatusChanged {
-                        connection_id: conn_id.into(),
-                        status: ConnectionStatus::Connected,
-                    },
-                );
+                emit_status_changed(connections, emitter, conn_id, ConnectionStatus::Connected)
+                    .await;
             }
             Some(ConnectionCommand::RespondPermission {
                 request_id,
@@ -2177,16 +2409,15 @@ async fn run_conversation_loop<'a>(
             }
             Some(ConnectionCommand::SetMode { mode_id }) => {
                 if let Err(e) = set_session_mode(session, conn_id, emitter, mode_id).await {
-                    crate::web::event_bridge::emit_event(
+                    emit_connection_error(
+                        connections,
                         emitter,
-                        "acp://event",
-                        AcpEvent::Error {
-                            connection_id: conn_id.into(),
-                            message: format!("Failed to set mode: {e}"),
-                            agent_type: agent_type.to_string(),
-                            code: None,
-                        },
-                    );
+                        conn_id,
+                        agent_type,
+                        format!("Failed to set mode: {e}"),
+                        None,
+                    )
+                    .await;
                 }
             }
             Some(ConnectionCommand::SetConfigOption {
@@ -2200,16 +2431,15 @@ async fn run_conversation_loop<'a>(
                 )
                 .await
                 {
-                    crate::web::event_bridge::emit_event(
+                    emit_connection_error(
+                        connections,
                         emitter,
-                        "acp://event",
-                        AcpEvent::Error {
-                            connection_id: conn_id.into(),
-                            message: format!("Failed to set config option: {e}"),
-                            agent_type: agent_type.to_string(),
-                            code: None,
-                        },
-                    );
+                        conn_id,
+                        agent_type,
+                        format!("Failed to set config option: {e}"),
+                        None,
+                    )
+                    .await;
                 }
             }
             Some(ConnectionCommand::Cancel) => {
@@ -2426,6 +2656,42 @@ fn is_claude_api_retry_message(message: &serde_json::Value) -> bool {
     matches!(message_type, Some("system")) && matches!(message_subtype, Some("api_retry"))
 }
 
+/// Classify a `_claude/sdkMessage` payload's compaction state.
+///
+/// The Claude Agent SDK announces auto-compaction with one of several
+/// markers depending on version: a `system/compact_boundary` notification,
+/// a `system/compact` system message, or an inline `subtype: "compact"` /
+/// `prompt_too_long` recovery message. We treat any `compact_boundary`
+/// / `compact_started` / `prompt_too_long` as the start of compaction
+/// and `compact_finished` / `compacted` as the end. When the SDK only
+/// emits a single boundary marker we still surface it as
+/// `CompactionStarted` so the UI can display "compacting…" and reset
+/// its watchdog; the next non-system event will naturally end the hint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompactionSignal {
+    Started,
+    Finished,
+}
+
+fn classify_compaction_signal(message: &serde_json::Value) -> Option<CompactionSignal> {
+    let obj = message.as_object()?;
+    let message_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let subtype = obj.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
+
+    // Common SDK markers, normalized.
+    match (message_type, subtype) {
+        ("system", "compact_boundary")
+        | ("system", "compact")
+        | ("system", "compact_started")
+        | ("system", "compacting")
+        | ("system", "prompt_too_long") => Some(CompactionSignal::Started),
+        ("system", "compact_finished")
+        | ("system", "compacted")
+        | ("system", "compact_complete") => Some(CompactionSignal::Finished),
+        _ => None,
+    }
+}
+
 fn map_claude_sdk_ext_notification(
     connection_id: &str,
     notification: &UntypedMessage,
@@ -2435,6 +2701,22 @@ fn map_claude_sdk_ext_notification(
     }
 
     let (session_id, message) = parse_claude_sdk_message_params(notification.params())?;
+
+    // Compaction takes priority: the UI needs to know the agent is
+    // alive but busy summarizing.
+    if let Some(signal) = classify_compaction_signal(&message) {
+        return Some(match signal {
+            CompactionSignal::Started => AcpEvent::CompactionStarted {
+                connection_id: connection_id.to_string(),
+                session_id,
+            },
+            CompactionSignal::Finished => AcpEvent::CompactionFinished {
+                connection_id: connection_id.to_string(),
+                session_id,
+            },
+        });
+    }
+
     if !is_claude_api_retry_message(&message) {
         return None;
     }

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -863,6 +863,7 @@ fn build_load_session_request(
 }
 
 /// The main ACP connection loop.
+#[allow(clippy::too_many_arguments)]
 async fn run_connection(
     agent: AcpAgent,
     connection_id: String,
@@ -1220,13 +1221,8 @@ async fn run_connection(
                         let fallback_sid = new_resp.session_id.0.to_string();
                         let initial_config_options = new_resp.config_options.clone();
                         let mut session = cx.attach_session(new_resp, Default::default())?;
-                        emit_session_started(
-                            &connections,
-                            &emitter_clone,
-                            &conn_id,
-                            &fallback_sid,
-                        )
-                        .await;
+                        emit_session_started(&connections, &emitter_clone, &conn_id, &fallback_sid)
+                            .await;
                         emit_session_modes(&conn_id, &emitter_clone, session.modes());
                         emit_session_config_options(
                             &conn_id,
@@ -2040,9 +2036,8 @@ async fn run_conversation_loop<'a>(
                 // stuck in "prompting" forever. Reset by every observable
                 // signal (stream notification, parse warning, terminal
                 // poll tick, command, prompt response).
-                let idle_deadline = tokio::time::sleep(std::time::Duration::from_millis(
-                    TURN_IDLE_TIMEOUT_MS,
-                ));
+                let idle_deadline =
+                    tokio::time::sleep(std::time::Duration::from_millis(TURN_IDLE_TIMEOUT_MS));
                 tokio::pin!(idle_deadline);
                 // Helper macro: every active branch resets the deadline.
                 // Using a macro instead of a closure avoids re-borrowing

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -493,6 +493,7 @@ pub async fn spawn_agent_connection(
     let run_connections = connections.clone();
     let cleanup_connection_id = connection_id.clone();
     let manager_clone = manager.clone_ref();
+    let task_tracker = manager.task_tracker().clone();
     let working_dir_for_metadata = working_dir.clone();
     let owner_window_label_for_log = owner_window_label.clone();
 
@@ -517,7 +518,7 @@ pub async fn spawn_agent_connection(
         },
     );
 
-    tokio::spawn(async move {
+    task_tracker.spawn(async move {
         // RAII guard: runs on normal exit AND on panic unwinding, so a
         // panic inside `run_connection` can't leak a stale map entry.
         let _cleanup = ConnectionCleanupGuard {
@@ -534,6 +535,7 @@ pub async fn spawn_agent_connection(
             cmd_rx,
             run_connections,
             emitter_clone.clone(),
+            manager_clone.task_tracker().clone(),
         )
         .await;
 
@@ -873,6 +875,7 @@ async fn run_connection(
     mut cmd_rx: mpsc::Receiver<ConnectionCommand>,
     connections: Arc<tokio::sync::Mutex<HashMap<String, AgentConnection>>>,
     emitter: EventEmitter,
+    task_tracker: tokio_util::task::TaskTracker,
 ) -> Result<(), AcpError> {
     let pending_perms: PendingPermissions = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let terminal_runtime = Arc::new(TerminalRuntime::new());
@@ -1167,6 +1170,7 @@ async fn run_connection(
                             terminal_runtime.clone(),
                             &cwd_string,
                             supports_fork,
+                            &task_tracker,
                         )
                         .await;
                         terminal_runtime.release_all_for_session(&sid).await;
@@ -1182,6 +1186,7 @@ async fn run_connection(
                             terminal_runtime.clone(),
                             &cwd,
                             &cwd_string,
+                            &task_tracker,
                         )
                         .await
                     }
@@ -1243,6 +1248,7 @@ async fn run_connection(
                             terminal_runtime.clone(),
                             &cwd_string,
                             supports_fork,
+                            &task_tracker,
                         )
                         .await;
                         terminal_runtime
@@ -1260,6 +1266,7 @@ async fn run_connection(
                             terminal_runtime.clone(),
                             &cwd,
                             &cwd_string,
+                            &task_tracker,
                         )
                         .await
                     }
@@ -1294,6 +1301,7 @@ async fn run_connection(
                     terminal_runtime.clone(),
                     &cwd_string,
                     supports_fork,
+                    &task_tracker,
                 )
                 .await;
                 terminal_runtime.release_all_for_session(&sid).await;
@@ -1309,6 +1317,7 @@ async fn run_connection(
                     terminal_runtime.clone(),
                     &cwd,
                     &cwd_string,
+                    &task_tracker,
                 )
                 .await
             }
@@ -1866,6 +1875,7 @@ async fn handle_fork_or_exit(
     terminal_runtime: Arc<TerminalRuntime>,
     _cwd: &std::path::Path,
     cwd_string: &str,
+    task_tracker: &tokio_util::task::TaskTracker,
 ) -> Result<(), sacp::Error> {
     let fork_info = match loop_result {
         Ok(Some(info)) => info,
@@ -1913,6 +1923,7 @@ async fn handle_fork_or_exit(
         terminal_runtime.clone(),
         cwd_string,
         true, // fork already succeeded on this process
+        task_tracker,
     )
     .await;
     terminal_runtime.release_all_for_session(&new_sid).await;
@@ -1930,6 +1941,7 @@ async fn handle_fork_or_exit(
         terminal_runtime,
         _cwd,
         cwd_string,
+        task_tracker,
     ))
     .await
 }
@@ -1950,6 +1962,7 @@ async fn run_conversation_loop<'a>(
     terminal_runtime: Arc<TerminalRuntime>,
     cwd: &str,
     supports_fork: bool,
+    task_tracker: &tokio_util::task::TaskTracker,
 ) -> Result<Option<ForkExitInfo>, sacp::Error> {
     loop {
         // Wait for either a user command or a session update (e.g. available_commands_update)
@@ -2238,7 +2251,7 @@ async fn run_conversation_loop<'a>(
                             );
                             // Drain prompt_response in the background;
                             // the agent may still respond eventually.
-                            tokio::spawn(async move {
+                            task_tracker.spawn(async move {
                                 let _ = prompt_response.await;
                             });
                             break;
@@ -2349,7 +2362,7 @@ async fn run_conversation_loop<'a>(
                                     // Drain the prompt response in the background so
                                     // the SACP library doesn't log "receiver dropped"
                                     // errors when the agent eventually responds.
-                                    tokio::spawn(async move {
+                                    task_tracker.spawn(async move {
                                         let _ = prompt_response.await;
                                     });
                                     break;

--- a/src-tauri/src/acp/error.rs
+++ b/src-tauri/src/acp/error.rs
@@ -4,6 +4,10 @@ use serde::Serialize;
 pub enum AcpError {
     #[error("agent process failed to spawn: {0}")]
     SpawnFailed(String),
+    #[error("{0}")]
+    LimitExceeded(String),
+    #[error("{0}")]
+    CircuitOpen(String),
     #[error("connection not found: {0}")]
     ConnectionNotFound(String),
     #[error("ACP protocol error: {0}")]
@@ -48,6 +52,8 @@ impl AcpError {
             Self::InitializeTimeout => Some("initialize_timeout"),
             Self::ProcessExited => Some("process_exited"),
             Self::SpawnFailed(_) => Some("spawn_failed"),
+            Self::LimitExceeded(_) => Some("limit_exceeded"),
+            Self::CircuitOpen(_) => Some("circuit_open"),
             Self::DownloadFailed(_) => Some("download_failed"),
             Self::ConnectionNotFound(_) => Some("connection_not_found"),
             Self::Protocol(_) => None,

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -1,30 +1,208 @@
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::Serialize;
 use tokio::sync::Mutex;
 
 use crate::acp::connection::{spawn_agent_connection, AgentConnection, ConnectionCommand};
 use crate::acp::error::AcpError;
 use crate::acp::types::{ConnectionInfo, ForkResultInfo, PromptInputBlock};
 use crate::models::agent::AgentType;
+use crate::runtime_monitor::RuntimeMonitor;
+use crate::web::client_owner::WebClientRegistry;
 use crate::web::event_bridge::EventEmitter;
 
+const DEFAULT_MAX_CONNECTIONS: usize = 16;
+const DEFAULT_MAX_CONNECTIONS_PER_OWNER: usize = 6;
+const DEFAULT_MAX_CONNECTIONS_PER_AGENT: usize = 8;
+const DEFAULT_BREAKER_THRESHOLD: usize = 4;
+const DEFAULT_BREAKER_WINDOW_SECONDS: u64 = 180;
+const DEFAULT_BREAKER_COOLDOWN_SECONDS: u64 = 120;
+const DEFAULT_ORPHAN_GRACE_SECONDS: u64 = 60;
+const DEFAULT_CONNECTING_TIMEOUT_SECONDS: u64 = 180;
+const WATCHDOG_INTERVAL_SECONDS: u64 = 30;
+
+#[derive(Debug, Clone)]
+struct ConnectionLimits {
+    max_connections: usize,
+    max_connections_per_owner: usize,
+    max_connections_per_agent: usize,
+    breaker_threshold: usize,
+    breaker_window: Duration,
+    breaker_cooldown: Duration,
+    orphan_grace: Duration,
+    connecting_timeout: Duration,
+}
+
+impl ConnectionLimits {
+    fn from_env() -> Self {
+        Self {
+            max_connections: parse_env_usize(
+                "CODEG_ACP_MAX_CONNECTIONS",
+                DEFAULT_MAX_CONNECTIONS,
+            ),
+            max_connections_per_owner: parse_env_usize(
+                "CODEG_ACP_MAX_CONNECTIONS_PER_OWNER",
+                DEFAULT_MAX_CONNECTIONS_PER_OWNER,
+            ),
+            max_connections_per_agent: parse_env_usize(
+                "CODEG_ACP_MAX_CONNECTIONS_PER_AGENT",
+                DEFAULT_MAX_CONNECTIONS_PER_AGENT,
+            ),
+            breaker_threshold: parse_env_usize(
+                "CODEG_ACP_BREAKER_THRESHOLD",
+                DEFAULT_BREAKER_THRESHOLD,
+            ),
+            breaker_window: Duration::from_secs(parse_env_u64(
+                "CODEG_ACP_BREAKER_WINDOW_SECONDS",
+                DEFAULT_BREAKER_WINDOW_SECONDS,
+            )),
+            breaker_cooldown: Duration::from_secs(parse_env_u64(
+                "CODEG_ACP_BREAKER_COOLDOWN_SECONDS",
+                DEFAULT_BREAKER_COOLDOWN_SECONDS,
+            )),
+            orphan_grace: Duration::from_secs(parse_env_u64(
+                "CODEG_ACP_ORPHAN_GRACE_SECONDS",
+                DEFAULT_ORPHAN_GRACE_SECONDS,
+            )),
+            connecting_timeout: Duration::from_secs(parse_env_u64(
+                "CODEG_ACP_CONNECTING_TIMEOUT_SECONDS",
+                DEFAULT_CONNECTING_TIMEOUT_SECONDS,
+            )),
+        }
+    }
+}
+
+struct CircuitBreakerState {
+    failure_timestamps: VecDeque<Instant>,
+    open_until: Option<Instant>,
+}
+
+impl Default for CircuitBreakerState {
+    fn default() -> Self {
+        Self {
+            failure_timestamps: VecDeque::new(),
+            open_until: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectionLimitSnapshot {
+    pub current_total: usize,
+    pub global_limit: usize,
+    pub per_owner_limit: usize,
+    pub per_agent_limit: usize,
+    pub by_agent: BTreeMap<String, usize>,
+    pub recent_failures: usize,
+    pub breaker_threshold: usize,
+    pub breaker_window_seconds: u64,
+    pub breaker_cooldown_seconds: u64,
+    pub breaker_open: bool,
+    pub breaker_open_until: Option<String>,
+    pub orphan_grace_seconds: u64,
+    pub connecting_timeout_seconds: u64,
+}
+
+#[derive(Clone)]
 pub struct ConnectionManager {
     connections: Arc<Mutex<HashMap<String, AgentConnection>>>,
+    breaker: Arc<Mutex<CircuitBreakerState>>,
+    limits: ConnectionLimits,
+    runtime_monitor: Arc<StdMutex<Option<Arc<RuntimeMonitor>>>>,
+    watchdog_started: Arc<AtomicBool>,
 }
 
 impl ConnectionManager {
     pub fn new() -> Self {
         Self {
             connections: Arc::new(Mutex::new(HashMap::new())),
+            breaker: Arc::new(Mutex::new(CircuitBreakerState::default())),
+            limits: ConnectionLimits::from_env(),
+            runtime_monitor: Arc::new(StdMutex::new(None)),
+            watchdog_started: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Returns a shallow clone sharing the same underlying connection map.
+    /// Returns a shallow clone sharing the same underlying connection state.
     pub fn clone_ref(&self) -> Self {
-        Self {
-            connections: self.connections.clone(),
+        self.clone()
+    }
+
+    pub fn attach_runtime_monitor(&self, monitor: Arc<RuntimeMonitor>) {
+        *self.runtime_monitor.lock().unwrap() = Some(monitor);
+    }
+
+    pub fn start_orphan_watchdog(&self, web_client_registry: Arc<WebClientRegistry>) {
+        if self
+            .watchdog_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
         }
+
+        let manager = self.clone_ref();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(Duration::from_secs(WATCHDOG_INTERVAL_SECONDS));
+            loop {
+                interval.tick().await;
+                manager.run_watchdog_pass(&web_client_registry).await;
+            }
+        });
+    }
+
+    pub(crate) fn connections_arc(&self) -> Arc<Mutex<HashMap<String, AgentConnection>>> {
+        self.connections.clone()
+    }
+
+    pub(crate) fn runtime_monitor(&self) -> Option<Arc<RuntimeMonitor>> {
+        self.runtime_monitor.lock().unwrap().clone()
+    }
+
+    pub(crate) fn log_runtime(
+        &self,
+        level: &str,
+        scope: &str,
+        message: impl Into<String>,
+        data: Option<serde_json::Value>,
+    ) {
+        if let Some(monitor) = self.runtime_monitor() {
+            monitor.record(level, scope, message, data);
+        }
+    }
+
+    pub(crate) async fn record_failure(
+        &self,
+        agent_type: AgentType,
+        message: &str,
+        connection_id: Option<&str>,
+    ) {
+        let now = Instant::now();
+        let recent_failures = {
+            let mut breaker = self.breaker.lock().await;
+            trim_failure_window(&mut breaker.failure_timestamps, self.limits.breaker_window, now);
+            breaker.failure_timestamps.push_back(now);
+            if breaker.failure_timestamps.len() >= self.limits.breaker_threshold {
+                breaker.open_until = Some(now + self.limits.breaker_cooldown);
+            }
+            breaker.failure_timestamps.len()
+        };
+
+        self.log_runtime(
+            "error",
+            "acp",
+            format!("[{agent_type}] {message}"),
+            Some(serde_json::json!({
+                "agent_type": serde_json::to_value(agent_type).ok(),
+                "connection_id": connection_id,
+                "recent_failures": recent_failures,
+            })),
+        );
     }
 
     pub async fn spawn_agent(
@@ -36,17 +214,21 @@ impl ConnectionManager {
         owner_window_label: String,
         emitter: EventEmitter,
     ) -> Result<String, AcpError> {
+        self.enforce_spawn_guards(agent_type, &owner_window_label).await?;
+
         let connection_id = uuid::Uuid::new_v4().to_string();
-        eprintln!(
-            "[ACP] spawning connection id={} owner_window={} agent={:?}",
-            connection_id, owner_window_label, agent_type
+        self.log_runtime(
+            "info",
+            "acp",
+            format!(
+                "spawning connection {} for {} ({owner_window_label})",
+                connection_id, agent_type
+            ),
+            None,
         );
 
-        // `spawn_agent_connection` inserts the entry into `self.connections`
-        // itself and registers a cleanup hook that removes it once the
-        // background `run_connection` task exits. This keeps the manager
-        // from leaking entries after timeouts / errors.
-        spawn_agent_connection(
+        if let Err(error) = spawn_agent_connection(
+            self.clone_ref(),
             connection_id.clone(),
             agent_type,
             working_dir,
@@ -54,9 +236,13 @@ impl ConnectionManager {
             runtime_env,
             owner_window_label,
             emitter,
-            self.connections.clone(),
         )
-        .await?;
+        .await
+        {
+            self.record_failure(agent_type, &error.to_string(), Some(&connection_id))
+                .await;
+            return Err(error);
+        }
 
         Ok(connection_id)
     }
@@ -209,9 +395,13 @@ impl ConnectionManager {
         for cmd_tx in cmd_txs {
             let _ = cmd_tx.send(ConnectionCommand::Disconnect).await;
         }
-        eprintln!(
-            "[ACP] disconnect by owner window owner_window={} count={}",
-            owner_window_label, disconnected
+        self.log_runtime(
+            "info",
+            "acp",
+            format!(
+                "disconnected {disconnected} connection(s) for owner {owner_window_label}"
+            ),
+            None,
         );
         disconnected
     }
@@ -225,12 +415,233 @@ impl ConnectionManager {
         for cmd_tx in cmd_txs {
             let _ = cmd_tx.send(ConnectionCommand::Disconnect).await;
         }
-        eprintln!("[ACP] disconnect_all count={}", disconnected);
+        self.log_runtime(
+            "info",
+            "acp",
+            format!("disconnected all ACP connections ({disconnected})"),
+            None,
+        );
         disconnected
     }
 
     pub async fn list_connections(&self) -> Vec<ConnectionInfo> {
-        let connections = self.connections.lock().await;
-        connections.values().map(|c| c.info()).collect()
+        let entries = {
+            let connections = self.connections.lock().await;
+            connections.values().cloned().collect::<Vec<_>>()
+        };
+
+        let mut result = Vec::with_capacity(entries.len());
+        for connection in entries {
+            result.push(connection.info().await);
+        }
+        result.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+        result
+    }
+
+    pub async fn limits_snapshot(&self) -> ConnectionLimitSnapshot {
+        let by_agent = {
+            let connections = self.connections.lock().await;
+            let mut counts = BTreeMap::<String, usize>::new();
+            for connection in connections.values() {
+                let key = serde_json::to_value(connection.agent_type)
+                    .ok()
+                    .and_then(|value| value.as_str().map(str::to_string))
+                    .unwrap_or_else(|| connection.agent_type.to_string());
+                *counts.entry(key).or_default() += 1;
+            }
+            (connections.len(), counts)
+        };
+
+        let (recent_failures, breaker_open, breaker_open_until) = {
+            let now = Instant::now();
+            let mut breaker = self.breaker.lock().await;
+            trim_failure_window(&mut breaker.failure_timestamps, self.limits.breaker_window, now);
+            let breaker_open = breaker.open_until.is_some_and(|until| until > now);
+            let breaker_open_until = breaker
+                .open_until
+                .filter(|until| *until > now)
+                .map(|until| {
+                    let seconds = until.saturating_duration_since(now).as_secs();
+                    (Utc::now() + chrono::Duration::seconds(seconds as i64)).to_rfc3339()
+                });
+            (breaker.failure_timestamps.len(), breaker_open, breaker_open_until)
+        };
+
+        ConnectionLimitSnapshot {
+            current_total: by_agent.0,
+            global_limit: self.limits.max_connections,
+            per_owner_limit: self.limits.max_connections_per_owner,
+            per_agent_limit: self.limits.max_connections_per_agent,
+            by_agent: by_agent.1,
+            recent_failures,
+            breaker_threshold: self.limits.breaker_threshold,
+            breaker_window_seconds: self.limits.breaker_window.as_secs(),
+            breaker_cooldown_seconds: self.limits.breaker_cooldown.as_secs(),
+            breaker_open,
+            breaker_open_until,
+            orphan_grace_seconds: self.limits.orphan_grace.as_secs(),
+            connecting_timeout_seconds: self.limits.connecting_timeout.as_secs(),
+        }
+    }
+
+    async fn enforce_spawn_guards(
+        &self,
+        agent_type: AgentType,
+        owner_window_label: &str,
+    ) -> Result<(), AcpError> {
+        let now = Instant::now();
+        {
+            let mut breaker = self.breaker.lock().await;
+            trim_failure_window(&mut breaker.failure_timestamps, self.limits.breaker_window, now);
+            if let Some(until) = breaker.open_until {
+                if until > now {
+                    let wait_seconds = until.saturating_duration_since(now).as_secs();
+                    let message = format!(
+                        "ACP circuit breaker is open after repeated failures. Retry in about {} seconds.",
+                        wait_seconds.max(1)
+                    );
+                    self.log_runtime("warn", "acp", &message, None);
+                    return Err(AcpError::CircuitOpen(message));
+                }
+                breaker.open_until = None;
+            }
+        }
+
+        let (current_total, owner_total, agent_total) = {
+            let connections = self.connections.lock().await;
+            let current_total = connections.len();
+            let owner_total = connections
+                .values()
+                .filter(|connection| connection.owner_window_label == owner_window_label)
+                .count();
+            let agent_total = connections
+                .values()
+                .filter(|connection| connection.agent_type == agent_type)
+                .count();
+            (current_total, owner_total, agent_total)
+        };
+
+        if current_total >= self.limits.max_connections {
+            let message = format!(
+                "ACP connection limit reached ({current_total}/{})",
+                self.limits.max_connections
+            );
+            self.log_runtime("warn", "acp", &message, None);
+            return Err(AcpError::LimitExceeded(message));
+        }
+
+        if owner_total >= self.limits.max_connections_per_owner {
+            let message = format!(
+                "ACP owner connection limit reached for {} ({owner_total}/{})",
+                owner_window_label, self.limits.max_connections_per_owner
+            );
+            self.log_runtime("warn", "acp", &message, None);
+            return Err(AcpError::LimitExceeded(message));
+        }
+
+        if agent_total >= self.limits.max_connections_per_agent {
+            let message = format!(
+                "ACP agent connection limit reached for {} ({agent_total}/{})",
+                agent_type, self.limits.max_connections_per_agent
+            );
+            self.log_runtime("warn", "acp", &message, None);
+            return Err(AcpError::LimitExceeded(message));
+        }
+
+        Ok(())
+    }
+
+    async fn run_watchdog_pass(&self, web_client_registry: &WebClientRegistry) {
+        let snapshots = {
+            let connections = self.connections.lock().await;
+            connections
+                .iter()
+                .map(|(id, connection)| {
+                    (
+                        id.clone(),
+                        connection.owner_window_label.clone(),
+                        connection.metadata.clone(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut stale_ids = BTreeSet::new();
+        for (connection_id, owner_window_label, metadata) in snapshots {
+            let metadata = metadata.read().await.clone();
+
+            if let Some(client_id) = owner_window_label.strip_prefix("web:") {
+                let has_active_client = web_client_registry.has_active_client(client_id).await;
+                let age = Utc::now()
+                    .signed_duration_since(metadata.created_at)
+                    .num_seconds()
+                    .max(0) as u64;
+                if !has_active_client && age >= self.limits.orphan_grace.as_secs() {
+                    stale_ids.insert(connection_id.clone());
+                    self.log_runtime(
+                        "warn",
+                        "acp",
+                        format!(
+                            "orphan watchdog disconnecting {} owned by {}",
+                            connection_id, owner_window_label
+                        ),
+                        None,
+                    );
+                    continue;
+                }
+            }
+
+            if metadata.status == crate::acp::types::ConnectionStatus::Connecting {
+                let idle_for = Utc::now()
+                    .signed_duration_since(metadata.updated_at)
+                    .num_seconds()
+                    .max(0) as u64;
+                if idle_for >= self.limits.connecting_timeout.as_secs() {
+                    stale_ids.insert(connection_id.clone());
+                    self.log_runtime(
+                        "warn",
+                        "acp",
+                        format!(
+                            "watchdog disconnecting {} after {}s stuck in connecting",
+                            connection_id, idle_for
+                        ),
+                        None,
+                    );
+                }
+            }
+        }
+
+        for connection_id in stale_ids {
+            let _ = self.disconnect(&connection_id).await;
+        }
+    }
+}
+
+fn parse_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn parse_env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn trim_failure_window(
+    failures: &mut VecDeque<Instant>,
+    window: Duration,
+    now: Instant,
+) {
+    while failures
+        .front()
+        .is_some_and(|instant| now.saturating_duration_since(*instant) > window)
+    {
+        failures.pop_front();
     }
 }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -40,10 +40,7 @@ struct ConnectionLimits {
 impl ConnectionLimits {
     fn from_env() -> Self {
         Self {
-            max_connections: parse_env_usize(
-                "CODEG_ACP_MAX_CONNECTIONS",
-                DEFAULT_MAX_CONNECTIONS,
-            ),
+            max_connections: parse_env_usize("CODEG_ACP_MAX_CONNECTIONS", DEFAULT_MAX_CONNECTIONS),
             max_connections_per_owner: parse_env_usize(
                 "CODEG_ACP_MAX_CONNECTIONS_PER_OWNER",
                 DEFAULT_MAX_CONNECTIONS_PER_OWNER,
@@ -76,18 +73,10 @@ impl ConnectionLimits {
     }
 }
 
+#[derive(Default)]
 struct CircuitBreakerState {
     failure_timestamps: VecDeque<Instant>,
     open_until: Option<Instant>,
-}
-
-impl Default for CircuitBreakerState {
-    fn default() -> Self {
-        Self {
-            failure_timestamps: VecDeque::new(),
-            open_until: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -185,7 +174,11 @@ impl ConnectionManager {
         let now = Instant::now();
         let recent_failures = {
             let mut breaker = self.breaker.lock().await;
-            trim_failure_window(&mut breaker.failure_timestamps, self.limits.breaker_window, now);
+            trim_failure_window(
+                &mut breaker.failure_timestamps,
+                self.limits.breaker_window,
+                now,
+            );
             breaker.failure_timestamps.push_back(now);
             if breaker.failure_timestamps.len() >= self.limits.breaker_threshold {
                 breaker.open_until = Some(now + self.limits.breaker_cooldown);
@@ -214,7 +207,8 @@ impl ConnectionManager {
         owner_window_label: String,
         emitter: EventEmitter,
     ) -> Result<String, AcpError> {
-        self.enforce_spawn_guards(agent_type, &owner_window_label).await?;
+        self.enforce_spawn_guards(agent_type, &owner_window_label)
+            .await?;
 
         let connection_id = uuid::Uuid::new_v4().to_string();
         self.log_runtime(
@@ -398,9 +392,7 @@ impl ConnectionManager {
         self.log_runtime(
             "info",
             "acp",
-            format!(
-                "disconnected {disconnected} connection(s) for owner {owner_window_label}"
-            ),
+            format!("disconnected {disconnected} connection(s) for owner {owner_window_label}"),
             None,
         );
         disconnected
@@ -455,7 +447,11 @@ impl ConnectionManager {
         let (recent_failures, breaker_open, breaker_open_until) = {
             let now = Instant::now();
             let mut breaker = self.breaker.lock().await;
-            trim_failure_window(&mut breaker.failure_timestamps, self.limits.breaker_window, now);
+            trim_failure_window(
+                &mut breaker.failure_timestamps,
+                self.limits.breaker_window,
+                now,
+            );
             let breaker_open = breaker.open_until.is_some_and(|until| until > now);
             let breaker_open_until = breaker
                 .open_until
@@ -464,7 +460,11 @@ impl ConnectionManager {
                     let seconds = until.saturating_duration_since(now).as_secs();
                     (Utc::now() + chrono::Duration::seconds(seconds as i64)).to_rfc3339()
                 });
-            (breaker.failure_timestamps.len(), breaker_open, breaker_open_until)
+            (
+                breaker.failure_timestamps.len(),
+                breaker_open,
+                breaker_open_until,
+            )
         };
 
         ConnectionLimitSnapshot {
@@ -492,7 +492,11 @@ impl ConnectionManager {
         let now = Instant::now();
         {
             let mut breaker = self.breaker.lock().await;
-            trim_failure_window(&mut breaker.failure_timestamps, self.limits.breaker_window, now);
+            trim_failure_window(
+                &mut breaker.failure_timestamps,
+                self.limits.breaker_window,
+                now,
+            );
             if let Some(until) = breaker.open_until {
                 if until > now {
                     let wait_seconds = until.saturating_duration_since(now).as_secs();
@@ -633,11 +637,7 @@ fn parse_env_u64(name: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
-fn trim_failure_window(
-    failures: &mut VecDeque<Instant>,
-    window: Duration,
-    now: Instant,
-) {
+fn trim_failure_window(failures: &mut VecDeque<Instant>, window: Duration, now: Instant) {
     while failures
         .front()
         .is_some_and(|instant| now.saturating_duration_since(*instant) > window)

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -103,6 +103,11 @@ pub struct ConnectionManager {
     limits: ConnectionLimits,
     runtime_monitor: Arc<StdMutex<Option<Arc<RuntimeMonitor>>>>,
     watchdog_started: Arc<AtomicBool>,
+    /// Tracks ACP background tasks (per-connection event loop, drain
+    /// helpers). Wired up so a graceful shutdown can `wait()` for ACP
+    /// agents to finish their current iteration instead of getting
+    /// detached on tokio runtime drop.
+    task_tracker: tokio_util::task::TaskTracker,
 }
 
 impl ConnectionManager {
@@ -113,7 +118,14 @@ impl ConnectionManager {
             limits: ConnectionLimits::from_env(),
             runtime_monitor: Arc::new(StdMutex::new(None)),
             watchdog_started: Arc::new(AtomicBool::new(false)),
+            task_tracker: tokio_util::task::TaskTracker::new(),
         }
+    }
+
+    /// Background-task tracker used for ACP-spawned tasks. Exposed so
+    /// graceful shutdown can `wait()` on it.
+    pub fn task_tracker(&self) -> &tokio_util::task::TaskTracker {
+        &self.task_tracker
     }
 
     /// Returns a shallow clone sharing the same underlying connection state.

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -428,6 +428,19 @@ impl ConnectionManager {
         disconnected
     }
 
+    /// Look up the live metadata for a single connection. Returns
+    /// `None` if the connection has been disconnected and removed.
+    pub async fn connection_info(&self, conn_id: &str) -> Option<ConnectionInfo> {
+        let connection = {
+            let connections = self.connections.lock().await;
+            connections.get(conn_id).cloned()
+        };
+        match connection {
+            Some(connection) => Some(connection.info().await),
+            None => None,
+        }
+    }
+
     pub async fn list_connections(&self) -> Vec<ConnectionInfo> {
         let entries = {
             let connections = self.connections.lock().await;

--- a/src-tauri/src/acp/registry.rs
+++ b/src-tauri/src/acp/registry.rs
@@ -5,7 +5,7 @@ pub enum AgentDistribution {
     Npx {
         version: &'static str,
         package: &'static str,
-        /// The command name provided by this npx package (e.g. "gemini", "openclaw").
+        /// The command name provided by this npx package (e.g. "gemini", "generic-agent").
         cmd: &'static str,
         args: &'static [&'static str],
         env: &'static [(&'static str, &'static str)],
@@ -77,7 +77,7 @@ pub fn all_acp_agents() -> Vec<AgentType> {
         AgentType::ClaudeCode,
         AgentType::Codex,
         AgentType::Gemini,
-        AgentType::OpenClaw,
+        AgentType::Generic,
         AgentType::OpenCode,
         AgentType::Cline,
     ]
@@ -88,7 +88,7 @@ pub fn registry_id_for(agent_type: AgentType) -> &'static str {
         AgentType::ClaudeCode => "claude-acp",
         AgentType::Codex => "codex-acp",
         AgentType::Gemini => "gemini",
-        AgentType::OpenClaw => "openclaw-acp",
+        AgentType::Generic => "generic-acp",
         AgentType::OpenCode => "opencode",
         AgentType::Cline => "cline",
     }
@@ -99,7 +99,7 @@ pub fn from_registry_id(id: &str) -> Option<AgentType> {
         "claude-acp" => Some(AgentType::ClaudeCode),
         "codex-acp" => Some(AgentType::Codex),
         "gemini" => Some(AgentType::Gemini),
-        "openclaw-acp" => Some(AgentType::OpenClaw),
+        "generic-acp" => Some(AgentType::Generic),
         "opencode" => Some(AgentType::OpenCode),
         "cline" => Some(AgentType::Cline),
         _ => None,
@@ -117,8 +117,8 @@ pub fn get_agent_meta(agent_type: AgentType) -> AcpAgentMeta {
             name: "Claude Code",
             description: "ACP wrapper for Anthropic's Claude",
             distribution: AgentDistribution::Npx {
-                version: "0.30.0",
-                package: "@agentclientprotocol/claude-agent-acp@0.30.0",
+                version: "0.31.0",
+                package: "@agentclientprotocol/claude-agent-acp@0.31.0",
                 cmd: "claude-agent-acp",
                 args: &[],
                 env: &[],
@@ -175,14 +175,14 @@ pub fn get_agent_meta(agent_type: AgentType) -> AcpAgentMeta {
                 node_required: None,
             },
         },
-        AgentType::OpenClaw => AcpAgentMeta {
+        AgentType::Generic => AcpAgentMeta {
             agent_type,
-            name: "OpenClaw",
-            description: "OpenClaw is a personal AI assistant you run on your own devices.",
+            name: "Generic",
+            description: "A generic AI coding agent.",
             distribution: AgentDistribution::Npx {
                 version: "2026.4.15",
-                package: "openclaw@2026.4.15",
-                cmd: "openclaw",
+                package: "generic-agent@2026.4.15",
+                cmd: "generic-agent",
                 args: &["acp"],
                 env: &[],
                 node_required: Some("22.12.0"),

--- a/src-tauri/src/acp/remote_registry.rs
+++ b/src-tauri/src/acp/remote_registry.rs
@@ -53,7 +53,7 @@ struct RegistryBinaryPlatformItem {
 }
 
 async fn fetch_registry_payload() -> Result<RegistryPayload, AppCommandError> {
-    let response = reqwest::Client::new()
+    let response = crate::network::http_client::build_client()
         .get(REGISTRY_URL)
         .send()
         .await

--- a/src-tauri/src/acp/types.rs
+++ b/src-tauri/src/acp/types.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -161,6 +162,33 @@ pub enum AcpEvent {
         used: u64,
         size: u64,
     },
+    /// Agent has begun compacting/summarizing context history mid-turn.
+    /// The frontend should keep the spinner running but display a hint
+    /// such as "Compacting context…" and reset its idle watchdog.
+    CompactionStarted {
+        connection_id: String,
+        session_id: String,
+    },
+    /// Compaction finished; agent will resume normal streaming.
+    CompactionFinished {
+        connection_id: String,
+        session_id: String,
+    },
+    /// Non-fatal stream parse/decode warning. Surfaced to the UI so a
+    /// silent loop swallow can't masquerade as a hang.
+    StreamWarning {
+        connection_id: String,
+        message: String,
+    },
+    /// Turn was aborted because no events arrived for too long. The
+    /// frontend treats this exactly like TurnComplete so the user can
+    /// resume sending messages.
+    TurnIdleTimeout {
+        connection_id: String,
+        session_id: String,
+        agent_type: String,
+        idle_ms: u64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -241,6 +269,12 @@ pub struct ConnectionInfo {
     pub id: String,
     pub agent_type: crate::models::agent::AgentType,
     pub status: ConnectionStatus,
+    pub owner_window_label: String,
+    pub working_dir: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub session_id: Option<String>,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use crate::acp::manager::ConnectionManager;
 use crate::chat_channel::manager::ChatChannelManager;
 use crate::db::AppDatabase;
+use crate::runtime_monitor::RuntimeMonitor;
 use crate::terminal::manager::TerminalManager;
+use crate::web::client_owner::WebClientRegistry;
 use crate::web::event_bridge::{EventEmitter, WebEventBroadcaster};
 use crate::web::WebServerState;
 
@@ -12,9 +14,11 @@ pub struct AppState {
     pub db: AppDatabase,
     pub connection_manager: ConnectionManager,
     pub terminal_manager: TerminalManager,
+    pub web_client_registry: Arc<WebClientRegistry>,
     pub event_broadcaster: Arc<WebEventBroadcaster>,
     pub emitter: EventEmitter,
     pub data_dir: PathBuf,
+    pub runtime_monitor: Arc<RuntimeMonitor>,
     pub web_server_state: WebServerState,
     pub chat_channel_manager: ChatChannelManager,
 }

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use tokio_util::task::TaskTracker;
+
 use crate::acp::manager::ConnectionManager;
 use crate::chat_channel::manager::ChatChannelManager;
 use crate::db::AppDatabase;
@@ -21,6 +23,9 @@ pub struct AppState {
     pub runtime_monitor: Arc<RuntimeMonitor>,
     pub web_server_state: WebServerState,
     pub chat_channel_manager: ChatChannelManager,
+    /// Tracks background tasks spawned by web request handlers (e.g. WS
+    /// cleanup timers). Allows graceful shutdown to await pending work.
+    pub task_tracker: TaskTracker,
 }
 
 pub fn default_connection_manager() -> ConnectionManager {

--- a/src-tauri/src/bin/codeg_server.rs
+++ b/src-tauri/src/bin/codeg_server.rs
@@ -172,6 +172,16 @@ async fn async_main() {
         )
         .await;
 
+    // Start squad ACP→pipeline bridge: see crate::squad::turn_listener.
+    codeg_lib::squad::turn_listener::spawn(
+        codeg_lib::db::AppDatabase {
+            conn: state.db.conn.clone(),
+        },
+        state.connection_manager.clone_ref(),
+        state.emitter.clone(),
+        state.event_broadcaster.clone(),
+    );
+
     // Build router
     let router = codeg_lib::web::router::build_router(state, token.clone(), static_dir);
 

--- a/src-tauri/src/bin/codeg_server.rs
+++ b/src-tauri/src/bin/codeg_server.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use codeg_lib::app_state::AppState;
+use codeg_lib::build_info;
+use codeg_lib::runtime_monitor::RuntimeMonitor;
+use codeg_lib::web::client_owner::WebClientRegistry;
 use codeg_lib::web::event_bridge::{EventEmitter, WebEventBroadcaster};
 use codeg_lib::web::{
     find_static_dir_standalone, generate_random_token, get_local_addresses, WebServerState,
@@ -34,7 +37,15 @@ async fn async_main() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(3080);
     let host = std::env::var("CODEG_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-    let token = std::env::var("CODEG_TOKEN").unwrap_or_else(|_| generate_random_token());
+    let disable_auth = std::env::var("CODEG_DISABLE_AUTH")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false);
+    let token = if disable_auth {
+        String::new()
+    } else {
+        std::env::var("CODEG_TOKEN").unwrap_or_else(|_| generate_random_token())
+    };
     let data_dir = std::env::var("CODEG_DATA_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| default_data_dir());
@@ -42,6 +53,55 @@ async fn async_main() {
 
     let static_dir = find_static_dir_standalone(static_dir_env.as_deref());
     let app_version = env!("CARGO_PKG_VERSION");
+    let runtime_monitor = Arc::new(RuntimeMonitor::new());
+
+    let build_consistency = match build_info::enforce_build_consistency(&static_dir) {
+        Ok(info) => info,
+        Err(error) => {
+            eprintln!("[SERVER] {}", error);
+            if let Some(detail) = error.detail {
+                eprintln!("[SERVER] {detail}");
+            }
+            std::process::exit(1);
+        }
+    };
+    runtime_monitor.set_build_consistency(build_consistency.clone());
+    runtime_monitor.record(
+        if build_consistency.status == "ok" {
+            "info"
+        } else {
+            "warn"
+        },
+        "startup",
+        build_consistency.message.clone(),
+        None,
+    );
+
+    let security_info = match build_info::enforce_startup_security(
+        "standalone",
+        &host,
+        !disable_auth,
+        Some(&static_dir),
+        Some(&data_dir),
+    ) {
+        Ok(info) => info,
+        Err(error) => {
+            eprintln!("[SERVER] {}", error);
+            if let Some(detail) = error.detail {
+                eprintln!("[SERVER] {detail}");
+            }
+            std::process::exit(1);
+        }
+    };
+    runtime_monitor.set_security(security_info.clone());
+    if security_info.insecure && security_info.override_active {
+        runtime_monitor.record(
+            "warn",
+            "startup",
+            "Insecure remote startup override is active",
+            None,
+        );
+    }
 
     eprintln!("[SERVER] codeg-server v{}", app_version);
     eprintln!("[SERVER] Data directory: {}", data_dir.display());
@@ -55,15 +115,21 @@ async fn async_main() {
     // Create shared broadcaster
     let broadcaster = Arc::new(WebEventBroadcaster::new());
     let emitter = EventEmitter::WebOnly(broadcaster.clone());
+    let connection_manager = codeg_lib::app_state::default_connection_manager();
+    let web_client_registry = Arc::new(WebClientRegistry::new());
+    connection_manager.attach_runtime_monitor(runtime_monitor.clone());
+    connection_manager.start_orphan_watchdog(web_client_registry.clone());
 
     // Build AppState
     let state = Arc::new(AppState {
         db,
-        connection_manager: codeg_lib::app_state::default_connection_manager(),
+        connection_manager,
         terminal_manager: codeg_lib::app_state::default_terminal_manager(),
+        web_client_registry,
         event_broadcaster: broadcaster,
         emitter,
         data_dir,
+        runtime_monitor,
         web_server_state: WebServerState::new(),
         chat_channel_manager: codeg_lib::app_state::default_chat_channel_manager(),
     });
@@ -115,7 +181,11 @@ async fn async_main() {
     let actual_port = listener.local_addr().map(|a| a.port()).unwrap_or(port);
     let addresses = get_local_addresses(actual_port);
 
-    eprintln!("[SERVER] Token: {}", token);
+    if token.is_empty() {
+        eprintln!("[SERVER] Auth: disabled");
+    } else {
+        eprintln!("[SERVER] Token: {}", token);
+    }
     eprintln!("[SERVER] Listening on:");
     for addr in &addresses {
         eprintln!("  {}", addr);

--- a/src-tauri/src/bin/codeg_server.rs
+++ b/src-tauri/src/bin/codeg_server.rs
@@ -132,6 +132,7 @@ async fn async_main() {
         runtime_monitor,
         web_server_state: WebServerState::new(),
         chat_channel_manager: codeg_lib::app_state::default_chat_channel_manager(),
+        task_tracker: tokio_util::task::TaskTracker::new(),
     });
 
     // Install bundled expert skills into the central store

--- a/src-tauri/src/bin/codeg_server.rs
+++ b/src-tauri/src/bin/codeg_server.rs
@@ -39,7 +39,12 @@ async fn async_main() {
     let host = std::env::var("CODEG_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let disable_auth = std::env::var("CODEG_DISABLE_AUTH")
         .ok()
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
         .unwrap_or(false);
     let token = if disable_auth {
         String::new()

--- a/src-tauri/src/build_info.rs
+++ b/src-tauri/src/build_info.rs
@@ -1,0 +1,218 @@
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::app_error::AppCommandError;
+
+const BUILD_MISMATCH_OVERRIDE_ENV: &str = "CODEG_ALLOW_BUILD_MISMATCH";
+const INSECURE_REMOTE_OVERRIDE_ENV: &str = "CODEG_ALLOW_INSECURE_REMOTE";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendBuildInfo {
+    pub version: String,
+    pub git_commit: Option<String>,
+    pub built_at: Option<String>,
+    pub profile: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrontendBuildManifest {
+    pub version: String,
+    #[serde(default)]
+    pub git_commit: Option<String>,
+    #[serde(default)]
+    pub built_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildConsistencyInfo {
+    pub status: String,
+    pub message: String,
+    pub backend: BackendBuildInfo,
+    pub frontend: Option<FrontendBuildManifest>,
+    pub manifest_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RuntimeSecurityInfo {
+    pub mode: String,
+    pub host: Option<String>,
+    pub auth_enabled: bool,
+    pub allow_remote_access: bool,
+    pub insecure: bool,
+    pub override_active: bool,
+    pub static_dir: Option<String>,
+    pub data_dir: Option<String>,
+}
+
+pub fn backend_build_info() -> BackendBuildInfo {
+    BackendBuildInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git_commit: option_env!("CODEG_BUILD_GIT_COMMIT")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        built_at: option_env!("CODEG_BUILD_TIMESTAMP")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        profile: option_env!("CODEG_BUILD_PROFILE")
+            .unwrap_or("unknown")
+            .to_string(),
+    }
+}
+
+pub fn build_manifest_path(static_dir: &Path) -> PathBuf {
+    static_dir.join("codeg-build.json")
+}
+
+pub fn load_frontend_build_manifest(
+    static_dir: &Path,
+) -> Result<Option<FrontendBuildManifest>, AppCommandError> {
+    let manifest_path = build_manifest_path(static_dir);
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+
+    let raw = std::fs::read_to_string(&manifest_path).map_err(AppCommandError::io)?;
+    let manifest = serde_json::from_str::<FrontendBuildManifest>(&raw).map_err(|error| {
+        AppCommandError::configuration_invalid("Failed to parse frontend build manifest")
+            .with_detail(error.to_string())
+    })?;
+    Ok(Some(manifest))
+}
+
+pub fn evaluate_build_consistency(static_dir: &Path) -> BuildConsistencyInfo {
+    let backend = backend_build_info();
+    let manifest_path = build_manifest_path(static_dir);
+
+    match load_frontend_build_manifest(static_dir) {
+        Ok(Some(frontend)) => {
+            let version_matches = frontend.version == backend.version;
+            let commit_matches = match (&frontend.git_commit, &backend.git_commit) {
+                (Some(frontend_commit), Some(backend_commit)) => frontend_commit == backend_commit,
+                _ => true,
+            };
+
+            let (status, message) = if version_matches && commit_matches {
+                (
+                    "ok".to_string(),
+                    "Frontend and backend builds are aligned".to_string(),
+                )
+            } else {
+                let mut reasons = Vec::new();
+                if !version_matches {
+                    reasons.push(format!(
+                        "version mismatch: frontend={} backend={}",
+                        frontend.version, backend.version
+                    ));
+                }
+                if !commit_matches {
+                    reasons.push(format!(
+                        "git commit mismatch: frontend={} backend={}",
+                        frontend.git_commit.as_deref().unwrap_or("unknown"),
+                        backend.git_commit.as_deref().unwrap_or("unknown")
+                    ));
+                }
+                (
+                    "mismatch".to_string(),
+                    format!("Static assets are out of sync: {}", reasons.join(", ")),
+                )
+            };
+
+            BuildConsistencyInfo {
+                status,
+                message,
+                backend,
+                frontend: Some(frontend),
+                manifest_path: manifest_path.to_string_lossy().to_string(),
+            }
+        }
+        Ok(None) => BuildConsistencyInfo {
+            status: "missing".to_string(),
+            message: "Frontend build manifest is missing".to_string(),
+            backend,
+            frontend: None,
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+        },
+        Err(error) => BuildConsistencyInfo {
+            status: "error".to_string(),
+            message: format!("Failed to read frontend build manifest: {error}"),
+            backend,
+            frontend: None,
+            manifest_path: manifest_path.to_string_lossy().to_string(),
+        },
+    }
+}
+
+pub fn enforce_build_consistency(static_dir: &Path) -> Result<BuildConsistencyInfo, AppCommandError> {
+    let info = evaluate_build_consistency(static_dir);
+    if info.status == "mismatch" && !env_flag(BUILD_MISMATCH_OVERRIDE_ENV) {
+        return Err(
+            AppCommandError::configuration_invalid("Frontend and backend builds do not match")
+                .with_detail(info.message.clone()),
+        );
+    }
+    Ok(info)
+}
+
+pub fn build_security_info(
+    mode: &str,
+    host: Option<&str>,
+    auth_enabled: bool,
+    static_dir: Option<&Path>,
+    data_dir: Option<&Path>,
+) -> RuntimeSecurityInfo {
+    let override_active = env_flag(INSECURE_REMOTE_OVERRIDE_ENV);
+    let allow_remote_access = host.is_some_and(|value| !is_loopback_host(value));
+    let insecure = allow_remote_access && !auth_enabled;
+
+    RuntimeSecurityInfo {
+        mode: mode.to_string(),
+        host: host.map(str::to_string),
+        auth_enabled,
+        allow_remote_access,
+        insecure,
+        override_active,
+        static_dir: static_dir.map(|path| path.to_string_lossy().to_string()),
+        data_dir: data_dir.map(|path| path.to_string_lossy().to_string()),
+    }
+}
+
+pub fn enforce_startup_security(
+    mode: &str,
+    host: &str,
+    auth_enabled: bool,
+    static_dir: Option<&Path>,
+    data_dir: Option<&Path>,
+) -> Result<RuntimeSecurityInfo, AppCommandError> {
+    let info = build_security_info(mode, Some(host), auth_enabled, static_dir, data_dir);
+    if info.insecure && !info.override_active {
+        return Err(AppCommandError::configuration_invalid(
+            "Refusing insecure startup: auth is disabled while listening on a non-loopback address",
+        )
+        .with_detail(format!(
+            "Set {INSECURE_REMOTE_OVERRIDE_ENV}=1 to override intentionally."
+        )));
+    }
+    Ok(info)
+}
+
+pub fn is_loopback_host(host: &str) -> bool {
+    let normalized = host.trim().trim_matches('[').trim_matches(']');
+    if normalized.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    match normalized.parse::<IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        Err(_) => false,
+    }
+}
+
+pub fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
+}

--- a/src-tauri/src/build_info.rs
+++ b/src-tauri/src/build_info.rs
@@ -146,13 +146,15 @@ pub fn evaluate_build_consistency(static_dir: &Path) -> BuildConsistencyInfo {
     }
 }
 
-pub fn enforce_build_consistency(static_dir: &Path) -> Result<BuildConsistencyInfo, AppCommandError> {
+pub fn enforce_build_consistency(
+    static_dir: &Path,
+) -> Result<BuildConsistencyInfo, AppCommandError> {
     let info = evaluate_build_consistency(static_dir);
     if info.status == "mismatch" && !env_flag(BUILD_MISMATCH_OVERRIDE_ENV) {
-        return Err(
-            AppCommandError::configuration_invalid("Frontend and backend builds do not match")
-                .with_detail(info.message.clone()),
-        );
+        return Err(AppCommandError::configuration_invalid(
+            "Frontend and backend builds do not match",
+        )
+        .with_detail(info.message.clone()));
     }
     Ok(info)
 }
@@ -213,6 +215,11 @@ pub fn is_loopback_host(host: &str) -> bool {
 pub fn env_flag(name: &str) -> bool {
     std::env::var(name)
         .ok()
-        .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
         .unwrap_or(false)
 }

--- a/src-tauri/src/chat_channel/backends/lark.rs
+++ b/src-tauri/src/chat_channel/backends/lark.rs
@@ -153,11 +153,12 @@ impl LarkBackend {
             app_secret,
             chat_id,
             channel_id,
-            client: reqwest::Client::builder()
-                .connect_timeout(Duration::from_secs(10))
-                .timeout(Duration::from_secs(30))
-                .build()
-                .unwrap_or_default(),
+            client: crate::network::http_client::build_client_with(
+                crate::network::http_client::ClientConfig::with_timeouts(
+                    Duration::from_secs(10),
+                    Duration::from_secs(30),
+                ),
+            ),
             token_cache: Arc::new(RwLock::new(None)),
             status: Arc::new(Mutex::new(ChannelConnectionStatus::Disconnected)),
             shutdown_tx: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/chat_channel/backends/lark.rs
+++ b/src-tauri/src/chat_channel/backends/lark.rs
@@ -284,7 +284,7 @@ impl LarkBackend {
                     Err(e) => {
                         eprintln!("[Lark] failed to get WS endpoint: {e}");
                         *status.lock().await = ChannelConnectionStatus::Error;
-                        let delay = Duration::from_secs((2u64).pow(retry_count.min(5)));
+                        let delay = crate::chat_channel::backoff::reconnect_delay(retry_count);
                         retry_count += 1;
                         tokio::select! {
                             _ = tokio::time::sleep(delay) => continue,
@@ -304,7 +304,7 @@ impl LarkBackend {
                     Err(e) => {
                         eprintln!("[Lark] WebSocket connect failed: {e}");
                         *status.lock().await = ChannelConnectionStatus::Error;
-                        let delay = Duration::from_secs((2u64).pow(retry_count.min(5)));
+                        let delay = crate::chat_channel::backoff::reconnect_delay(retry_count);
                         retry_count += 1;
                         tokio::select! {
                             _ = tokio::time::sleep(delay) => continue,

--- a/src-tauri/src/chat_channel/backends/telegram.rs
+++ b/src-tauri/src/chat_channel/backends/telegram.rs
@@ -133,6 +133,7 @@ impl ChatChannelBackend for TelegramBackend {
 
         tokio::spawn(async move {
             let mut offset: i64 = 0;
+            let mut consecutive_errors: u32 = 0;
             loop {
                 if *shutdown_rx.borrow() {
                     break;
@@ -157,6 +158,7 @@ impl ChatChannelBackend for TelegramBackend {
                                 *s = ChannelConnectionStatus::Connected;
                             }
                         }
+                        consecutive_errors = 0;
 
                         if let Ok(body) = resp.json::<serde_json::Value>().await {
                             if let Some(updates) = body.get("result").and_then(|r| r.as_array()) {
@@ -220,7 +222,10 @@ impl ChatChannelBackend for TelegramBackend {
                     Err(e) => {
                         eprintln!("[Telegram] polling error: {e}");
                         *status.lock().await = ChannelConnectionStatus::Error;
-                        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                        let delay =
+                            crate::chat_channel::backoff::reconnect_delay(consecutive_errors);
+                        consecutive_errors = consecutive_errors.saturating_add(1);
+                        tokio::time::sleep(delay).await;
                     }
                 }
             }

--- a/src-tauri/src/chat_channel/backends/telegram.rs
+++ b/src-tauri/src/chat_channel/backends/telegram.rs
@@ -22,11 +22,12 @@ impl TelegramBackend {
         Self {
             bot_token,
             chat_id,
-            client: reqwest::Client::builder()
-                .connect_timeout(Duration::from_secs(10))
-                .timeout(Duration::from_secs(60))
-                .build()
-                .unwrap_or_default(),
+            client: crate::network::http_client::build_client_with(
+                crate::network::http_client::ClientConfig::with_timeouts(
+                    Duration::from_secs(10),
+                    Duration::from_secs(60),
+                ),
+            ),
             status: Arc::new(Mutex::new(ChannelConnectionStatus::Disconnected)),
             channel_id,
             shutdown_tx: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/chat_channel/backends/weixin.rs
+++ b/src-tauri/src/chat_channel/backends/weixin.rs
@@ -17,19 +17,17 @@ const ILINK_CHANNEL_VERSION: &str = "1.0.2";
 /// Maximum number of messages buffered while context_token is expired.
 const MAX_PENDING_MESSAGES: usize = 50;
 
-/// Shared HTTP client for QR code auth requests (avoids re-creating TLS state).
+/// HTTP client for QR code auth requests. Built fresh each call so proxy
+/// updates are picked up without requiring a process restart; the QR auth
+/// flow runs at most a handful of times per session, so the TLS-state
+/// rebuild cost is irrelevant.
 fn qr_client() -> reqwest::Client {
-    use std::sync::OnceLock;
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT
-        .get_or_init(|| {
-            reqwest::Client::builder()
-                .connect_timeout(Duration::from_secs(10))
-                .timeout(Duration::from_secs(15))
-                .build()
-                .unwrap_or_default()
-        })
-        .clone()
+    crate::network::http_client::build_client_with(
+        crate::network::http_client::ClientConfig::with_timeouts(
+            Duration::from_secs(10),
+            Duration::from_secs(15),
+        ),
+    )
 }
 
 // ── QR code auth types (public, used by commands) ──
@@ -266,11 +264,12 @@ impl WeixinBackend {
         Self {
             bot_token,
             base_url,
-            client: reqwest::Client::builder()
-                .connect_timeout(Duration::from_secs(10))
-                .timeout(Duration::from_secs(45))
-                .build()
-                .unwrap_or_default(),
+            client: crate::network::http_client::build_client_with(
+                crate::network::http_client::ClientConfig::with_timeouts(
+                    Duration::from_secs(10),
+                    Duration::from_secs(45),
+                ),
+            ),
             status: Arc::new(Mutex::new(ChannelConnectionStatus::Disconnected)),
             channel_id,
             shutdown_tx: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/chat_channel/backends/weixin.rs
+++ b/src-tauri/src/chat_channel/backends/weixin.rs
@@ -710,13 +710,12 @@ impl ChatChannelBackend for WeixinBackend {
                         }
                     }
                     Err(e) => {
-                        consecutive_errors += 1;
                         eprintln!("[Weixin] polling error ({consecutive_errors}): {e}");
                         *status.lock().await = ChannelConnectionStatus::Error;
-                        // Exponential backoff: 5s, 10s, 20s, capped at 30s
                         let delay =
-                            std::cmp::min(5 * 2u64.saturating_pow(consecutive_errors - 1), 30);
-                        tokio::time::sleep(Duration::from_secs(delay)).await;
+                            crate::chat_channel::backoff::reconnect_delay(consecutive_errors);
+                        consecutive_errors += 1;
+                        tokio::time::sleep(delay).await;
                     }
                 }
             }

--- a/src-tauri/src/chat_channel/backoff.rs
+++ b/src-tauri/src/chat_channel/backoff.rs
@@ -1,0 +1,97 @@
+//! Reconnect backoff helpers shared by chat-channel backends.
+//!
+//! Each backend used to roll its own exponential backoff with subtly
+//! different parameters (lark: 2^n; weixin: 5*2^n cap 30s; telegram:
+//! flat 5s). They also disagreed on whether HTTP 401/403/429 should
+//! reset the loop, keep retrying, or honor `Retry-After`. This module
+//! gives them one place to fix bugs and tune behavior.
+
+use std::time::Duration;
+
+/// Standard reconnect schedule used by chat-channel polling and WS loops.
+///
+/// Returns the delay to wait before the next attempt given the current
+/// retry counter (0-based: 0 means "first failure since success").
+///
+/// Schedule: 1s, 2s, 4s, 8s, 16s, 32s, then capped at 60s. Keeps the
+/// channel responsive on transient failures while avoiding hammering an
+/// already-down upstream.
+pub fn reconnect_delay(retry_count: u32) -> Duration {
+    let secs = 1u64.checked_shl(retry_count.min(6)).unwrap_or(64).min(60);
+    Duration::from_secs(secs)
+}
+
+/// Backoff policy for HTTP responses. Drives whether the channel should
+/// stop reconnecting (auth failure), honor a server-provided cooldown,
+/// or fall back to the standard exponential schedule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpRetryDecision {
+    /// Auth failed (401/403). Stop reconnecting; user must fix
+    /// credentials. Caller should mark status as `Error` and exit.
+    StopAuth,
+    /// Server told us when to retry (429 with Retry-After).
+    RetryAfter(Duration),
+    /// Generic transient failure, follow exponential schedule.
+    ExponentialBackoff,
+    /// 2xx — no retry needed.
+    Success,
+}
+
+/// Classify an HTTP status + optional Retry-After header.
+pub fn classify_http_status(
+    status: reqwest::StatusCode,
+    retry_after_secs: Option<u64>,
+) -> HttpRetryDecision {
+    if status.is_success() {
+        return HttpRetryDecision::Success;
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return HttpRetryDecision::StopAuth;
+    }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        if let Some(secs) = retry_after_secs {
+            // Cap server-suggested delay at 5 minutes to avoid
+            // pathological values from a misbehaving upstream.
+            return HttpRetryDecision::RetryAfter(Duration::from_secs(secs.min(300)));
+        }
+    }
+    HttpRetryDecision::ExponentialBackoff
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schedule_caps_at_sixty_seconds() {
+        assert_eq!(reconnect_delay(0), Duration::from_secs(1));
+        assert_eq!(reconnect_delay(1), Duration::from_secs(2));
+        assert_eq!(reconnect_delay(5), Duration::from_secs(32));
+        assert_eq!(reconnect_delay(6), Duration::from_secs(60));
+        assert_eq!(reconnect_delay(20), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn auth_codes_stop() {
+        assert_eq!(
+            classify_http_status(reqwest::StatusCode::UNAUTHORIZED, None),
+            HttpRetryDecision::StopAuth
+        );
+        assert_eq!(
+            classify_http_status(reqwest::StatusCode::FORBIDDEN, Some(10)),
+            HttpRetryDecision::StopAuth
+        );
+    }
+
+    #[test]
+    fn retry_after_honored_then_capped() {
+        assert_eq!(
+            classify_http_status(reqwest::StatusCode::TOO_MANY_REQUESTS, Some(15)),
+            HttpRetryDecision::RetryAfter(Duration::from_secs(15))
+        );
+        assert_eq!(
+            classify_http_status(reqwest::StatusCode::TOO_MANY_REQUESTS, Some(9999)),
+            HttpRetryDecision::RetryAfter(Duration::from_secs(300))
+        );
+    }
+}

--- a/src-tauri/src/chat_channel/mod.rs
+++ b/src-tauri/src/chat_channel/mod.rs
@@ -1,4 +1,5 @@
 pub mod backends;
+pub mod backoff;
 pub mod command_dispatcher;
 pub mod command_handlers;
 pub mod error;

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -21,6 +21,8 @@ use crate::acp::types::{
 use crate::acp::types::{ConnectionInfo, ForkResultInfo, PromptInputBlock};
 use crate::db::service::agent_setting_service;
 use crate::db::service::model_provider_service;
+#[cfg(feature = "tauri-runtime")]
+use crate::db::service::folder_service;
 use crate::db::AppDatabase;
 use crate::models::agent::AgentType;
 use crate::web::event_bridge::EventEmitter;
@@ -1417,9 +1419,9 @@ pub(crate) fn skill_storage_spec(agent_type: AgentType) -> Option<SkillStorageSp
             ],
             project_rel_dirs: vec![".gemini/skills", ".agents/skills"],
         }),
-        AgentType::OpenClaw => Some(SkillStorageSpec {
+        AgentType::Generic => Some(SkillStorageSpec {
             kind: SkillStorageKind::SkillDirectoryOnly,
-            global_dirs: vec![home_dir_or_default().join(".openclaw").join("skills")],
+            global_dirs: vec![home_dir_or_default().join(".generic").join("skills")],
             project_rel_dirs: vec!["skills"],
         }),
         AgentType::Cline => Some(SkillStorageSpec {
@@ -1799,10 +1801,11 @@ pub(crate) fn build_runtime_env_from_setting(
 pub(crate) async fn apply_model_provider_env(
     agent_type: AgentType,
     setting: Option<&crate::db::entities::agent_setting::Model>,
+    provider_id_override: Option<i32>,
     runtime_env: &mut BTreeMap<String, String>,
     conn: &sea_orm::DatabaseConnection,
 ) {
-    let provider_id = match setting.and_then(|s| s.model_provider_id) {
+    let provider_id = match provider_id_override.or_else(|| setting.and_then(|s| s.model_provider_id)) {
         Some(id) => id,
         None => return,
     };
@@ -1844,8 +1847,8 @@ fn cascade_update_agent_config(
                 serde_json::to_string(&patch).map_err(|e| AcpError::protocol(e.to_string()))?;
             persist_agent_local_config_json(agent_type, Some(&patch_str))?;
         }
-        AgentType::OpenClaw => {
-            // agent_local_config_path returns None for OpenClaw — no-op
+        AgentType::Generic => {
+            // agent_local_config_path returns None for Generic — no-op
         }
         AgentType::Codex => {
             let auth_path = codex_auth_json_path();
@@ -2010,12 +2013,40 @@ pub async fn acp_connect(
         build_runtime_env_from_setting(agent_type, setting.as_ref(), local_config_json.as_deref());
 
     // Resolve model provider credentials if configured.
-    apply_model_provider_env(agent_type, setting.as_ref(), &mut runtime_env, &db.conn).await;
+    let workspace_preset = match working_dir
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+    {
+        Some(path) => folder_service::get_folder_by_path(&db.conn, path)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|folder| folder.workspace_preset),
+        None => None,
+    };
 
-    // For OpenClaw: when creating a new conversation (no session_id to resume),
+    let preset_model_provider_id = workspace_preset
+        .as_ref()
+        .and_then(|preset| preset.model_provider_id);
+    apply_model_provider_env(
+        agent_type,
+        setting.as_ref(),
+        preset_model_provider_id,
+        &mut runtime_env,
+        &db.conn,
+    )
+    .await;
+
+    if let Some(preset) = workspace_preset.as_ref() {
+        for (key, value) in &preset.env_overrides {
+            runtime_env.insert(key.clone(), value.clone());
+        }
+    }
+
+    // For Generic: when creating a new conversation (no session_id to resume),
     // signal that we want a fresh transcript via --reset-session.
-    if agent_type == AgentType::OpenClaw && session_id.is_none() {
-        runtime_env.insert("OPENCLAW_RESET_SESSION".into(), "1".into());
+    if agent_type == AgentType::Generic && session_id.is_none() {
+        runtime_env.insert("GENERIC_RESET_SESSION".into(), "1".into());
     }
 
     // Guard: the session page must never trigger a download or install.
@@ -2558,7 +2589,7 @@ pub(crate) async fn acp_update_agent_config_core(
         return Ok(());
     }
 
-    // Claude Code, Gemini, OpenClaw — write config JSON to local file without merging env
+    // Claude Code, Gemini, Generic — write config JSON to local file without merging env
     let local_patch_value = config_json
         .as_deref()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -20,9 +20,9 @@ use crate::acp::types::{
 #[cfg(feature = "tauri-runtime")]
 use crate::acp::types::{ConnectionInfo, ForkResultInfo, PromptInputBlock};
 use crate::db::service::agent_setting_service;
-use crate::db::service::model_provider_service;
 #[cfg(feature = "tauri-runtime")]
 use crate::db::service::folder_service;
+use crate::db::service::model_provider_service;
 use crate::db::AppDatabase;
 use crate::models::agent::AgentType;
 use crate::web::event_bridge::EventEmitter;
@@ -1805,10 +1805,11 @@ pub(crate) async fn apply_model_provider_env(
     runtime_env: &mut BTreeMap<String, String>,
     conn: &sea_orm::DatabaseConnection,
 ) {
-    let provider_id = match provider_id_override.or_else(|| setting.and_then(|s| s.model_provider_id)) {
-        Some(id) => id,
-        None => return,
-    };
+    let provider_id =
+        match provider_id_override.or_else(|| setting.and_then(|s| s.model_provider_id)) {
+            Some(id) => id,
+            None => return,
+        };
     let provider = match model_provider_service::get_by_id(conn, provider_id).await {
         Ok(Some(p)) => p,
         _ => return,
@@ -3247,7 +3248,7 @@ struct OAuthTokenResp {
 }
 
 pub(crate) async fn codex_request_device_code_core() -> Result<CodexDeviceCodeResponse, AcpError> {
-    let client = reqwest::Client::new();
+    let client = crate::network::http_client::build_client();
     let url = format!("{CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/usercode");
     let body = serde_json::json!({ "client_id": CODEX_OAUTH_CLIENT_ID });
 
@@ -3301,7 +3302,7 @@ pub(crate) async fn codex_poll_device_code_core(
     device_auth_id: String,
     user_code: String,
 ) -> Result<CodexDeviceCodePollResult, AcpError> {
-    let client = reqwest::Client::new();
+    let client = crate::network::http_client::build_client();
     let poll_url = format!("{CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/token");
     let poll_body = serde_json::json!({
         "device_auth_id": device_auth_id,

--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -13,7 +13,7 @@ use crate::parsers::claude::ClaudeParser;
 use crate::parsers::cline::ClineParser;
 use crate::parsers::codex::CodexParser;
 use crate::parsers::gemini::GeminiParser;
-use crate::parsers::openclaw::OpenClawParser;
+use crate::parsers::generic::GenericParser;
 use crate::parsers::opencode::OpenCodeParser;
 use crate::parsers::{path_eq_for_matching, AgentParser, ParseError};
 
@@ -70,7 +70,7 @@ fn list_conversations_sync(
         (AgentType::Codex, Box::new(CodexParser::new())),
         (AgentType::OpenCode, Box::new(OpenCodeParser::new())),
         (AgentType::Gemini, Box::new(GeminiParser::new())),
-        (AgentType::OpenClaw, Box::new(OpenClawParser::new())),
+        (AgentType::Generic, Box::new(GenericParser::new())),
         (AgentType::Cline, Box::new(ClineParser::new())),
     ];
 
@@ -171,7 +171,7 @@ pub async fn get_conversation(
             AgentType::Codex => Box::new(CodexParser::new()),
             AgentType::OpenCode => Box::new(OpenCodeParser::new()),
             AgentType::Gemini => Box::new(GeminiParser::new()),
-            AgentType::OpenClaw => Box::new(OpenClawParser::new()),
+            AgentType::Generic => Box::new(GenericParser::new()),
             AgentType::Cline => Box::new(ClineParser::new()),
         };
 
@@ -278,7 +278,7 @@ pub async fn import_local_conversations(
         .map_err(AppCommandError::from)
 }
 
-/// Core logic for loading a folder conversation with full OpenClaw fallback.
+/// Core logic for loading a folder conversation with full Generic fallback.
 /// Shared by both the Tauri command and the web handler.
 pub async fn get_folder_conversation_core(
     conn: &sea_orm::DatabaseConnection,
@@ -305,20 +305,20 @@ pub async fn get_folder_conversation_core(
                 AgentType::Codex => Box::new(CodexParser::new()),
                 AgentType::OpenCode => Box::new(OpenCodeParser::new()),
                 AgentType::Gemini => Box::new(GeminiParser::new()),
-                AgentType::OpenClaw => Box::new(OpenClawParser::new()),
+                AgentType::Generic => Box::new(GenericParser::new()),
                 AgentType::Cline => Box::new(ClineParser::new()),
             };
             match parser.get_conversation(&eid) {
                 Ok(d) => Ok((d.turns, d.session_stats, None)),
                 Err(crate::parsers::ParseError::ConversationNotFound(_)) => {
                     // The external_id may no longer match any local file —
-                    // e.g. an ACP session UUID (OpenClaw, Cline) or a stale
+                    // e.g. an ACP session UUID (Generic, Cline) or a stale
                     // ID after session/new fallback overwrote the original
                     // (Gemini CLI).  Fall back to matching by folder_path
                     // and started_at from the parsed conversation list.
                     if matches!(
                         at,
-                        AgentType::OpenClaw | AgentType::Cline | AgentType::Gemini
+                        AgentType::Generic | AgentType::Cline | AgentType::Gemini
                     ) {
                         if let Ok(all) = parser.list_conversations() {
                             // Filter by folder_path first, then find the closest

--- a/src-tauri/src/commands/experts.rs
+++ b/src-tauri/src/commands/experts.rs
@@ -755,7 +755,7 @@ fn supported_agents() -> Vec<AgentType> {
         AgentType::Codex,
         AgentType::OpenCode,
         AgentType::Gemini,
-        AgentType::OpenClaw,
+        AgentType::Generic,
         AgentType::Cline,
     ];
     ALL.iter()

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -24,7 +24,7 @@ use crate::db::service::folder_service;
 use crate::db::AppDatabase;
 use crate::models::GitCredentials;
 #[cfg(feature = "tauri-runtime")]
-use crate::models::{FolderDetail, FolderHistoryEntry};
+use crate::models::{FolderDetail, FolderHistoryEntry, WorkspacePreset};
 use crate::web::event_bridge::EventEmitter;
 
 /// Configure a git command for remote operations:
@@ -552,6 +552,18 @@ pub async fn remove_folder_from_workspace(
         .await
         .map_err(AppCommandError::from)?;
     folder_service::set_folder_open(&db.conn, folder_id, false)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn update_folder_workspace_preset(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+    workspace_preset: Option<WorkspacePreset>,
+) -> Result<FolderDetail, AppCommandError> {
+    folder_service::update_workspace_preset(&db.conn, folder_id, workspace_preset)
         .await
         .map_err(AppCommandError::from)
 }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 use std::time::Duration;
 
 use serde::de::DeserializeOwned;
@@ -12,14 +11,6 @@ use crate::app_error::AppCommandError;
 
 const MARKETPLACE_OFFICIAL: &str = "official_registry";
 const MARKETPLACE_SMITHERY: &str = "smithery";
-static MARKETPLACE_HTTP_CLIENT: LazyLock<Result<reqwest::Client, String>> = LazyLock::new(|| {
-    reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(8))
-        .timeout(Duration::from_secs(20))
-        .user_agent("codeg-mcp-market/1.0")
-        .build()
-        .map_err(|e| format!("failed to initialize marketplace HTTP client: {e}"))
-});
 
 fn mcp_invalid_input(message: impl Into<String>) -> AppCommandError {
     AppCommandError::invalid_input(message)
@@ -551,9 +542,7 @@ fn gemini_config_path() -> PathBuf {
 }
 
 fn generic_config_path() -> PathBuf {
-    home_dir_or_default()
-        .join(".generic")
-        .join("generic.json")
+    home_dir_or_default().join(".generic").join("generic.json")
 }
 
 fn cline_config_path() -> PathBuf {
@@ -650,10 +639,13 @@ fn contains_unresolved_placeholder(value: &str) -> bool {
 }
 
 fn marketplace_http_client() -> Result<reqwest::Client, AppCommandError> {
-    match &*MARKETPLACE_HTTP_CLIENT {
-        Ok(client) => Ok(client.clone()),
-        Err(err) => Err(mcp_network(err.clone())),
-    }
+    Ok(crate::network::http_client::build_client_with(
+        crate::network::http_client::ClientConfig::with_timeouts(
+            Duration::from_secs(8),
+            Duration::from_secs(20),
+        )
+        .user_agent("codeg-mcp-market/1.0"),
+    ))
 }
 
 fn should_retry_http_status(status: reqwest::StatusCode) -> bool {

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -43,7 +43,7 @@ pub enum McpAppType {
     ClaudeCode,
     Codex,
     Gemini,
-    OpenClaw,
+    Generic,
     OpenCode,
     Cline,
 }
@@ -354,7 +354,7 @@ pub async fn mcp_upsert_local_server(
         McpAppType::ClaudeCode,
         McpAppType::Codex,
         McpAppType::Gemini,
-        McpAppType::OpenClaw,
+        McpAppType::Generic,
         McpAppType::OpenCode,
         McpAppType::Cline,
     ];
@@ -408,7 +408,7 @@ pub async fn mcp_remove_server(
             McpAppType::ClaudeCode,
             McpAppType::Codex,
             McpAppType::Gemini,
-            McpAppType::OpenClaw,
+            McpAppType::Generic,
             McpAppType::OpenCode,
             McpAppType::Cline,
         ],
@@ -550,10 +550,10 @@ fn gemini_config_path() -> PathBuf {
     home_dir_or_default().join(".gemini").join("settings.json")
 }
 
-fn openclaw_config_path() -> PathBuf {
+fn generic_config_path() -> PathBuf {
     home_dir_or_default()
-        .join(".openclaw")
-        .join("openclaw.json")
+        .join(".generic")
+        .join("generic.json")
 }
 
 fn cline_config_path() -> PathBuf {
@@ -1687,11 +1687,11 @@ fn remove_gemini_server(id: &str) -> Result<bool, AppCommandError> {
 }
 
 // ---------------------------------------------------------------------------
-// OpenClaw  (~/.openclaw/openclaw.json  →  mcp.servers)
+// Generic  (~/.generic/generic.json  →  mcp.servers)
 // ---------------------------------------------------------------------------
 
-fn read_openclaw_servers() -> Result<BTreeMap<String, Value>, AppCommandError> {
-    let path = openclaw_config_path();
+fn read_generic_servers() -> Result<BTreeMap<String, Value>, AppCommandError> {
+    let path = generic_config_path();
     let root = read_json_file(&path)?;
     let mut out = BTreeMap::new();
 
@@ -1703,12 +1703,12 @@ fn read_openclaw_servers() -> Result<BTreeMap<String, Value>, AppCommandError> {
     };
 
     for (id, spec) in servers {
-        match canonicalize_spec(spec, "OpenClaw config") {
+        match canonicalize_spec(spec, "Generic config") {
             Ok(normalized) => {
                 out.insert(id.to_string(), normalized);
             }
             Err(err) => {
-                eprintln!("[MCP] skip invalid OpenClaw MCP entry id={id}: {err}");
+                eprintln!("[MCP] skip invalid Generic MCP entry id={id}: {err}");
             }
         }
     }
@@ -1716,14 +1716,14 @@ fn read_openclaw_servers() -> Result<BTreeMap<String, Value>, AppCommandError> {
     Ok(out)
 }
 
-fn upsert_openclaw_server(id: &str, spec: &Value) -> Result<(), AppCommandError> {
-    let path = openclaw_config_path();
+fn upsert_generic_server(id: &str, spec: &Value) -> Result<(), AppCommandError> {
+    let path = generic_config_path();
     let mut root = read_json_file(&path)?;
     if !root.is_object() {
         root = json!({});
     }
 
-    let canonical = canonicalize_spec(spec, "OpenClaw write")?;
+    let canonical = canonicalize_spec(spec, "Generic write")?;
 
     let obj = root.as_object_mut().ok_or_else(|| {
         mcp_configuration_invalid(format!("invalid JSON root in {}", path.display()))
@@ -1751,8 +1751,8 @@ fn upsert_openclaw_server(id: &str, spec: &Value) -> Result<(), AppCommandError>
     write_json_file(&path, &root)
 }
 
-fn remove_openclaw_server(id: &str) -> Result<bool, AppCommandError> {
-    let path = openclaw_config_path();
+fn remove_generic_server(id: &str) -> Result<bool, AppCommandError> {
+    let path = generic_config_path();
     if !path.exists() {
         return Ok(false);
     }
@@ -1887,11 +1887,11 @@ fn scan_local_servers() -> Result<Vec<LocalMcpServer>, AppCommandError> {
         entry.1.insert(McpAppType::Gemini);
     }
 
-    for (id, spec) in read_openclaw_servers()? {
+    for (id, spec) in read_generic_servers()? {
         let entry = merged
             .entry(id)
             .or_insert_with(|| (spec.clone(), BTreeSet::new()));
-        entry.1.insert(McpAppType::OpenClaw);
+        entry.1.insert(McpAppType::Generic);
     }
 
     for (id, spec) in read_cline_servers()? {
@@ -1922,7 +1922,7 @@ fn upsert_server_for_app(app: McpAppType, id: &str, spec: &Value) -> Result<(), 
         McpAppType::Codex => upsert_codex_server(id, spec),
         McpAppType::OpenCode => upsert_opencode_server(id, spec),
         McpAppType::Gemini => upsert_gemini_server(id, spec),
-        McpAppType::OpenClaw => upsert_openclaw_server(id, spec),
+        McpAppType::Generic => upsert_generic_server(id, spec),
         McpAppType::Cline => upsert_cline_server(id, spec),
     }
 }
@@ -1933,7 +1933,7 @@ fn remove_server_for_app(app: McpAppType, id: &str) -> Result<bool, AppCommandEr
         McpAppType::Codex => remove_codex_server(id),
         McpAppType::OpenCode => remove_opencode_server(id),
         McpAppType::Gemini => remove_gemini_server(id),
-        McpAppType::OpenClaw => remove_openclaw_server(id),
+        McpAppType::Generic => remove_generic_server(id),
         McpAppType::Cline => remove_cline_server(id),
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod model_provider;
 #[cfg(feature = "tauri-runtime")]
 pub mod notification;
 pub mod project_boot;
+pub mod runtime;
 pub mod system_settings;
 pub mod terminal;
 pub mod version_control;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod model_provider;
 pub mod notification;
 pub mod project_boot;
 pub mod runtime;
+pub mod squad;
 pub mod system_settings;
 pub mod terminal;
 pub mod version_control;

--- a/src-tauri/src/commands/runtime.rs
+++ b/src-tauri/src/commands/runtime.rs
@@ -1,0 +1,77 @@
+use serde::Serialize;
+#[cfg(feature = "tauri-runtime")]
+use tauri::State;
+
+use crate::acp::manager::{ConnectionLimitSnapshot, ConnectionManager};
+use crate::acp::types::ConnectionInfo;
+use crate::app_error::AppCommandError;
+use crate::build_info::{BuildConsistencyInfo, RuntimeSecurityInfo};
+use crate::runtime_monitor::{RuntimeLogEntry, RuntimeMonitor};
+use crate::terminal::manager::TerminalManager;
+use crate::terminal::types::TerminalInfo;
+use crate::web::client_owner::{WebClientInfo, WebClientRegistry};
+#[cfg(feature = "tauri-runtime")]
+use {
+    std::sync::Arc,
+    crate::acp::binary_cache::{self, AcpCacheInventory},
+};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeDiagnostics {
+    pub build: Option<BuildConsistencyInfo>,
+    pub security: Option<RuntimeSecurityInfo>,
+    pub connections: Vec<ConnectionInfo>,
+    pub terminals: Vec<TerminalInfo>,
+    pub web_clients: Vec<WebClientInfo>,
+    pub recent_logs: Vec<RuntimeLogEntry>,
+    pub connection_limits: ConnectionLimitSnapshot,
+}
+
+pub async fn get_runtime_diagnostics_core(
+    connection_manager: &ConnectionManager,
+    terminal_manager: &TerminalManager,
+    web_client_registry: &WebClientRegistry,
+    runtime_monitor: &RuntimeMonitor,
+) -> Result<RuntimeDiagnostics, AppCommandError> {
+    let connections = connection_manager.list_connections().await;
+    let connection_limits = connection_manager.limits_snapshot().await;
+    let terminals = terminal_manager.list_with_exit_check(None);
+    let web_clients = web_client_registry.list_clients().await;
+    let recent_logs = runtime_monitor.recent_entries(100);
+    let build = runtime_monitor.build_consistency();
+    let security = runtime_monitor.security();
+
+    Ok(RuntimeDiagnostics {
+        build,
+        security,
+        connections,
+        terminals,
+        web_clients,
+        recent_logs,
+        connection_limits,
+    })
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn get_runtime_diagnostics(
+    connection_manager: State<'_, ConnectionManager>,
+    terminal_manager: State<'_, TerminalManager>,
+    web_client_registry: State<'_, Arc<WebClientRegistry>>,
+    runtime_monitor: State<'_, Arc<RuntimeMonitor>>,
+) -> Result<RuntimeDiagnostics, AppCommandError> {
+    get_runtime_diagnostics_core(
+        connection_manager.inner(),
+        terminal_manager.inner(),
+        web_client_registry.inner(),
+        runtime_monitor.inner(),
+    )
+    .await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn get_acp_cache_inventory() -> Result<AcpCacheInventory, AppCommandError> {
+    binary_cache::inventory_agent_caches()
+        .map_err(|error| AppCommandError::task_execution_failed(error.to_string()))
+}

--- a/src-tauri/src/commands/runtime.rs
+++ b/src-tauri/src/commands/runtime.rs
@@ -12,8 +12,8 @@ use crate::terminal::types::TerminalInfo;
 use crate::web::client_owner::{WebClientInfo, WebClientRegistry};
 #[cfg(feature = "tauri-runtime")]
 use {
-    std::sync::Arc,
     crate::acp::binary_cache::{self, AcpCacheInventory},
+    std::sync::Arc,
 };
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/commands/squad.rs
+++ b/src-tauri/src/commands/squad.rs
@@ -180,8 +180,10 @@ pub async fn squad_list_tasks_core(
         .map_err(AppCommandError::from)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn squad_create_artifact_core(
     db: &AppDatabase,
+    emitter: &EventEmitter,
     squad_run_id: i32,
     role_kind: Option<SquadRoleKind>,
     task_id: Option<i32>,
@@ -189,8 +191,9 @@ pub async fn squad_create_artifact_core(
     title: String,
     content_json: String,
 ) -> Result<SquadArtifactInfo, AppCommandError> {
-    squad_service::create_artifact(
-        &db.conn,
+    dispatcher::record_role_artifact(
+        db,
+        emitter,
         squad_run_id,
         role_kind,
         task_id,
@@ -199,7 +202,7 @@ pub async fn squad_create_artifact_core(
         content_json,
     )
     .await
-    .map_err(AppCommandError::from)
+    .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
 }
 
 pub async fn squad_list_artifacts_core(
@@ -231,6 +234,28 @@ pub async fn squad_dispatch_pending_tasks_core(
     dispatcher::dispatch_pending_tasks(db, manager, emitter, squad_run_id)
         .await
         .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
+pub async fn squad_record_turn_artifacts_core(
+    db: &AppDatabase,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+    role_kind: SquadRoleKind,
+    task_id: Option<i32>,
+    agent_text: String,
+    plan_json: Option<String>,
+) -> Result<dispatcher::TurnArtifactsResult, AppCommandError> {
+    dispatcher::record_turn_artifacts(
+        db,
+        emitter,
+        squad_run_id,
+        role_kind,
+        task_id,
+        agent_text,
+        plan_json,
+    )
+    .await
+    .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
 }
 
 #[cfg(feature = "tauri-runtime")]
@@ -398,6 +423,7 @@ pub async fn squad_list_tasks(
 #[tauri::command]
 pub async fn squad_create_artifact(
     db: tauri::State<'_, AppDatabase>,
+    app: tauri::AppHandle,
     squad_run_id: i32,
     role_kind: Option<SquadRoleKind>,
     task_id: Option<i32>,
@@ -405,8 +431,10 @@ pub async fn squad_create_artifact(
     title: String,
     content_json: String,
 ) -> Result<SquadArtifactInfo, AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
     squad_create_artifact_core(
         &db,
+        &emitter,
         squad_run_id,
         role_kind,
         task_id,
@@ -448,4 +476,28 @@ pub async fn squad_dispatch_pending_tasks(
 ) -> Result<dispatcher::DispatchPendingTasksResult, AppCommandError> {
     let emitter = EventEmitter::Tauri(app);
     squad_dispatch_pending_tasks_core(&db, &manager, &emitter, squad_run_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_record_turn_artifacts(
+    db: tauri::State<'_, AppDatabase>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+    role_kind: SquadRoleKind,
+    task_id: Option<i32>,
+    agent_text: String,
+    plan_json: Option<String>,
+) -> Result<dispatcher::TurnArtifactsResult, AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_record_turn_artifacts_core(
+        &db,
+        &emitter,
+        squad_run_id,
+        role_kind,
+        task_id,
+        agent_text,
+        plan_json,
+    )
+    .await
 }

--- a/src-tauri/src/commands/squad.rs
+++ b/src-tauri/src/commands/squad.rs
@@ -1,0 +1,306 @@
+use crate::acp::manager::ConnectionManager;
+use crate::app_error::AppCommandError;
+use crate::db::service::squad_service;
+use crate::db::AppDatabase;
+use crate::models::squad::{
+    SquadArtifactInfo, SquadArtifactType, SquadRoleKind, SquadRoleProfileInfo,
+    SquadRoleProfilePatch, SquadRoleRunInfo, SquadRunInfo, SquadRunMode, SquadRunSnapshot,
+    SquadTaskInfo, SquadTaskStatus,
+};
+use crate::squad::dispatcher;
+use crate::web::event_bridge::EventEmitter;
+
+pub async fn squad_get_role_profiles_core(
+    db: &AppDatabase,
+    folder_id: i32,
+) -> Result<Vec<SquadRoleProfileInfo>, AppCommandError> {
+    squad_service::list_role_profiles(&db.conn, folder_id)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_seed_role_profiles_core(
+    db: &AppDatabase,
+    folder_id: i32,
+) -> Result<Vec<SquadRoleProfileInfo>, AppCommandError> {
+    squad_service::seed_role_profiles(&db.conn, folder_id)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_update_role_profile_core(
+    db: &AppDatabase,
+    folder_id: i32,
+    role_kind: SquadRoleKind,
+    patch: SquadRoleProfilePatch,
+) -> Result<SquadRoleProfileInfo, AppCommandError> {
+    squad_service::update_role_profile(&db.conn, folder_id, role_kind, patch)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_reset_role_profile_core(
+    db: &AppDatabase,
+    folder_id: i32,
+    role_kind: SquadRoleKind,
+) -> Result<SquadRoleProfileInfo, AppCommandError> {
+    squad_service::reset_role_profile(&db.conn, folder_id, role_kind)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_create_run_core(
+    db: &AppDatabase,
+    folder_id: i32,
+    origin_conversation_id: Option<i32>,
+    mode: SquadRunMode,
+    goal_summary: String,
+) -> Result<SquadRunSnapshot, AppCommandError> {
+    let snapshot = squad_service::create_run(
+        &db.conn,
+        folder_id,
+        origin_conversation_id,
+        mode,
+        goal_summary,
+    )
+    .await
+    .map_err(AppCommandError::from)?;
+    Ok(snapshot)
+}
+
+pub async fn squad_get_run_core(
+    db: &AppDatabase,
+    squad_run_id: i32,
+) -> Result<SquadRunSnapshot, AppCommandError> {
+    squad_service::get_run(&db.conn, squad_run_id)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_list_runs_core(
+    db: &AppDatabase,
+    folder_id: i32,
+) -> Result<Vec<SquadRunInfo>, AppCommandError> {
+    squad_service::list_runs(&db.conn, folder_id)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_start_run_core(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+    working_dir: Option<String>,
+) -> Result<(), AppCommandError> {
+    dispatcher::start_run(db, manager, emitter, squad_run_id, working_dir)
+        .await
+        .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
+pub async fn squad_stop_run_core(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+) -> Result<(), AppCommandError> {
+    dispatcher::stop_run(db, manager, emitter, squad_run_id)
+        .await
+        .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
+pub async fn squad_connect_role_core(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+    role_kind: SquadRoleKind,
+    working_dir: Option<String>,
+) -> Result<SquadRoleRunInfo, AppCommandError> {
+    dispatcher::connect_role(db, manager, emitter, squad_run_id, role_kind, working_dir)
+        .await
+        .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
+pub async fn squad_prompt_role_core(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+    role_kind: SquadRoleKind,
+    task_id: Option<i32>,
+) -> Result<SquadRoleRunInfo, AppCommandError> {
+    let task = match task_id {
+        Some(task_id) => Some(
+            squad_service::get_task_for_run(&db.conn, squad_run_id, task_id)
+                .await
+                .map_err(AppCommandError::from)?,
+        ),
+        None => None,
+    };
+    dispatcher::prompt_role(db, manager, emitter, squad_run_id, role_kind, task)
+        .await
+        .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
+pub async fn squad_create_task_core(
+    db: &AppDatabase,
+    squad_run_id: i32,
+    assigned_role_kind: SquadRoleKind,
+    title: String,
+    description: String,
+) -> Result<SquadTaskInfo, AppCommandError> {
+    squad_service::create_task(
+        &db.conn,
+        squad_run_id,
+        assigned_role_kind,
+        title,
+        description,
+    )
+    .await
+    .map_err(AppCommandError::from)
+}
+
+pub async fn squad_update_task_status_core(
+    db: &AppDatabase,
+    task_id: i32,
+    status: SquadTaskStatus,
+) -> Result<SquadTaskInfo, AppCommandError> {
+    squad_service::update_task_status(&db.conn, task_id, status)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_list_tasks_core(
+    db: &AppDatabase,
+    squad_run_id: i32,
+) -> Result<Vec<SquadTaskInfo>, AppCommandError> {
+    squad_service::list_tasks(&db.conn, squad_run_id)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+pub async fn squad_create_artifact_core(
+    db: &AppDatabase,
+    squad_run_id: i32,
+    role_kind: Option<SquadRoleKind>,
+    task_id: Option<i32>,
+    artifact_type: SquadArtifactType,
+    title: String,
+    content_json: String,
+) -> Result<SquadArtifactInfo, AppCommandError> {
+    squad_service::create_artifact(
+        &db.conn,
+        squad_run_id,
+        role_kind,
+        task_id,
+        artifact_type,
+        title,
+        content_json,
+    )
+    .await
+    .map_err(AppCommandError::from)
+}
+
+pub async fn squad_list_artifacts_core(
+    db: &AppDatabase,
+    squad_run_id: i32,
+) -> Result<Vec<SquadArtifactInfo>, AppCommandError> {
+    squad_service::list_artifacts(&db.conn, squad_run_id)
+        .await
+        .map_err(AppCommandError::from)
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_get_role_profiles(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+) -> Result<Vec<SquadRoleProfileInfo>, AppCommandError> {
+    squad_get_role_profiles_core(&db, folder_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_seed_role_profiles(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+) -> Result<Vec<SquadRoleProfileInfo>, AppCommandError> {
+    squad_seed_role_profiles_core(&db, folder_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_update_role_profile(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+    role_kind: SquadRoleKind,
+    patch: SquadRoleProfilePatch,
+) -> Result<SquadRoleProfileInfo, AppCommandError> {
+    squad_update_role_profile_core(&db, folder_id, role_kind, patch).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_reset_role_profile(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+    role_kind: SquadRoleKind,
+) -> Result<SquadRoleProfileInfo, AppCommandError> {
+    squad_reset_role_profile_core(&db, folder_id, role_kind).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_create_run(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+    origin_conversation_id: Option<i32>,
+    mode: SquadRunMode,
+    goal_summary: String,
+) -> Result<SquadRunSnapshot, AppCommandError> {
+    squad_create_run_core(&db, folder_id, origin_conversation_id, mode, goal_summary).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_get_run(
+    db: tauri::State<'_, AppDatabase>,
+    squad_run_id: i32,
+) -> Result<SquadRunSnapshot, AppCommandError> {
+    squad_get_run_core(&db, squad_run_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_list_runs(
+    db: tauri::State<'_, AppDatabase>,
+    folder_id: i32,
+) -> Result<Vec<SquadRunInfo>, AppCommandError> {
+    squad_list_runs_core(&db, folder_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_start_run(
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, ConnectionManager>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+    working_dir: Option<String>,
+) -> Result<(), AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_start_run_core(&db, &manager, &emitter, squad_run_id, working_dir).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_stop_run(
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, ConnectionManager>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+) -> Result<(), AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_stop_run_core(&db, &manager, &emitter, squad_run_id).await
+}

--- a/src-tauri/src/commands/squad.rs
+++ b/src-tauri/src/commands/squad.rs
@@ -222,6 +222,17 @@ pub async fn squad_apply_conductor_output_core(
         .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
 }
 
+pub async fn squad_dispatch_pending_tasks_core(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+) -> Result<dispatcher::DispatchPendingTasksResult, AppCommandError> {
+    dispatcher::dispatch_pending_tasks(db, manager, emitter, squad_run_id)
+        .await
+        .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
 #[cfg(feature = "tauri-runtime")]
 #[tauri::command]
 pub async fn squad_get_role_profiles(
@@ -425,4 +436,16 @@ pub async fn squad_apply_conductor_output(
 ) -> Result<dispatcher::ApplyConductorOutputResult, AppCommandError> {
     let emitter = EventEmitter::Tauri(app);
     squad_apply_conductor_output_core(&db, &emitter, squad_run_id, raw_text).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_dispatch_pending_tasks(
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, ConnectionManager>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+) -> Result<dispatcher::DispatchPendingTasksResult, AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_dispatch_pending_tasks_core(&db, &manager, &emitter, squad_run_id).await
 }

--- a/src-tauri/src/commands/squad.rs
+++ b/src-tauri/src/commands/squad.rs
@@ -304,3 +304,102 @@ pub async fn squad_stop_run(
     let emitter = EventEmitter::Tauri(app);
     squad_stop_run_core(&db, &manager, &emitter, squad_run_id).await
 }
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_connect_role(
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, ConnectionManager>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+    role_kind: SquadRoleKind,
+    working_dir: Option<String>,
+) -> Result<SquadRoleRunInfo, AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_connect_role_core(
+        &db,
+        &manager,
+        &emitter,
+        squad_run_id,
+        role_kind,
+        working_dir,
+    )
+    .await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_prompt_role(
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, ConnectionManager>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+    role_kind: SquadRoleKind,
+    task_id: Option<i32>,
+) -> Result<SquadRoleRunInfo, AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_prompt_role_core(&db, &manager, &emitter, squad_run_id, role_kind, task_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_create_task(
+    db: tauri::State<'_, AppDatabase>,
+    squad_run_id: i32,
+    assigned_role_kind: SquadRoleKind,
+    title: String,
+    description: String,
+) -> Result<SquadTaskInfo, AppCommandError> {
+    squad_create_task_core(&db, squad_run_id, assigned_role_kind, title, description).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_update_task_status(
+    db: tauri::State<'_, AppDatabase>,
+    task_id: i32,
+    status: SquadTaskStatus,
+) -> Result<SquadTaskInfo, AppCommandError> {
+    squad_update_task_status_core(&db, task_id, status).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_list_tasks(
+    db: tauri::State<'_, AppDatabase>,
+    squad_run_id: i32,
+) -> Result<Vec<SquadTaskInfo>, AppCommandError> {
+    squad_list_tasks_core(&db, squad_run_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_create_artifact(
+    db: tauri::State<'_, AppDatabase>,
+    squad_run_id: i32,
+    role_kind: Option<SquadRoleKind>,
+    task_id: Option<i32>,
+    artifact_type: SquadArtifactType,
+    title: String,
+    content_json: String,
+) -> Result<SquadArtifactInfo, AppCommandError> {
+    squad_create_artifact_core(
+        &db,
+        squad_run_id,
+        role_kind,
+        task_id,
+        artifact_type,
+        title,
+        content_json,
+    )
+    .await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_list_artifacts(
+    db: tauri::State<'_, AppDatabase>,
+    squad_run_id: i32,
+) -> Result<Vec<SquadArtifactInfo>, AppCommandError> {
+    squad_list_artifacts_core(&db, squad_run_id).await
+}

--- a/src-tauri/src/commands/squad.rs
+++ b/src-tauri/src/commands/squad.rs
@@ -421,6 +421,7 @@ pub async fn squad_list_tasks(
 
 #[cfg(feature = "tauri-runtime")]
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command surface mirrors the underlying _core fn.
 pub async fn squad_create_artifact(
     db: tauri::State<'_, AppDatabase>,
     app: tauri::AppHandle,

--- a/src-tauri/src/commands/squad.rs
+++ b/src-tauri/src/commands/squad.rs
@@ -211,6 +211,17 @@ pub async fn squad_list_artifacts_core(
         .map_err(AppCommandError::from)
 }
 
+pub async fn squad_apply_conductor_output_core(
+    db: &AppDatabase,
+    emitter: &EventEmitter,
+    squad_run_id: i32,
+    raw_text: String,
+) -> Result<dispatcher::ApplyConductorOutputResult, AppCommandError> {
+    dispatcher::apply_conductor_output(db, emitter, squad_run_id, &raw_text)
+        .await
+        .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))
+}
+
 #[cfg(feature = "tauri-runtime")]
 #[tauri::command]
 pub async fn squad_get_role_profiles(
@@ -402,4 +413,16 @@ pub async fn squad_list_artifacts(
     squad_run_id: i32,
 ) -> Result<Vec<SquadArtifactInfo>, AppCommandError> {
     squad_list_artifacts_core(&db, squad_run_id).await
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[tauri::command]
+pub async fn squad_apply_conductor_output(
+    db: tauri::State<'_, AppDatabase>,
+    app: tauri::AppHandle,
+    squad_run_id: i32,
+    raw_text: String,
+) -> Result<dispatcher::ApplyConductorOutputResult, AppCommandError> {
+    let emitter = EventEmitter::Tauri(app);
+    squad_apply_conductor_output_core(&db, &emitter, squad_run_id, raw_text).await
 }

--- a/src-tauri/src/commands/version_control.rs
+++ b/src-tauri/src/commands/version_control.rs
@@ -264,7 +264,7 @@ pub async fn validate_github_token(
         format!("{trimmed_url}/api/v3/user")
     };
 
-    let response = reqwest::Client::new()
+    let response = crate::network::http_client::build_client()
         .get(&api_url)
         .header("Authorization", format!("Bearer {trimmed_token}"))
         .header("User-Agent", "codeg")

--- a/src-tauri/src/db/entities/folder.rs
+++ b/src-tauri/src/db/entities/folder.rs
@@ -10,6 +10,7 @@ pub struct Model {
     pub path: String,
     pub git_branch: Option<String>,
     pub default_agent_type: Option<String>,
+    pub workspace_preset_json: Option<String>,
     pub last_opened_at: DateTimeUtc,
     pub created_at: DateTimeUtc,
     pub updated_at: DateTimeUtc,

--- a/src-tauri/src/db/entities/mod.rs
+++ b/src-tauri/src/db/entities/mod.rs
@@ -9,3 +9,8 @@ pub mod folder_command;
 pub mod model_provider;
 pub mod opened_tab;
 pub mod prelude;
+pub mod squad_artifact;
+pub mod squad_role_profile;
+pub mod squad_role_run;
+pub mod squad_run;
+pub mod squad_task;

--- a/src-tauri/src/db/entities/prelude.rs
+++ b/src-tauri/src/db/entities/prelude.rs
@@ -10,3 +10,8 @@ pub use super::folder::Entity as Folder;
 pub use super::folder_command::Entity as FolderCommand;
 pub use super::model_provider::Entity as ModelProvider;
 pub use super::opened_tab::Entity as OpenedTab;
+pub use super::squad_artifact::Entity as SquadArtifact;
+pub use super::squad_role_profile::Entity as SquadRoleProfile;
+pub use super::squad_role_run::Entity as SquadRoleRun;
+pub use super::squad_run::Entity as SquadRun;
+pub use super::squad_task::Entity as SquadTask;

--- a/src-tauri/src/db/entities/squad_artifact.rs
+++ b/src-tauri/src/db/entities/squad_artifact.rs
@@ -1,0 +1,34 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "squad_artifact")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub squad_run_id: i32,
+    pub squad_role_run_id: Option<i32>,
+    pub task_id: Option<i32>,
+    pub role_kind: Option<String>,
+    pub artifact_type: String,
+    pub title: String,
+    pub content_json: String,
+    pub created_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::squad_run::Entity",
+        from = "Column::SquadRunId",
+        to = "super::squad_run::Column::Id"
+    )]
+    SquadRun,
+}
+
+impl Related<super::squad_run::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SquadRun.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src-tauri/src/db/entities/squad_role_profile.rs
+++ b/src-tauri/src/db/entities/squad_role_profile.rs
@@ -1,0 +1,41 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "squad_role_profile")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub folder_id: i32,
+    pub role_kind: String,
+    pub enabled: bool,
+    pub agent_type: String,
+    pub registry_id: String,
+    pub model_provider_id: Option<i32>,
+    pub model_id: Option<String>,
+    pub env_json: Option<String>,
+    pub system_prompt: String,
+    pub workspace_policy: String,
+    pub default_run_mode: String,
+    pub mode_id: Option<String>,
+    pub config_options_json: Option<String>,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::folder::Entity",
+        from = "Column::FolderId",
+        to = "super::folder::Column::Id"
+    )]
+    Folder,
+}
+
+impl Related<super::folder::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Folder.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src-tauri/src/db/entities/squad_role_run.rs
+++ b/src-tauri/src/db/entities/squad_role_run.rs
@@ -1,0 +1,40 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "squad_role_run")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub squad_run_id: i32,
+    pub role_kind: String,
+    pub role_profile_snapshot_json: String,
+    pub connection_id: Option<String>,
+    pub session_id: Option<String>,
+    pub conversation_id: Option<i32>,
+    pub workspace_path: Option<String>,
+    pub branch_name: Option<String>,
+    pub status: String,
+    pub last_event_at: Option<DateTimeUtc>,
+    pub budget_state_json: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::squad_run::Entity",
+        from = "Column::SquadRunId",
+        to = "super::squad_run::Column::Id"
+    )]
+    SquadRun,
+}
+
+impl Related<super::squad_run::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SquadRun.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src-tauri/src/db/entities/squad_run.rs
+++ b/src-tauri/src/db/entities/squad_run.rs
@@ -1,0 +1,40 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "squad_run")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub folder_id: i32,
+    pub origin_conversation_id: Option<i32>,
+    pub mode: String,
+    pub status: String,
+    pub goal_summary: String,
+    pub base_branch: Option<String>,
+    pub isolation_mode: String,
+    pub started_with_dirty_base: bool,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+    pub started_at: Option<DateTimeUtc>,
+    pub completed_at: Option<DateTimeUtc>,
+    pub cancelled_at: Option<DateTimeUtc>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::folder::Entity",
+        from = "Column::FolderId",
+        to = "super::folder::Column::Id"
+    )]
+    Folder,
+}
+
+impl Related<super::folder::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Folder.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src-tauri/src/db/entities/squad_task.rs
+++ b/src-tauri/src/db/entities/squad_task.rs
@@ -1,0 +1,38 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "squad_task")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub squad_run_id: i32,
+    pub assigned_role_kind: String,
+    pub title: String,
+    pub description: String,
+    pub input_summary: Option<String>,
+    pub status: String,
+    pub depends_on_json: Option<String>,
+    pub priority: i32,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+    pub completed_at: Option<DateTimeUtc>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::squad_run::Entity",
+        from = "Column::SquadRunId",
+        to = "super::squad_run::Column::Id"
+    )]
+    SquadRun,
+}
+
+impl Related<super::squad_run::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::SquadRun.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src-tauri/src/db/migration/m20260424_000001_folder_workspace_preset.rs
+++ b/src-tauri/src/db/migration/m20260424_000001_folder_workspace_preset.rs
@@ -10,11 +10,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Folder::Table)
-                    .add_column(
-                        ColumnDef::new(Folder::WorkspacePresetJson)
-                            .text()
-                            .null(),
-                    )
+                    .add_column(ColumnDef::new(Folder::WorkspacePresetJson).text().null())
                     .to_owned(),
             )
             .await

--- a/src-tauri/src/db/migration/m20260424_000001_folder_workspace_preset.rs
+++ b/src-tauri/src/db/migration/m20260424_000001_folder_workspace_preset.rs
@@ -1,0 +1,39 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Folder::Table)
+                    .add_column(
+                        ColumnDef::new(Folder::WorkspacePresetJson)
+                            .text()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Folder::Table)
+                    .drop_column(Folder::WorkspacePresetJson)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Folder {
+    Table,
+    WorkspacePresetJson,
+}

--- a/src-tauri/src/db/migration/m20260425_000001_squad.rs
+++ b/src-tauri/src/db/migration/m20260425_000001_squad.rs
@@ -1,0 +1,369 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(SquadRoleProfile::Table)
+                    .if_not_exists()
+                    .col(id_col(SquadRoleProfile::Id))
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::FolderId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::RoleKind)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::Enabled)
+                            .boolean()
+                            .not_null()
+                            .default(true),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::AgentType)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::RegistryId)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::ModelProviderId)
+                            .integer()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadRoleProfile::ModelId).string().null())
+                    .col(ColumnDef::new(SquadRoleProfile::EnvJson).text().null())
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::SystemPrompt)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::WorkspacePolicy)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::DefaultRunMode)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SquadRoleProfile::ModeId).string().null())
+                    .col(
+                        ColumnDef::new(SquadRoleProfile::ConfigOptionsJson)
+                            .text()
+                            .null(),
+                    )
+                    .col(timestamp_col(SquadRoleProfile::CreatedAt))
+                    .col(timestamp_col(SquadRoleProfile::UpdatedAt))
+                    .index(
+                        Index::create()
+                            .name("idx_squad_role_profile_folder_role")
+                            .col(SquadRoleProfile::FolderId)
+                            .col(SquadRoleProfile::RoleKind)
+                            .unique(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(SquadRun::Table)
+                    .if_not_exists()
+                    .col(id_col(SquadRun::Id))
+                    .col(ColumnDef::new(SquadRun::FolderId).integer().not_null())
+                    .col(
+                        ColumnDef::new(SquadRun::OriginConversationId)
+                            .integer()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadRun::Mode).string().not_null())
+                    .col(ColumnDef::new(SquadRun::Status).string().not_null())
+                    .col(ColumnDef::new(SquadRun::GoalSummary).text().not_null())
+                    .col(ColumnDef::new(SquadRun::BaseBranch).string().null())
+                    .col(ColumnDef::new(SquadRun::IsolationMode).string().not_null())
+                    .col(
+                        ColumnDef::new(SquadRun::StartedWithDirtyBase)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(timestamp_col(SquadRun::CreatedAt))
+                    .col(timestamp_col(SquadRun::UpdatedAt))
+                    .col(
+                        ColumnDef::new(SquadRun::StartedAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRun::CompletedAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadRun::CancelledAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadRun::ErrorMessage).text().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(SquadRoleRun::Table)
+                    .if_not_exists()
+                    .col(id_col(SquadRoleRun::Id))
+                    .col(
+                        ColumnDef::new(SquadRoleRun::SquadRunId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SquadRoleRun::RoleKind).string().not_null())
+                    .col(
+                        ColumnDef::new(SquadRoleRun::RoleProfileSnapshotJson)
+                            .text()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SquadRoleRun::ConnectionId).string().null())
+                    .col(ColumnDef::new(SquadRoleRun::SessionId).string().null())
+                    .col(
+                        ColumnDef::new(SquadRoleRun::ConversationId)
+                            .integer()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadRoleRun::WorkspacePath).text().null())
+                    .col(ColumnDef::new(SquadRoleRun::BranchName).string().null())
+                    .col(ColumnDef::new(SquadRoleRun::Status).string().not_null())
+                    .col(
+                        ColumnDef::new(SquadRoleRun::LastEventAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadRoleRun::BudgetStateJson).text().null())
+                    .col(ColumnDef::new(SquadRoleRun::ErrorMessage).text().null())
+                    .col(timestamp_col(SquadRoleRun::CreatedAt))
+                    .col(timestamp_col(SquadRoleRun::UpdatedAt))
+                    .index(
+                        Index::create()
+                            .name("idx_squad_role_run_run_role")
+                            .col(SquadRoleRun::SquadRunId)
+                            .col(SquadRoleRun::RoleKind)
+                            .unique(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(SquadTask::Table)
+                    .if_not_exists()
+                    .col(id_col(SquadTask::Id))
+                    .col(ColumnDef::new(SquadTask::SquadRunId).integer().not_null())
+                    .col(
+                        ColumnDef::new(SquadTask::AssignedRoleKind)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SquadTask::Title).string().not_null())
+                    .col(ColumnDef::new(SquadTask::Description).text().not_null())
+                    .col(ColumnDef::new(SquadTask::InputSummary).text().null())
+                    .col(ColumnDef::new(SquadTask::Status).string().not_null())
+                    .col(ColumnDef::new(SquadTask::DependsOnJson).text().null())
+                    .col(
+                        ColumnDef::new(SquadTask::Priority)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(timestamp_col(SquadTask::CreatedAt))
+                    .col(timestamp_col(SquadTask::UpdatedAt))
+                    .col(
+                        ColumnDef::new(SquadTask::CompletedAt)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadTask::ErrorMessage).text().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(SquadArtifact::Table)
+                    .if_not_exists()
+                    .col(id_col(SquadArtifact::Id))
+                    .col(
+                        ColumnDef::new(SquadArtifact::SquadRunId)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SquadArtifact::SquadRoleRunId)
+                            .integer()
+                            .null(),
+                    )
+                    .col(ColumnDef::new(SquadArtifact::TaskId).integer().null())
+                    .col(ColumnDef::new(SquadArtifact::RoleKind).string().null())
+                    .col(
+                        ColumnDef::new(SquadArtifact::ArtifactType)
+                            .string()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(SquadArtifact::Title).string().not_null())
+                    .col(ColumnDef::new(SquadArtifact::ContentJson).text().not_null())
+                    .col(timestamp_col(SquadArtifact::CreatedAt))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(SquadArtifact::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(SquadTask::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(SquadRoleRun::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(SquadRun::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(SquadRoleProfile::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+fn id_col<T: Iden + 'static>(col: T) -> ColumnDef {
+    ColumnDef::new(col)
+        .integer()
+        .not_null()
+        .auto_increment()
+        .primary_key()
+        .to_owned()
+}
+
+fn timestamp_col<T: Iden + 'static>(col: T) -> ColumnDef {
+    ColumnDef::new(col)
+        .timestamp_with_time_zone()
+        .not_null()
+        .to_owned()
+}
+
+#[derive(DeriveIden)]
+enum SquadRoleProfile {
+    Table,
+    Id,
+    FolderId,
+    RoleKind,
+    Enabled,
+    AgentType,
+    RegistryId,
+    ModelProviderId,
+    ModelId,
+    EnvJson,
+    SystemPrompt,
+    WorkspacePolicy,
+    DefaultRunMode,
+    ModeId,
+    ConfigOptionsJson,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum SquadRun {
+    Table,
+    Id,
+    FolderId,
+    OriginConversationId,
+    Mode,
+    Status,
+    GoalSummary,
+    BaseBranch,
+    IsolationMode,
+    StartedWithDirtyBase,
+    CreatedAt,
+    UpdatedAt,
+    StartedAt,
+    CompletedAt,
+    CancelledAt,
+    ErrorMessage,
+}
+
+#[derive(DeriveIden)]
+enum SquadRoleRun {
+    Table,
+    Id,
+    SquadRunId,
+    RoleKind,
+    RoleProfileSnapshotJson,
+    ConnectionId,
+    SessionId,
+    ConversationId,
+    WorkspacePath,
+    BranchName,
+    Status,
+    LastEventAt,
+    BudgetStateJson,
+    ErrorMessage,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum SquadTask {
+    Table,
+    Id,
+    SquadRunId,
+    AssignedRoleKind,
+    Title,
+    Description,
+    InputSummary,
+    Status,
+    DependsOnJson,
+    Priority,
+    CreatedAt,
+    UpdatedAt,
+    CompletedAt,
+    ErrorMessage,
+}
+
+#[derive(DeriveIden)]
+enum SquadArtifact {
+    Table,
+    Id,
+    SquadRunId,
+    SquadRoleRunId,
+    TaskId,
+    RoleKind,
+    ArtifactType,
+    Title,
+    ContentJson,
+    CreatedAt,
+}

--- a/src-tauri/src/db/migration/m20260426_000001_conversation_updated_index.rs
+++ b/src-tauri/src/db/migration/m20260426_000001_conversation_updated_index.rs
@@ -1,0 +1,45 @@
+use sea_orm_migration::prelude::*;
+
+/// Adds a covering index on (deleted_at, updated_at DESC) to speed up
+/// the very common `list_all` query, which orders by `updated_at DESC`
+/// while filtering out soft-deleted rows.
+///
+/// The pre-existing `idx_conversation_deleted_created (deleted_at, created_at)`
+/// does NOT cover the typical sort key (updated_at), forcing SQLite into
+/// a full-table scan + filesort once the table grows.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_conversation_deleted_updated")
+                    .table(Conversation::Table)
+                    .col(Conversation::DeletedAt)
+                    .col(Conversation::UpdatedAt)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("idx_conversation_deleted_updated")
+                    .table(Conversation::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Conversation {
+    Table,
+    DeletedAt,
+    UpdatedAt,
+}

--- a/src-tauri/src/db/migration/mod.rs
+++ b/src-tauri/src/db/migration/mod.rs
@@ -13,6 +13,7 @@ mod m20260420_000001_opened_tabs;
 mod m20260422_000001_folder_sort_order;
 mod m20260423_000001_drop_folder_parent_branch;
 mod m20260424_000001_folder_workspace_preset;
+mod m20260425_000001_squad;
 pub struct Migrator;
 
 #[async_trait::async_trait]
@@ -32,6 +33,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260422_000001_folder_sort_order::Migration),
             Box::new(m20260423_000001_drop_folder_parent_branch::Migration),
             Box::new(m20260424_000001_folder_workspace_preset::Migration),
+            Box::new(m20260425_000001_squad::Migration),
         ]
     }
 }

--- a/src-tauri/src/db/migration/mod.rs
+++ b/src-tauri/src/db/migration/mod.rs
@@ -13,6 +13,7 @@ mod m20260420_000001_opened_tabs;
 mod m20260422_000001_folder_sort_order;
 mod m20260423_000001_drop_folder_parent_branch;
 mod m20260424_000001_folder_workspace_preset;
+mod m20260426_000001_conversation_updated_index;
 pub struct Migrator;
 
 #[async_trait::async_trait]
@@ -32,6 +33,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260422_000001_folder_sort_order::Migration),
             Box::new(m20260423_000001_drop_folder_parent_branch::Migration),
             Box::new(m20260424_000001_folder_workspace_preset::Migration),
+            Box::new(m20260426_000001_conversation_updated_index::Migration),
         ]
     }
 }

--- a/src-tauri/src/db/migration/mod.rs
+++ b/src-tauri/src/db/migration/mod.rs
@@ -12,6 +12,7 @@ mod m20260406_000001_agent_setting_model_provider;
 mod m20260420_000001_opened_tabs;
 mod m20260422_000001_folder_sort_order;
 mod m20260423_000001_drop_folder_parent_branch;
+mod m20260424_000001_folder_workspace_preset;
 pub struct Migrator;
 
 #[async_trait::async_trait]
@@ -30,6 +31,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260420_000001_opened_tabs::Migration),
             Box::new(m20260422_000001_folder_sort_order::Migration),
             Box::new(m20260423_000001_drop_folder_parent_branch::Migration),
+            Box::new(m20260424_000001_folder_workspace_preset::Migration),
         ]
     }
 }

--- a/src-tauri/src/db/service/agent_setting_service.rs
+++ b/src-tauri/src/db/service/agent_setting_service.rs
@@ -32,7 +32,7 @@ fn default_enabled(agent_type: AgentType) -> bool {
             | AgentType::Codex
             | AgentType::Gemini
             | AgentType::OpenCode
-            | AgentType::OpenClaw
+            | AgentType::Generic
             | AgentType::Cline
     )
 }

--- a/src-tauri/src/db/service/conversation_service.rs
+++ b/src-tauri/src/db/service/conversation_service.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use std::collections::HashMap;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, DatabaseConnection, EntityTrait,
     QueryFilter, QueryOrder, Set,
@@ -113,7 +114,10 @@ fn parse_agent_type(s: &str) -> AgentType {
     }
 }
 
-fn conv_to_summary(r: conversation::Model) -> DbConversationSummary {
+fn conv_to_summary(
+    r: conversation::Model,
+    folder: Option<&folder::Model>,
+) -> DbConversationSummary {
     let status = serde_json::to_value(&r.status)
         .ok()
         .and_then(|v| v.as_str().map(String::from))
@@ -121,6 +125,8 @@ fn conv_to_summary(r: conversation::Model) -> DbConversationSummary {
     DbConversationSummary {
         id: r.id,
         folder_id: r.folder_id,
+        folder_name: folder.map(|value| value.name.clone()),
+        folder_path: folder.map(|value| value.path.clone()),
         title: r.title,
         agent_type: parse_agent_type(&r.agent_type),
         status,
@@ -142,8 +148,9 @@ pub async fn get_by_id(
         .one(conn)
         .await?
         .ok_or_else(|| DbError::Migration(format!("Conversation not found: {conversation_id}")))?;
+    let folder = folder::Entity::find_by_id(conv.folder_id).one(conn).await?;
 
-    Ok(conv_to_summary(conv))
+    Ok(conv_to_summary(conv, folder.as_ref()))
 }
 
 pub async fn list_by_folder(
@@ -168,12 +175,6 @@ pub async fn list_by_folder(
     }
 
     // Search by title
-    if let Some(ref s) = search {
-        if !s.is_empty() {
-            query = query.filter(conversation::Column::Title.contains(s));
-        }
-    }
-
     // Filter by status
     if let Some(ref st) = status {
         if let Ok(status_enum) = serde_json::from_value::<conversation::ConversationStatus>(
@@ -190,9 +191,13 @@ pub async fn list_by_folder(
     };
 
     let rows = query.all(conn).await?;
+    let folder_row = folder::Entity::find_by_id(folder_id).one(conn).await?;
+    let mut summaries: Vec<DbConversationSummary> = rows
+        .into_iter()
+        .map(|row| conv_to_summary(row, folder_row.as_ref()))
+        .collect();
 
-    let summaries: Vec<DbConversationSummary> = rows.into_iter().map(conv_to_summary).collect();
-
+    apply_search_and_sort(&mut summaries, search, sort_by, false);
     Ok(summaries)
 }
 
@@ -237,12 +242,6 @@ pub async fn list_all(
         query = query.filter(conversation::Column::AgentType.eq(at_str));
     }
 
-    if let Some(ref s) = search {
-        if !s.is_empty() {
-            query = query.filter(conversation::Column::Title.contains(s));
-        }
-    }
-
     if let Some(ref st) = status {
         if let Ok(status_enum) = serde_json::from_value::<conversation::ConversationStatus>(
             serde_json::Value::String(st.clone()),
@@ -257,5 +256,100 @@ pub async fn list_all(
     };
 
     let rows = query.all(conn).await?;
-    Ok(rows.into_iter().map(conv_to_summary).collect())
+    let folder_rows = folder::Entity::find()
+        .filter(folder::Column::DeletedAt.is_null())
+        .all(conn)
+        .await?;
+    let folder_map: HashMap<i32, folder::Model> =
+        folder_rows.into_iter().map(|row| (row.id, row)).collect();
+
+    let mut summaries = rows
+        .into_iter()
+        .map(|row| conv_to_summary(row.clone(), folder_map.get(&row.folder_id)))
+        .collect::<Vec<_>>();
+    apply_search_and_sort(&mut summaries, search, sort_by, true);
+    Ok(summaries)
+}
+
+fn apply_search_and_sort(
+    rows: &mut Vec<DbConversationSummary>,
+    search: Option<String>,
+    sort_by: Option<String>,
+    use_updated_at: bool,
+) {
+    let search = search
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_lowercase);
+
+    if let Some(query) = search.as_deref() {
+        let mut scored = Vec::with_capacity(rows.len());
+        for row in rows.drain(..) {
+            if let Some(score) = search_score(&row, query) {
+                scored.push((score, row));
+            }
+        }
+
+        scored.sort_by(|left, right| {
+            right
+                .0
+                .cmp(&left.0)
+                .then_with(|| right.1.updated_at.cmp(&left.1.updated_at))
+        });
+        rows.extend(scored.into_iter().map(|(_, row)| row));
+        return;
+    }
+
+    match sort_by.as_deref() {
+        Some("oldest") => rows.sort_by(|left, right| {
+            if use_updated_at {
+                left.updated_at.cmp(&right.updated_at)
+            } else {
+                left.created_at.cmp(&right.created_at)
+            }
+        }),
+        _ => rows.sort_by(|left, right| {
+            if use_updated_at {
+                right.updated_at.cmp(&left.updated_at)
+            } else {
+                right.created_at.cmp(&left.created_at)
+            }
+        }),
+    }
+}
+
+fn search_score(row: &DbConversationSummary, query: &str) -> Option<i32> {
+    let mut score = 0i32;
+
+    score = score.max(field_score(row.title.as_deref(), query, 120, 100, 75));
+    score = score.max(field_score(row.external_id.as_deref(), query, 110, 95, 70));
+    score = score.max(field_score(row.folder_name.as_deref(), query, 90, 80, 60));
+    score = score.max(field_score(row.folder_path.as_deref(), query, 85, 70, 55));
+    score = score.max(field_score(row.model.as_deref(), query, 70, 60, 45));
+    score = score.max(field_score(row.git_branch.as_deref(), query, 65, 55, 40));
+
+    if score == 0 { None } else { Some(score) }
+}
+
+fn field_score(
+    candidate: Option<&str>,
+    query: &str,
+    exact_score: i32,
+    prefix_score: i32,
+    contains_score: i32,
+) -> i32 {
+    let Some(candidate) = candidate.map(str::trim).filter(|value| !value.is_empty()) else {
+        return 0;
+    };
+    let lowered = candidate.to_lowercase();
+    if lowered == query {
+        exact_score
+    } else if lowered.starts_with(query) {
+        prefix_score
+    } else if lowered.contains(query) {
+        contains_score
+    } else {
+        0
+    }
 }

--- a/src-tauri/src/db/service/conversation_service.rs
+++ b/src-tauri/src/db/service/conversation_service.rs
@@ -1,9 +1,9 @@
 use chrono::Utc;
-use std::collections::HashMap;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, DatabaseConnection, EntityTrait,
-    JoinType, QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set,
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, DatabaseConnection, EntityTrait, JoinType,
+    QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set,
 };
+use std::collections::HashMap;
 
 use crate::db::entities::{conversation, folder};
 use crate::db::error::DbError;
@@ -324,7 +324,11 @@ fn search_score(row: &DbConversationSummary, query: &str) -> Option<i32> {
     score = score.max(field_score(row.model.as_deref(), query, 70, 60, 45));
     score = score.max(field_score(row.git_branch.as_deref(), query, 65, 55, 40));
 
-    if score == 0 { None } else { Some(score) }
+    if score == 0 {
+        None
+    } else {
+        Some(score)
+    }
 }
 
 fn field_score(

--- a/src-tauri/src/db/service/conversation_service.rs
+++ b/src-tauri/src/db/service/conversation_service.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use std::collections::HashMap;
 use sea_orm::{
     ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, DatabaseConnection, EntityTrait,
-    QueryFilter, QueryOrder, Set,
+    JoinType, QueryFilter, QueryOrder, QuerySelect, RelationTrait, Set,
 };
 
 use crate::db::entities::{conversation, folder};
@@ -212,25 +212,20 @@ pub async fn list_all(
     sort_by: Option<String>,
     status: Option<String>,
 ) -> Result<Vec<DbConversationSummary>, DbError> {
-    let mut query = conversation::Entity::find().filter(conversation::Column::DeletedAt.is_null());
+    // Join folder so we can (a) cheaply exclude conversations whose folder
+    // was soft-deleted without a separate round-trip, and (b) reuse the
+    // covering index `idx_conversation_deleted_updated`. Previously this
+    // path issued a `SELECT id FROM folder WHERE deleted_at IS NULL` and
+    // shoved the result into an `is_in(...)` clause, which scaled with the
+    // number of folders and forced a wide IN list.
+    let mut query = conversation::Entity::find()
+        .filter(conversation::Column::DeletedAt.is_null())
+        .join(JoinType::InnerJoin, conversation::Relation::Folder.def())
+        .filter(folder::Column::DeletedAt.is_null());
 
-    match folder_ids {
-        Some(ids) if !ids.is_empty() => {
+    if let Some(ids) = folder_ids {
+        if !ids.is_empty() {
             query = query.filter(conversation::Column::FolderId.is_in(ids));
-        }
-        _ => {
-            // Exclude conversations whose folder was soft-deleted.
-            let active_folder_ids: Vec<i32> = folder::Entity::find()
-                .filter(folder::Column::DeletedAt.is_null())
-                .all(conn)
-                .await?
-                .into_iter()
-                .map(|m| m.id)
-                .collect();
-            if active_folder_ids.is_empty() {
-                return Ok(Vec::new());
-            }
-            query = query.filter(conversation::Column::FolderId.is_in(active_folder_ids));
         }
     }
 

--- a/src-tauri/src/db/service/folder_service.rs
+++ b/src-tauri/src/db/service/folder_service.rs
@@ -8,7 +8,7 @@ use sea_orm::{
 use crate::db::entities::folder;
 use crate::db::error::DbError;
 use crate::models::agent::AgentType;
-use crate::models::{FolderDetail, FolderHistoryEntry};
+use crate::models::{FolderDetail, FolderHistoryEntry, WorkspacePreset};
 
 fn to_entry(m: folder::Model) -> FolderHistoryEntry {
     FolderHistoryEntry {
@@ -24,6 +24,11 @@ fn parse_agent_type(s: &Option<String>) -> Option<AgentType> {
         .and_then(|v| serde_json::from_value(serde_json::Value::String(v.to_string())).ok())
 }
 
+fn parse_workspace_preset(s: &Option<String>) -> Option<WorkspacePreset> {
+    s.as_deref()
+        .and_then(|raw| serde_json::from_str::<WorkspacePreset>(raw).ok())
+}
+
 fn to_detail(m: folder::Model) -> FolderDetail {
     let default_agent_type = parse_agent_type(&m.default_agent_type);
     FolderDetail {
@@ -32,6 +37,7 @@ fn to_detail(m: folder::Model) -> FolderDetail {
         path: m.path,
         git_branch: m.git_branch,
         default_agent_type,
+        workspace_preset: parse_workspace_preset(&m.workspace_preset_json),
         last_opened_at: m.last_opened_at,
         sort_order: m.sort_order,
     }
@@ -42,6 +48,19 @@ pub async fn get_folder_by_id(
     folder_id: i32,
 ) -> Result<Option<FolderDetail>, DbError> {
     let row = folder::Entity::find_by_id(folder_id)
+        .filter(folder::Column::DeletedAt.is_null())
+        .one(conn)
+        .await?;
+
+    Ok(row.map(to_detail))
+}
+
+pub async fn get_folder_by_path(
+    conn: &DatabaseConnection,
+    path: &str,
+) -> Result<Option<FolderDetail>, DbError> {
+    let row = folder::Entity::find()
+        .filter(folder::Column::Path.eq(path))
         .filter(folder::Column::DeletedAt.is_null())
         .one(conn)
         .await?;
@@ -85,6 +104,7 @@ pub async fn add_folder(
             path: Set(path.to_string()),
             git_branch: Set(None),
             default_agent_type: Set(None),
+            workspace_preset_json: Set(None),
             last_opened_at: Set(now),
             created_at: Set(now),
             updated_at: Set(now),
@@ -207,4 +227,36 @@ pub async fn reorder_folders(conn: &DatabaseConnection, ids: Vec<i32>) -> Result
         .await?;
 
     Ok(())
+}
+
+pub async fn update_workspace_preset(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+    preset: Option<WorkspacePreset>,
+) -> Result<FolderDetail, DbError> {
+    let row = folder::Entity::find_by_id(folder_id)
+        .filter(folder::Column::DeletedAt.is_null())
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("Folder not found: {folder_id}")))?;
+
+    let mut active = row.into_active_model();
+    let now = Utc::now();
+    let preset_json = preset
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|error| DbError::Migration(error.to_string()))?;
+    let default_agent_type = preset
+        .as_ref()
+        .and_then(|value| value.default_agent_type)
+        .and_then(|value| serde_json::to_value(value).ok())
+        .and_then(|value| value.as_str().map(str::to_string));
+
+    active.workspace_preset_json = Set(preset_json);
+    active.default_agent_type = Set(default_agent_type);
+    active.updated_at = Set(now);
+
+    let updated = active.update(conn).await?;
+    Ok(to_detail(updated))
 }

--- a/src-tauri/src/db/service/import_service.rs
+++ b/src-tauri/src/db/service/import_service.rs
@@ -10,7 +10,7 @@ use crate::parsers::claude::ClaudeParser;
 use crate::parsers::cline::ClineParser;
 use crate::parsers::codex::CodexParser;
 use crate::parsers::gemini::GeminiParser;
-use crate::parsers::openclaw::OpenClawParser;
+use crate::parsers::generic::GenericParser;
 use crate::parsers::opencode::OpenCodeParser;
 use crate::parsers::{path_eq_for_matching, AgentParser};
 
@@ -28,7 +28,7 @@ pub async fn import_local_conversations(
             (AgentType::Codex, Box::new(CodexParser::new())),
             (AgentType::OpenCode, Box::new(OpenCodeParser::new())),
             (AgentType::Gemini, Box::new(GeminiParser::new())),
-            (AgentType::OpenClaw, Box::new(OpenClawParser::new())),
+            (AgentType::Generic, Box::new(GenericParser::new())),
             (AgentType::Cline, Box::new(ClineParser::new())),
         ];
 

--- a/src-tauri/src/db/service/mod.rs
+++ b/src-tauri/src/db/service/mod.rs
@@ -8,4 +8,5 @@ pub mod folder_service;
 pub mod import_service;
 pub mod model_provider_service;
 pub mod sender_context_service;
+pub mod squad_service;
 pub mod tab_service;

--- a/src-tauri/src/db/service/squad_service.rs
+++ b/src-tauri/src/db/service/squad_service.rs
@@ -1,0 +1,605 @@
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::NotSet, ColumnTrait, DatabaseConnection, EntityTrait,
+    IntoActiveModel, QueryFilter, QueryOrder, Set,
+};
+
+use crate::acp::registry;
+use crate::db::entities::{
+    squad_artifact, squad_role_profile, squad_role_run, squad_run, squad_task,
+};
+use crate::db::error::DbError;
+use crate::models::agent::AgentType;
+use crate::models::squad::{
+    SquadArtifactInfo, SquadArtifactType, SquadRoleKind, SquadRoleProfileInfo,
+    SquadRoleProfilePatch, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunInfo, SquadRunMode,
+    SquadRunSnapshot, SquadRunStatus, SquadTaskInfo, SquadTaskStatus, SquadWorkspacePolicy,
+};
+
+fn to_json_string<T: serde::Serialize>(value: &T) -> Result<String, DbError> {
+    serde_json::to_string(value).map_err(|e| DbError::Migration(e.to_string()))
+}
+
+fn from_json_string<T: serde::de::DeserializeOwned>(value: &str) -> Result<T, DbError> {
+    serde_json::from_str(value).map_err(|e| DbError::Migration(e.to_string()))
+}
+
+fn parse_or<T: serde::de::DeserializeOwned>(value: &str, fallback: T) -> T {
+    serde_json::from_str(value).unwrap_or(fallback)
+}
+
+fn serialize_env_json(raw: Option<String>) -> Result<Option<String>, DbError> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let env: BTreeMap<String, String> = serde_json::from_str(trimmed)
+        .map_err(|e| DbError::Migration(format!("invalid env_json: {e}")))?;
+    validate_env_map(&env)?;
+    serde_json::to_string(&env)
+        .map(Some)
+        .map_err(|e| DbError::Migration(e.to_string()))
+}
+
+pub fn validate_env_map(env: &BTreeMap<String, String>) -> Result<(), DbError> {
+    for (key, value) in env {
+        if key.is_empty() || key.len() > 256 {
+            return Err(DbError::Migration(
+                "env key must be 1-256 characters".into(),
+            ));
+        }
+        if value.len() > 8192 {
+            return Err(DbError::Migration(format!("env value too long: {key}")));
+        }
+        if key.contains('\0') || value.contains('\0') {
+            return Err(DbError::Migration(format!("env contains NUL byte: {key}")));
+        }
+        if key == "PATH"
+            || key == "LD_PRELOAD"
+            || key == "LD_LIBRARY_PATH"
+            || key == "LD_AUDIT"
+            || key.starts_with("DYLD_")
+            || key.starts_with("CODEG_")
+        {
+            return Err(DbError::Migration(format!("env key is not allowed: {key}")));
+        }
+    }
+    Ok(())
+}
+
+fn role_profile_info(row: squad_role_profile::Model) -> SquadRoleProfileInfo {
+    SquadRoleProfileInfo {
+        id: row.id,
+        folder_id: row.folder_id,
+        role_kind: parse_or(&row.role_kind, SquadRoleKind::Worker),
+        enabled: row.enabled,
+        agent_type: parse_or(&row.agent_type, AgentType::ClaudeCode),
+        registry_id: row.registry_id,
+        model_provider_id: row.model_provider_id,
+        model_id: row.model_id,
+        env_json: row.env_json,
+        system_prompt: row.system_prompt,
+        workspace_policy: parse_or(&row.workspace_policy, SquadWorkspacePolicy::ReadOnly),
+        default_run_mode: parse_or(&row.default_run_mode, SquadRunMode::Manual),
+        mode_id: row.mode_id,
+        config_options_json: row.config_options_json,
+        created_at: row.created_at.to_rfc3339(),
+        updated_at: row.updated_at.to_rfc3339(),
+    }
+}
+
+fn run_info(row: squad_run::Model) -> SquadRunInfo {
+    SquadRunInfo {
+        id: row.id,
+        folder_id: row.folder_id,
+        origin_conversation_id: row.origin_conversation_id,
+        mode: parse_or(&row.mode, SquadRunMode::Manual),
+        status: parse_or(&row.status, SquadRunStatus::Pending),
+        goal_summary: row.goal_summary,
+        base_branch: row.base_branch,
+        isolation_mode: row.isolation_mode,
+        started_with_dirty_base: row.started_with_dirty_base,
+        created_at: row.created_at.to_rfc3339(),
+        updated_at: row.updated_at.to_rfc3339(),
+        started_at: row.started_at.map(|v| v.to_rfc3339()),
+        completed_at: row.completed_at.map(|v| v.to_rfc3339()),
+        cancelled_at: row.cancelled_at.map(|v| v.to_rfc3339()),
+        error_message: row.error_message,
+    }
+}
+
+fn role_run_info(row: squad_role_run::Model) -> SquadRoleRunInfo {
+    SquadRoleRunInfo {
+        id: row.id,
+        squad_run_id: row.squad_run_id,
+        role_kind: parse_or(&row.role_kind, SquadRoleKind::Worker),
+        role_profile_snapshot_json: row.role_profile_snapshot_json,
+        connection_id: row.connection_id,
+        session_id: row.session_id,
+        conversation_id: row.conversation_id,
+        workspace_path: row.workspace_path,
+        branch_name: row.branch_name,
+        status: parse_or(&row.status, SquadRoleRunStatus::Pending),
+        last_event_at: row.last_event_at.map(|v| v.to_rfc3339()),
+        budget_state_json: row.budget_state_json,
+        error_message: row.error_message,
+        created_at: row.created_at.to_rfc3339(),
+        updated_at: row.updated_at.to_rfc3339(),
+    }
+}
+
+fn task_info(row: squad_task::Model) -> SquadTaskInfo {
+    SquadTaskInfo {
+        id: row.id,
+        squad_run_id: row.squad_run_id,
+        assigned_role_kind: parse_or(&row.assigned_role_kind, SquadRoleKind::Worker),
+        title: row.title,
+        description: row.description,
+        input_summary: row.input_summary,
+        status: parse_or(&row.status, SquadTaskStatus::Pending),
+        depends_on_json: row.depends_on_json,
+        priority: row.priority,
+        created_at: row.created_at.to_rfc3339(),
+        updated_at: row.updated_at.to_rfc3339(),
+        completed_at: row.completed_at.map(|v| v.to_rfc3339()),
+        error_message: row.error_message,
+    }
+}
+
+fn artifact_info(row: squad_artifact::Model) -> SquadArtifactInfo {
+    SquadArtifactInfo {
+        id: row.id,
+        squad_run_id: row.squad_run_id,
+        squad_role_run_id: row.squad_role_run_id,
+        task_id: row.task_id,
+        role_kind: row
+            .role_kind
+            .as_deref()
+            .map(|v| parse_or(v, SquadRoleKind::Worker)),
+        artifact_type: parse_or(&row.artifact_type, SquadArtifactType::Log),
+        title: row.title,
+        content_json: row.content_json,
+        created_at: row.created_at.to_rfc3339(),
+    }
+}
+
+pub async fn seed_role_profiles(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+) -> Result<Vec<SquadRoleProfileInfo>, DbError> {
+    for (index, role_kind) in SquadRoleKind::all().into_iter().enumerate() {
+        let role_kind_json = to_json_string(&role_kind)?;
+        let existing = squad_role_profile::Entity::find()
+            .filter(squad_role_profile::Column::FolderId.eq(folder_id))
+            .filter(squad_role_profile::Column::RoleKind.eq(role_kind_json.clone()))
+            .one(conn)
+            .await?;
+        if existing.is_some() {
+            continue;
+        }
+
+        let agent_type = AgentType::ClaudeCode;
+        let now = Utc::now();
+        let active = squad_role_profile::ActiveModel {
+            id: NotSet,
+            folder_id: Set(folder_id),
+            role_kind: Set(role_kind_json),
+            enabled: Set(true),
+            agent_type: Set(to_json_string(&agent_type)?),
+            registry_id: Set(registry::registry_id_for(agent_type).to_string()),
+            model_provider_id: Set(None),
+            model_id: Set(None),
+            env_json: Set(None),
+            system_prompt: Set(role_kind.default_prompt().to_string()),
+            workspace_policy: Set(to_json_string(&role_kind.default_workspace_policy())?),
+            default_run_mode: Set(to_json_string(&if index == 0 {
+                SquadRunMode::ConductorDispatch
+            } else {
+                SquadRunMode::Manual
+            })?),
+            mode_id: Set(None),
+            config_options_json: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+        };
+        active.insert(conn).await?;
+    }
+    list_role_profiles(conn, folder_id).await
+}
+
+pub async fn list_role_profiles(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+) -> Result<Vec<SquadRoleProfileInfo>, DbError> {
+    let rows = squad_role_profile::Entity::find()
+        .filter(squad_role_profile::Column::FolderId.eq(folder_id))
+        .order_by_asc(squad_role_profile::Column::Id)
+        .all(conn)
+        .await?;
+    Ok(rows.into_iter().map(role_profile_info).collect())
+}
+
+pub async fn update_role_profile(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+    role_kind: SquadRoleKind,
+    patch: SquadRoleProfilePatch,
+) -> Result<SquadRoleProfileInfo, DbError> {
+    let role_kind_json = to_json_string(&role_kind)?;
+    let row = squad_role_profile::Entity::find()
+        .filter(squad_role_profile::Column::FolderId.eq(folder_id))
+        .filter(squad_role_profile::Column::RoleKind.eq(role_kind_json))
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration("squad role profile not found".into()))?;
+    let mut active = row.into_active_model();
+
+    if let Some(v) = patch.enabled {
+        active.enabled = Set(v);
+    }
+    if let Some(v) = patch.agent_type {
+        active.agent_type = Set(to_json_string(&v)?);
+    }
+    if let Some(v) = patch.registry_id {
+        active.registry_id = Set(v);
+    }
+    if let Some(v) = patch.model_provider_id {
+        active.model_provider_id = Set(Some(v));
+    }
+    if let Some(v) = patch.model_id {
+        active.model_id = Set(if v.trim().is_empty() { None } else { Some(v) });
+    }
+    if patch.env_json.is_some() {
+        active.env_json = Set(serialize_env_json(patch.env_json)?);
+    }
+    if let Some(v) = patch.system_prompt {
+        active.system_prompt = Set(v);
+    }
+    if let Some(v) = patch.workspace_policy {
+        active.workspace_policy = Set(to_json_string(&v)?);
+    }
+    if let Some(v) = patch.default_run_mode {
+        active.default_run_mode = Set(to_json_string(&v)?);
+    }
+    if let Some(v) = patch.mode_id {
+        active.mode_id = Set(if v.trim().is_empty() { None } else { Some(v) });
+    }
+    if let Some(v) = patch.config_options_json {
+        active.config_options_json = Set(if v.trim().is_empty() { None } else { Some(v) });
+    }
+    active.updated_at = Set(Utc::now());
+    Ok(role_profile_info(active.update(conn).await?))
+}
+
+pub async fn reset_role_profile(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+    role_kind: SquadRoleKind,
+) -> Result<SquadRoleProfileInfo, DbError> {
+    let role_kind_json = to_json_string(&role_kind)?;
+    if let Some(row) = squad_role_profile::Entity::find()
+        .filter(squad_role_profile::Column::FolderId.eq(folder_id))
+        .filter(squad_role_profile::Column::RoleKind.eq(role_kind_json))
+        .one(conn)
+        .await?
+    {
+        squad_role_profile::Entity::delete_by_id(row.id)
+            .exec(conn)
+            .await?;
+    }
+    seed_role_profiles(conn, folder_id).await?;
+    let profiles = list_role_profiles(conn, folder_id).await?;
+    profiles
+        .into_iter()
+        .find(|profile| profile.role_kind == role_kind)
+        .ok_or_else(|| DbError::Migration("squad role profile reset failed".into()))
+}
+
+pub async fn create_run(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+    origin_conversation_id: Option<i32>,
+    mode: SquadRunMode,
+    goal_summary: String,
+) -> Result<SquadRunSnapshot, DbError> {
+    let profiles = seed_role_profiles(conn, folder_id).await?;
+    let now = Utc::now();
+    let run = squad_run::ActiveModel {
+        id: NotSet,
+        folder_id: Set(folder_id),
+        origin_conversation_id: Set(origin_conversation_id),
+        mode: Set(to_json_string(&mode)?),
+        status: Set(to_json_string(&SquadRunStatus::Pending)?),
+        goal_summary: Set(goal_summary),
+        base_branch: Set(None),
+        isolation_mode: Set("workspace_policy".to_string()),
+        started_with_dirty_base: Set(false),
+        created_at: Set(now),
+        updated_at: Set(now),
+        started_at: Set(None),
+        completed_at: Set(None),
+        cancelled_at: Set(None),
+        error_message: Set(None),
+    }
+    .insert(conn)
+    .await?;
+
+    for profile in profiles.into_iter().filter(|profile| profile.enabled) {
+        let snapshot =
+            serde_json::to_string(&profile).map_err(|e| DbError::Migration(e.to_string()))?;
+        squad_role_run::ActiveModel {
+            id: NotSet,
+            squad_run_id: Set(run.id),
+            role_kind: Set(to_json_string(&profile.role_kind)?),
+            role_profile_snapshot_json: Set(snapshot),
+            connection_id: Set(None),
+            session_id: Set(None),
+            conversation_id: Set(None),
+            workspace_path: Set(None),
+            branch_name: Set(None),
+            status: Set(to_json_string(&SquadRoleRunStatus::Pending)?),
+            last_event_at: Set(None),
+            budget_state_json: Set(None),
+            error_message: Set(None),
+            created_at: Set(now),
+            updated_at: Set(now),
+        }
+        .insert(conn)
+        .await?;
+    }
+    get_run(conn, run.id).await
+}
+
+pub async fn get_run(conn: &DatabaseConnection, run_id: i32) -> Result<SquadRunSnapshot, DbError> {
+    let run = squad_run::Entity::find_by_id(run_id)
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("squad run not found: {run_id}")))?;
+    let roles = squad_role_run::Entity::find()
+        .filter(squad_role_run::Column::SquadRunId.eq(run_id))
+        .order_by_asc(squad_role_run::Column::Id)
+        .all(conn)
+        .await?;
+    let tasks = squad_task::Entity::find()
+        .filter(squad_task::Column::SquadRunId.eq(run_id))
+        .order_by_asc(squad_task::Column::Id)
+        .all(conn)
+        .await?;
+    let artifacts = squad_artifact::Entity::find()
+        .filter(squad_artifact::Column::SquadRunId.eq(run_id))
+        .order_by_asc(squad_artifact::Column::Id)
+        .all(conn)
+        .await?;
+    Ok(SquadRunSnapshot {
+        run: run_info(run),
+        roles: roles.into_iter().map(role_run_info).collect(),
+        tasks: tasks.into_iter().map(task_info).collect(),
+        artifacts: artifacts.into_iter().map(artifact_info).collect(),
+    })
+}
+
+pub async fn list_runs(
+    conn: &DatabaseConnection,
+    folder_id: i32,
+) -> Result<Vec<SquadRunInfo>, DbError> {
+    let rows = squad_run::Entity::find()
+        .filter(squad_run::Column::FolderId.eq(folder_id))
+        .order_by_desc(squad_run::Column::UpdatedAt)
+        .all(conn)
+        .await?;
+    Ok(rows.into_iter().map(run_info).collect())
+}
+
+pub async fn set_run_status(
+    conn: &DatabaseConnection,
+    run_id: i32,
+    status: SquadRunStatus,
+    error_message: Option<String>,
+) -> Result<SquadRunInfo, DbError> {
+    let row = squad_run::Entity::find_by_id(run_id)
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("squad run not found: {run_id}")))?;
+    let now = Utc::now();
+    let mut active = row.into_active_model();
+    active.status = Set(to_json_string(&status)?);
+    active.updated_at = Set(now);
+    if matches!(status, SquadRunStatus::Running) {
+        active.started_at = Set(Some(now));
+    }
+    if matches!(status, SquadRunStatus::Completed | SquadRunStatus::Failed) {
+        active.completed_at = Set(Some(now));
+    }
+    if matches!(status, SquadRunStatus::Cancelled) {
+        active.cancelled_at = Set(Some(now));
+    }
+    active.error_message = Set(error_message);
+    Ok(run_info(active.update(conn).await?))
+}
+
+pub async fn list_role_runs(
+    conn: &DatabaseConnection,
+    run_id: i32,
+) -> Result<Vec<SquadRoleRunInfo>, DbError> {
+    let rows = squad_role_run::Entity::find()
+        .filter(squad_role_run::Column::SquadRunId.eq(run_id))
+        .order_by_asc(squad_role_run::Column::Id)
+        .all(conn)
+        .await?;
+    Ok(rows.into_iter().map(role_run_info).collect())
+}
+
+pub async fn get_role_run(
+    conn: &DatabaseConnection,
+    run_id: i32,
+    role_kind: SquadRoleKind,
+) -> Result<SquadRoleRunInfo, DbError> {
+    let role_kind_json = to_json_string(&role_kind)?;
+    let row = squad_role_run::Entity::find()
+        .filter(squad_role_run::Column::SquadRunId.eq(run_id))
+        .filter(squad_role_run::Column::RoleKind.eq(role_kind_json))
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration("squad role run not found".into()))?;
+    Ok(role_run_info(row))
+}
+
+pub async fn update_role_workspace(
+    conn: &DatabaseConnection,
+    role_run_id: i32,
+    workspace_path: Option<String>,
+    branch_name: Option<String>,
+) -> Result<SquadRoleRunInfo, DbError> {
+    let row = squad_role_run::Entity::find_by_id(role_run_id)
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("squad role run not found: {role_run_id}")))?;
+    let mut active = row.into_active_model();
+    active.workspace_path = Set(workspace_path);
+    active.branch_name = Set(branch_name);
+    active.updated_at = Set(Utc::now());
+    Ok(role_run_info(active.update(conn).await?))
+}
+
+pub async fn update_role_connection(
+    conn: &DatabaseConnection,
+    role_run_id: i32,
+    connection_id: Option<String>,
+    session_id: Option<String>,
+    status: SquadRoleRunStatus,
+    error_message: Option<String>,
+) -> Result<SquadRoleRunInfo, DbError> {
+    let row = squad_role_run::Entity::find_by_id(role_run_id)
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("squad role run not found: {role_run_id}")))?;
+    let now = Utc::now();
+    let mut active = row.into_active_model();
+    active.connection_id = Set(connection_id);
+    active.session_id = Set(session_id);
+    active.status = Set(to_json_string(&status)?);
+    active.last_event_at = Set(Some(now));
+    active.error_message = Set(error_message);
+    active.updated_at = Set(now);
+    Ok(role_run_info(active.update(conn).await?))
+}
+
+pub async fn create_task(
+    conn: &DatabaseConnection,
+    run_id: i32,
+    assigned_role_kind: SquadRoleKind,
+    title: String,
+    description: String,
+) -> Result<SquadTaskInfo, DbError> {
+    let now = Utc::now();
+    let row = squad_task::ActiveModel {
+        id: NotSet,
+        squad_run_id: Set(run_id),
+        assigned_role_kind: Set(to_json_string(&assigned_role_kind)?),
+        title: Set(title),
+        description: Set(description),
+        input_summary: Set(None),
+        status: Set(to_json_string(&SquadTaskStatus::Pending)?),
+        depends_on_json: Set(None),
+        priority: Set(0),
+        created_at: Set(now),
+        updated_at: Set(now),
+        completed_at: Set(None),
+        error_message: Set(None),
+    }
+    .insert(conn)
+    .await?;
+    Ok(task_info(row))
+}
+
+pub async fn list_tasks(
+    conn: &DatabaseConnection,
+    run_id: i32,
+) -> Result<Vec<SquadTaskInfo>, DbError> {
+    let rows = squad_task::Entity::find()
+        .filter(squad_task::Column::SquadRunId.eq(run_id))
+        .order_by_asc(squad_task::Column::Id)
+        .all(conn)
+        .await?;
+    Ok(rows.into_iter().map(task_info).collect())
+}
+
+pub async fn get_task_for_run(
+    conn: &DatabaseConnection,
+    run_id: i32,
+    task_id: i32,
+) -> Result<SquadTaskInfo, DbError> {
+    let row = squad_task::Entity::find()
+        .filter(squad_task::Column::Id.eq(task_id))
+        .filter(squad_task::Column::SquadRunId.eq(run_id))
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("squad task not found: {task_id}")))?;
+    Ok(task_info(row))
+}
+
+pub async fn update_task_status(
+    conn: &DatabaseConnection,
+    task_id: i32,
+    status: SquadTaskStatus,
+) -> Result<SquadTaskInfo, DbError> {
+    let row = squad_task::Entity::find_by_id(task_id)
+        .one(conn)
+        .await?
+        .ok_or_else(|| DbError::Migration(format!("squad task not found: {task_id}")))?;
+    let now = Utc::now();
+    let mut active = row.into_active_model();
+    active.status = Set(to_json_string(&status)?);
+    active.updated_at = Set(now);
+    if matches!(status, SquadTaskStatus::Completed) {
+        active.completed_at = Set(Some(now));
+    }
+    Ok(task_info(active.update(conn).await?))
+}
+
+pub async fn create_artifact(
+    conn: &DatabaseConnection,
+    run_id: i32,
+    role_kind: Option<SquadRoleKind>,
+    task_id: Option<i32>,
+    artifact_type: SquadArtifactType,
+    title: String,
+    content_json: String,
+) -> Result<SquadArtifactInfo, DbError> {
+    let _: serde_json::Value = from_json_string(&content_json)?;
+    let row = squad_artifact::ActiveModel {
+        id: NotSet,
+        squad_run_id: Set(run_id),
+        squad_role_run_id: Set(None),
+        task_id: Set(task_id),
+        role_kind: Set(role_kind.map(|role| to_json_string(&role)).transpose()?),
+        artifact_type: Set(to_json_string(&artifact_type)?),
+        title: Set(title),
+        content_json: Set(content_json),
+        created_at: Set(Utc::now()),
+    }
+    .insert(conn)
+    .await?;
+    Ok(artifact_info(row))
+}
+
+pub async fn list_artifacts(
+    conn: &DatabaseConnection,
+    run_id: i32,
+) -> Result<Vec<SquadArtifactInfo>, DbError> {
+    let rows = squad_artifact::Entity::find()
+        .filter(squad_artifact::Column::SquadRunId.eq(run_id))
+        .order_by_asc(squad_artifact::Column::Id)
+        .all(conn)
+        .await?;
+    Ok(rows.into_iter().map(artifact_info).collect())
+}
+
+pub fn role_profile_from_snapshot(snapshot: &str) -> Result<SquadRoleProfileInfo, DbError> {
+    from_json_string(snapshot)
+}

--- a/src-tauri/src/db/service/squad_service.rs
+++ b/src-tauri/src/db/service/squad_service.rs
@@ -434,6 +434,21 @@ pub async fn list_role_runs(
     Ok(rows.into_iter().map(role_run_info).collect())
 }
 
+/// Look up an active role run by ACP connection id. Returns `None` when
+/// the connection isn't bound to any squad role (typical case — most
+/// ACP connections are normal user-driven conversations, not squad
+/// role processes).
+pub async fn find_role_run_by_connection_id(
+    conn: &DatabaseConnection,
+    connection_id: &str,
+) -> Result<Option<SquadRoleRunInfo>, DbError> {
+    let row = squad_role_run::Entity::find()
+        .filter(squad_role_run::Column::ConnectionId.eq(connection_id))
+        .one(conn)
+        .await?;
+    Ok(row.map(role_run_info))
+}
+
 pub async fn get_role_run(
     conn: &DatabaseConnection,
     run_id: i32,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,9 +27,8 @@ mod tauri_app {
         acp as acp_commands, chat_channel as chat_channel_commands, conversations,
         experts as experts_commands, folder_commands, folders, mcp as mcp_commands,
         model_provider as model_provider_commands, notification, project_boot,
-        runtime as runtime_commands, system_settings,
-        terminal as terminal_commands, version_control, windows,
-        workspace_state as workspace_state_commands,
+        runtime as runtime_commands, system_settings, terminal as terminal_commands,
+        version_control, windows, workspace_state as workspace_state_commands,
     };
     use crate::runtime_monitor::RuntimeMonitor;
     use crate::terminal::manager::TerminalManager;
@@ -60,7 +59,9 @@ mod tauri_app {
             .manage(windows::CommitWindowState::new())
             .manage(windows::MergeWindowState::new())
             .manage(web::WebServerState::new())
-            .manage(std::sync::Arc::new(web::client_owner::WebClientRegistry::new()))
+            .manage(std::sync::Arc::new(
+                web::client_owner::WebClientRegistry::new(),
+            ))
             .manage(std::sync::Arc::new(
                 web::event_bridge::WebEventBroadcaster::new(),
             ))
@@ -74,7 +75,10 @@ mod tauri_app {
                 app.manage(database);
 
                 {
-                    let runtime_monitor = app.state::<std::sync::Arc<RuntimeMonitor>>().inner().clone();
+                    let runtime_monitor = app
+                        .state::<std::sync::Arc<RuntimeMonitor>>()
+                        .inner()
+                        .clone();
                     let connection_manager = app.state::<ConnectionManager>().inner().clone_ref();
                     let web_client_registry = app
                         .state::<std::sync::Arc<web::client_owner::WebClientRegistry>>()
@@ -84,7 +88,8 @@ mod tauri_app {
                     connection_manager.start_orphan_watchdog(web_client_registry);
 
                     let static_dir = web::find_static_dir_tauri(&app.handle());
-                    let build_consistency = crate::build_info::evaluate_build_consistency(&static_dir);
+                    let build_consistency =
+                        crate::build_info::evaluate_build_consistency(&static_dir);
                     runtime_monitor.set_build_consistency(build_consistency.clone());
                     runtime_monitor.record(
                         if build_consistency.status == "ok" {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod network;
 mod parsers;
 pub mod process;
 pub mod runtime_monitor;
+mod squad;
 mod terminal;
 pub mod web;
 pub mod workspace_state;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ mod network;
 mod parsers;
 pub mod process;
 pub mod runtime_monitor;
-mod squad;
+pub mod squad;
 mod terminal;
 pub mod web;
 pub mod workspace_state;
@@ -165,6 +165,27 @@ mod tauri_app {
                     tauri::async_runtime::spawn(async move {
                         ccm_ref.start_background(br, db_conn, cm, emitter).await;
                     });
+                }
+
+                // Start squad ACP→pipeline bridge: eavesdrops on the
+                // event broadcast and, when a squad-bound connection
+                // completes a turn, records artifacts and dispatches
+                // any newly-unblocked tasks. Detached; failure is
+                // logged in-task and never propagated.
+                {
+                    let db_conn = app.state::<db::AppDatabase>().conn.clone();
+                    let cm = app.state::<ConnectionManager>().clone_ref();
+                    let br = app
+                        .state::<std::sync::Arc<web::event_bridge::WebEventBroadcaster>>()
+                        .inner()
+                        .clone();
+                    let emitter = web::event_bridge::EventEmitter::Tauri(app.handle().clone());
+                    crate::squad::turn_listener::spawn(
+                        db::AppDatabase { conn: db_conn },
+                        cm,
+                        emitter,
+                        br,
+                    );
                 }
 
                 // Single-window workspace: ensure the main window exists.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod acp;
 mod app_error;
 pub mod app_state;
+pub mod build_info;
 pub mod chat_channel;
 pub mod commands;
 pub mod db;
@@ -11,6 +12,7 @@ mod models;
 mod network;
 mod parsers;
 pub mod process;
+pub mod runtime_monitor;
 mod terminal;
 pub mod web;
 pub mod workspace_state;
@@ -24,10 +26,12 @@ mod tauri_app {
     use crate::commands::{
         acp as acp_commands, chat_channel as chat_channel_commands, conversations,
         experts as experts_commands, folder_commands, folders, mcp as mcp_commands,
-        model_provider as model_provider_commands, notification, project_boot, system_settings,
+        model_provider as model_provider_commands, notification, project_boot,
+        runtime as runtime_commands, system_settings,
         terminal as terminal_commands, version_control, windows,
         workspace_state as workspace_state_commands,
     };
+    use crate::runtime_monitor::RuntimeMonitor;
     use crate::terminal::manager::TerminalManager;
     use crate::{db, network, process, web};
     use tauri::Manager;
@@ -56,9 +60,11 @@ mod tauri_app {
             .manage(windows::CommitWindowState::new())
             .manage(windows::MergeWindowState::new())
             .manage(web::WebServerState::new())
+            .manage(std::sync::Arc::new(web::client_owner::WebClientRegistry::new()))
             .manage(std::sync::Arc::new(
                 web::event_bridge::WebEventBroadcaster::new(),
             ))
+            .manage(std::sync::Arc::new(RuntimeMonitor::new()))
             .setup(|app| {
                 let app_data_dir = app.path().app_data_dir()?;
                 let app_version = env!("CARGO_PKG_VERSION");
@@ -66,6 +72,40 @@ mod tauri_app {
                     tauri::async_runtime::block_on(db::init_database(&app_data_dir, app_version))
                         .map_err(|e| e.to_string())?;
                 app.manage(database);
+
+                {
+                    let runtime_monitor = app.state::<std::sync::Arc<RuntimeMonitor>>().inner().clone();
+                    let connection_manager = app.state::<ConnectionManager>().inner().clone_ref();
+                    let web_client_registry = app
+                        .state::<std::sync::Arc<web::client_owner::WebClientRegistry>>()
+                        .inner()
+                        .clone();
+                    connection_manager.attach_runtime_monitor(runtime_monitor.clone());
+                    connection_manager.start_orphan_watchdog(web_client_registry);
+
+                    let static_dir = web::find_static_dir_tauri(&app.handle());
+                    let build_consistency = crate::build_info::evaluate_build_consistency(&static_dir);
+                    runtime_monitor.set_build_consistency(build_consistency.clone());
+                    runtime_monitor.record(
+                        if build_consistency.status == "ok" {
+                            "info"
+                        } else {
+                            "warn"
+                        },
+                        "startup",
+                        build_consistency.message.clone(),
+                        None,
+                    );
+
+                    let security = crate::build_info::build_security_info(
+                        "desktop",
+                        None,
+                        true,
+                        Some(&static_dir),
+                        Some(&app_data_dir),
+                    );
+                    runtime_monitor.set_security(security);
+                }
 
                 // Restore and apply saved system proxy settings before any network operation.
                 let db = app.state::<db::AppDatabase>();
@@ -220,6 +260,7 @@ mod tauri_app {
                 folders::open_folder,
                 folders::open_folder_by_id,
                 folders::remove_folder_from_workspace,
+                folders::update_folder_workspace_preset,
                 folders::reorder_folders,
                 folders::add_folder_to_history,
                 folders::remove_folder_from_history,
@@ -300,6 +341,8 @@ mod tauri_app {
                 system_settings::update_system_proxy_settings,
                 system_settings::get_system_language_settings,
                 system_settings::update_system_language_settings,
+                runtime_commands::get_runtime_diagnostics,
+                runtime_commands::get_acp_cache_inventory,
                 version_control::detect_git,
                 version_control::test_git_path,
                 version_control::get_git_settings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,6 +461,7 @@ mod tauri_app {
                 squad_commands::squad_list_tasks,
                 squad_commands::squad_create_artifact,
                 squad_commands::squad_list_artifacts,
+                squad_commands::squad_apply_conductor_output,
             ])
             .build(tauri::generate_context!())
             .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,8 +28,9 @@ mod tauri_app {
         acp as acp_commands, chat_channel as chat_channel_commands, conversations,
         experts as experts_commands, folder_commands, folders, mcp as mcp_commands,
         model_provider as model_provider_commands, notification, project_boot,
-        runtime as runtime_commands, system_settings, terminal as terminal_commands,
-        version_control, windows, workspace_state as workspace_state_commands,
+        runtime as runtime_commands, squad as squad_commands, system_settings,
+        terminal as terminal_commands, version_control, windows,
+        workspace_state as workspace_state_commands,
     };
     use crate::runtime_monitor::RuntimeMonitor;
     use crate::terminal::manager::TerminalManager;
@@ -444,6 +445,22 @@ mod tauri_app {
                 web::stop_web_server,
                 web::get_web_server_status,
                 web::get_web_service_config,
+                squad_commands::squad_get_role_profiles,
+                squad_commands::squad_seed_role_profiles,
+                squad_commands::squad_update_role_profile,
+                squad_commands::squad_reset_role_profile,
+                squad_commands::squad_create_run,
+                squad_commands::squad_get_run,
+                squad_commands::squad_list_runs,
+                squad_commands::squad_start_run,
+                squad_commands::squad_stop_run,
+                squad_commands::squad_connect_role,
+                squad_commands::squad_prompt_role,
+                squad_commands::squad_create_task,
+                squad_commands::squad_update_task_status,
+                squad_commands::squad_list_tasks,
+                squad_commands::squad_create_artifact,
+                squad_commands::squad_list_artifacts,
             ])
             .build(tauri::generate_context!())
             .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -463,6 +463,7 @@ mod tauri_app {
                 squad_commands::squad_list_artifacts,
                 squad_commands::squad_apply_conductor_output,
                 squad_commands::squad_dispatch_pending_tasks,
+                squad_commands::squad_record_turn_artifacts,
             ])
             .build(tauri::generate_context!())
             .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -462,6 +462,7 @@ mod tauri_app {
                 squad_commands::squad_create_artifact,
                 squad_commands::squad_list_artifacts,
                 squad_commands::squad_apply_conductor_output,
+                squad_commands::squad_dispatch_pending_tasks,
             ])
             .build(tauri::generate_context!())
             .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,7 +89,7 @@ mod tauri_app {
                     connection_manager.attach_runtime_monitor(runtime_monitor.clone());
                     connection_manager.start_orphan_watchdog(web_client_registry);
 
-                    let static_dir = web::find_static_dir_tauri(&app.handle());
+                    let static_dir = web::find_static_dir_tauri(app.handle());
                     let build_consistency =
                         crate::build_info::evaluate_build_consistency(&static_dir);
                     runtime_monitor.set_build_consistency(build_consistency.clone());

--- a/src-tauri/src/models/agent.rs
+++ b/src-tauri/src/models/agent.rs
@@ -8,7 +8,7 @@ pub enum AgentType {
     Codex,
     OpenCode,
     Gemini,
-    OpenClaw,
+    Generic,
     Cline,
 }
 
@@ -19,8 +19,21 @@ impl fmt::Display for AgentType {
             AgentType::Codex => write!(f, "Codex CLI"),
             AgentType::OpenCode => write!(f, "OpenCode"),
             AgentType::Gemini => write!(f, "Gemini CLI"),
-            AgentType::OpenClaw => write!(f, "OpenClaw"),
+            AgentType::Generic => write!(f, "Generic"),
             AgentType::Cline => write!(f, "Cline"),
         }
+    }
+}
+
+impl AgentType {
+    pub const fn all() -> [AgentType; 6] {
+        [
+            AgentType::ClaudeCode,
+            AgentType::Codex,
+            AgentType::OpenCode,
+            AgentType::Gemini,
+            AgentType::Generic,
+            AgentType::Cline,
+        ]
     }
 }

--- a/src-tauri/src/models/conversation.rs
+++ b/src-tauri/src/models/conversation.rs
@@ -22,6 +22,8 @@ pub struct ConversationSummary {
 pub struct DbConversationSummary {
     pub id: i32,
     pub folder_id: i32,
+    pub folder_name: Option<String>,
+    pub folder_path: Option<String>,
     pub title: Option<String>,
     pub agent_type: AgentType,
     pub status: String,

--- a/src-tauri/src/models/folder.rs
+++ b/src-tauri/src/models/folder.rs
@@ -1,7 +1,20 @@
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::agent::AgentType;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct WorkspacePreset {
+    pub default_agent_type: Option<AgentType>,
+    pub model_provider_id: Option<i32>,
+    pub approval_policy: Option<String>,
+    pub skill_ids: Vec<String>,
+    pub mcp_server_ids: Vec<String>,
+    pub env_overrides: BTreeMap<String, String>,
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FolderHistoryEntry {
@@ -18,6 +31,7 @@ pub struct FolderDetail {
     pub path: String,
     pub git_branch: Option<String>,
     pub default_agent_type: Option<AgentType>,
+    pub workspace_preset: Option<WorkspacePreset>,
     pub last_opened_at: DateTime<Utc>,
     pub sort_order: i32,
 }

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod conversation;
 pub mod folder;
 pub mod message;
 pub mod model_provider;
+pub mod squad;
 pub mod system;
 
 pub use agent::AgentType;

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -14,7 +14,7 @@ pub use conversation::{
     DbConversationDetail, DbConversationSummary, FolderInfo, ImportResult, SessionStats,
     SidebarData,
 };
-pub use folder::{FolderCommandInfo, FolderDetail, FolderHistoryEntry, OpenedTab};
+pub use folder::{FolderCommandInfo, FolderDetail, FolderHistoryEntry, OpenedTab, WorkspacePreset};
 pub use message::{
     AgentExecutionStats, AgentToolCall, ContentBlock, MessageRole, MessageTurn, TurnRole,
     TurnUsage, UnifiedMessage,

--- a/src-tauri/src/models/squad.rs
+++ b/src-tauri/src/models/squad.rs
@@ -1,0 +1,242 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::models::agent::AgentType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadRoleKind {
+    Conductor,
+    Frontend,
+    Backend,
+    Worker,
+}
+
+impl SquadRoleKind {
+    pub const fn all() -> [Self; 4] {
+        [Self::Conductor, Self::Frontend, Self::Backend, Self::Worker]
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Conductor => "conductor",
+            Self::Frontend => "frontend",
+            Self::Backend => "backend",
+            Self::Worker => "worker",
+        }
+    }
+
+    pub const fn default_workspace_policy(self) -> SquadWorkspacePolicy {
+        match self {
+            Self::Conductor => SquadWorkspacePolicy::ReadOnly,
+            Self::Frontend | Self::Backend | Self::Worker => SquadWorkspacePolicy::WriteIsolated,
+        }
+    }
+
+    pub const fn default_prompt(self) -> &'static str {
+        match self {
+            Self::Conductor => "Coordinate the squad, break the user goal into safe tasks, and summarize decisions and blockers.",
+            Self::Frontend => "Act as the frontend role. Focus on UI, React, TypeScript, state management, accessibility, and i18n.",
+            Self::Backend => "Act as the backend role. Focus on Rust, database schema, API boundaries, runtime safety, and correctness.",
+            Self::Worker => "Act as the implementation worker. Execute scoped coding tasks carefully and report exact changed files and validation results.",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadRunMode {
+    Manual,
+    ConductorDispatch,
+    AllHandsReview,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadRunStatus {
+    Pending,
+    Preparing,
+    Running,
+    Blocked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadRoleRunStatus {
+    Pending,
+    Preparing,
+    Connecting,
+    Connected,
+    Prompting,
+    Stopped,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadTaskStatus {
+    Pending,
+    Assigned,
+    Running,
+    Blocked,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadArtifactType {
+    Summary,
+    Diff,
+    FilePatch,
+    Review,
+    Terminal,
+    Plan,
+    Warning,
+    Log,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SquadWorkspacePolicy {
+    ReadOnly,
+    WriteIsolated,
+    WriteShared,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadRoleProfileInfo {
+    pub id: i32,
+    pub folder_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub enabled: bool,
+    pub agent_type: AgentType,
+    pub registry_id: String,
+    pub model_provider_id: Option<i32>,
+    pub model_id: Option<String>,
+    pub env_json: Option<String>,
+    pub system_prompt: String,
+    pub workspace_policy: SquadWorkspacePolicy,
+    pub default_run_mode: SquadRunMode,
+    pub mode_id: Option<String>,
+    pub config_options_json: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadRoleProfilePatch {
+    pub enabled: Option<bool>,
+    pub agent_type: Option<AgentType>,
+    pub registry_id: Option<String>,
+    pub model_provider_id: Option<i32>,
+    pub model_id: Option<String>,
+    pub env_json: Option<String>,
+    pub system_prompt: Option<String>,
+    pub workspace_policy: Option<SquadWorkspacePolicy>,
+    pub default_run_mode: Option<SquadRunMode>,
+    pub mode_id: Option<String>,
+    pub config_options_json: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadRunInfo {
+    pub id: i32,
+    pub folder_id: i32,
+    pub origin_conversation_id: Option<i32>,
+    pub mode: SquadRunMode,
+    pub status: SquadRunStatus,
+    pub goal_summary: String,
+    pub base_branch: Option<String>,
+    pub isolation_mode: String,
+    pub started_with_dirty_base: bool,
+    pub created_at: String,
+    pub updated_at: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub cancelled_at: Option<String>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadRoleRunInfo {
+    pub id: i32,
+    pub squad_run_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub role_profile_snapshot_json: String,
+    pub connection_id: Option<String>,
+    pub session_id: Option<String>,
+    pub conversation_id: Option<i32>,
+    pub workspace_path: Option<String>,
+    pub branch_name: Option<String>,
+    pub status: SquadRoleRunStatus,
+    pub last_event_at: Option<String>,
+    pub budget_state_json: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadTaskInfo {
+    pub id: i32,
+    pub squad_run_id: i32,
+    pub assigned_role_kind: SquadRoleKind,
+    pub title: String,
+    pub description: String,
+    pub input_summary: Option<String>,
+    pub status: SquadTaskStatus,
+    pub depends_on_json: Option<String>,
+    pub priority: i32,
+    pub created_at: String,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadArtifactInfo {
+    pub id: i32,
+    pub squad_run_id: i32,
+    pub squad_role_run_id: Option<i32>,
+    pub task_id: Option<i32>,
+    pub role_kind: Option<SquadRoleKind>,
+    pub artifact_type: SquadArtifactType,
+    pub title: String,
+    pub content_json: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadRunSnapshot {
+    pub run: SquadRunInfo,
+    pub roles: Vec<SquadRoleRunInfo>,
+    pub tasks: Vec<SquadTaskInfo>,
+    pub artifacts: Vec<SquadArtifactInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SquadEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub squad_run_id: i32,
+    pub seq: i64,
+    pub at: DateTime<Utc>,
+    pub role_kind: Option<SquadRoleKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+}

--- a/src-tauri/src/network/http_client.rs
+++ b/src-tauri/src/network/http_client.rs
@@ -1,0 +1,111 @@
+//! Centralized reqwest client factory.
+//!
+//! Every outbound HTTP call inside this crate must go through one of the
+//! helpers in this module so that user-configured proxy settings are honored
+//! consistently. Previously each call site built its own client and relied on
+//! `HTTP_PROXY` / `HTTPS_PROXY` env vars being mutated at runtime — that path
+//! is unsound under multi-threading (Rust 2024 marks `set_var` `unsafe`) and
+//! never affected long-lived clients which read env vars only at construction.
+//!
+//! The factory keeps a single `RwLock<SystemProxySettings>` snapshot. Reads
+//! are cheap, writes happen only when the user toggles proxy settings or at
+//! startup. Each call to [`build_client`] / [`build_client_with`] reads the
+//! current snapshot and injects an explicit `reqwest::Proxy` so the resulting
+//! client has its proxy baked in.
+
+use std::sync::OnceLock;
+use std::sync::RwLock;
+use std::time::Duration;
+
+use crate::models::SystemProxySettings;
+
+fn snapshot_lock() -> &'static RwLock<SystemProxySettings> {
+    static SNAPSHOT: OnceLock<RwLock<SystemProxySettings>> = OnceLock::new();
+    SNAPSHOT.get_or_init(|| RwLock::new(SystemProxySettings::default()))
+}
+
+/// Update the global proxy snapshot. Subsequent calls to [`build_client`] will
+/// honor the new settings; previously constructed clients keep their old
+/// proxy. Callers that want to force-rebuild should hold their own
+/// `Arc<reqwest::Client>` and recreate it.
+pub fn set_proxy_settings(settings: SystemProxySettings) {
+    if let Ok(mut guard) = snapshot_lock().write() {
+        *guard = settings;
+    }
+}
+
+/// Read the current proxy snapshot.
+pub fn current_proxy_settings() -> SystemProxySettings {
+    snapshot_lock()
+        .read()
+        .map(|guard| guard.clone())
+        .unwrap_or_default()
+}
+
+/// Builder configuration for an HTTP client. Defaults match the previous
+/// per-site values used across the codebase.
+#[derive(Debug, Clone)]
+pub struct ClientConfig {
+    pub connect_timeout: Duration,
+    pub timeout: Duration,
+    pub user_agent: Option<String>,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(10),
+            timeout: Duration::from_secs(30),
+            user_agent: None,
+        }
+    }
+}
+
+impl ClientConfig {
+    pub fn with_timeouts(connect: Duration, total: Duration) -> Self {
+        Self {
+            connect_timeout: connect,
+            timeout: total,
+            ..Self::default()
+        }
+    }
+
+    pub fn user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(ua.into());
+        self
+    }
+}
+
+fn proxy_for(snapshot: &SystemProxySettings) -> Option<reqwest::Proxy> {
+    if !snapshot.enabled {
+        return None;
+    }
+    let url = snapshot.proxy_url.as_deref()?.trim();
+    if url.is_empty() {
+        return None;
+    }
+    reqwest::Proxy::all(url).ok()
+}
+
+/// Build a `reqwest::Client` using the given config and the current proxy
+/// snapshot. Falls back to an unconfigured client if the builder fails — the
+/// same behavior the prior `unwrap_or_default()` callers relied on.
+pub fn build_client_with(config: ClientConfig) -> reqwest::Client {
+    let snapshot = current_proxy_settings();
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(config.connect_timeout)
+        .timeout(config.timeout);
+    if let Some(ua) = &config.user_agent {
+        builder = builder.user_agent(ua);
+    }
+    if let Some(proxy) = proxy_for(&snapshot) {
+        builder = builder.proxy(proxy);
+    }
+    builder.build().unwrap_or_default()
+}
+
+/// Convenience helper for ad-hoc one-shot requests (used to be
+/// `reqwest::Client::new()` at call sites).
+pub fn build_client() -> reqwest::Client {
+    build_client_with(ClientConfig::default())
+}

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -1,1 +1,2 @@
+pub mod http_client;
 pub mod proxy;

--- a/src-tauri/src/network/proxy.rs
+++ b/src-tauri/src/network/proxy.rs
@@ -1,5 +1,6 @@
 use crate::app_error::AppCommandError;
 use crate::models::SystemProxySettings;
+use crate::network::http_client;
 
 const PROXY_ENV_KEYS: [&str; 6] = [
     "HTTP_PROXY",
@@ -10,6 +11,17 @@ const PROXY_ENV_KEYS: [&str; 6] = [
     "all_proxy",
 ];
 
+/// Apply proxy settings.
+///
+/// Two effects:
+/// 1. Pushes the snapshot into the [`http_client`] factory so all reqwest
+///    calls inside this process pick up the new proxy on next build.
+/// 2. Mirrors into the process environment so child processes (`git`, ACP
+///    binaries, MCP subprocesses) inherit it. The env mutation runs only
+///    on settings changes, which under Tauri/Axum happens from the command
+///    handler thread; that's still racy in theory but matches prior
+///    behavior — the alternative (drop env vars entirely) would silently
+///    break every spawned subprocess that relies on proxy.
 pub fn apply_system_proxy_settings(settings: &SystemProxySettings) -> Result<(), AppCommandError> {
     if settings.enabled {
         let proxy_url = settings
@@ -24,6 +36,8 @@ pub fn apply_system_proxy_settings(settings: &SystemProxySettings) -> Result<(),
             })?;
 
         for key in PROXY_ENV_KEYS {
+            // SAFETY: see module-level comment. Called from a command handler
+            // before child processes are spawned for the new request.
             unsafe {
                 std::env::set_var(key, proxy_url);
             }
@@ -32,11 +46,13 @@ pub fn apply_system_proxy_settings(settings: &SystemProxySettings) -> Result<(),
         clear_proxy_env();
     }
 
+    http_client::set_proxy_settings(settings.clone());
     Ok(())
 }
 
 pub fn clear_proxy_env() {
     for key in PROXY_ENV_KEYS {
+        // SAFETY: see apply_system_proxy_settings.
         unsafe {
             std::env::remove_var(key);
         }

--- a/src-tauri/src/parsers/generic.rs
+++ b/src-tauri/src/parsers/generic.rs
@@ -16,7 +16,7 @@ use crate::parsers::{
 };
 
 /// Regex to strip the "Sender (untrusted metadata):" block and optional
-/// timestamp prefix from OpenClaw user messages.
+/// timestamp prefix from Generic user messages.
 fn sender_block_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| Regex::new(r"(?s)^Sender \(untrusted metadata\):\s*```[^`]*```\s*").unwrap())
@@ -38,7 +38,7 @@ fn working_dir_extract_regex() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"\[Working directory:\s*([^\]]+)\]").unwrap())
 }
 
-/// Extract the working directory from OpenClaw user message text.
+/// Extract the working directory from Generic user message text.
 /// Returns the expanded path (~ replaced with home dir).
 fn extract_working_dir(text: &str) -> Option<String> {
     let captures = working_dir_extract_regex().captures(text)?;
@@ -55,8 +55,8 @@ fn extract_working_dir(text: &str) -> Option<String> {
     Some(raw_path.to_string())
 }
 
-/// Strip OpenClaw user message prefix metadata.
-fn strip_openclaw_user_prefix(text: &str) -> String {
+/// Strip Generic user message prefix metadata.
+fn strip_generic_user_prefix(text: &str) -> String {
     let cleaned = sender_block_regex().replace(text, "");
     let cleaned = timestamp_prefix_regex().replace(&cleaned, "");
     let cleaned = working_dir_prefix_regex().replace(&cleaned, "");
@@ -338,15 +338,15 @@ impl JTree {
 
 // ── Parser ─────────────────────────────────────────────────────────────
 
-pub struct OpenClawParser {
+pub struct GenericParser {
     base_dir: PathBuf,
 }
 
-impl OpenClawParser {
+impl GenericParser {
     pub fn new() -> Self {
         let base_dir = dirs::home_dir()
             .unwrap_or_default()
-            .join(".openclaw")
+            .join(".generic")
             .join("agents");
         Self { base_dir }
     }
@@ -435,7 +435,7 @@ impl OpenClawParser {
                                 cwd = Some(wd);
                             }
                             if title.is_none() {
-                                let cleaned = strip_openclaw_user_prefix(&text);
+                                let cleaned = strip_generic_user_prefix(&text);
                                 if !cleaned.is_empty() {
                                     title = Some(truncate_str(&cleaned, 100));
                                 }
@@ -473,7 +473,7 @@ impl OpenClawParser {
 
             summaries.push(ConversationSummary {
                 id: conversation_id,
-                agent_type: AgentType::OpenClaw,
+                agent_type: AgentType::Generic,
                 folder_path,
                 folder_name,
                 title,
@@ -663,7 +663,7 @@ impl OpenClawParser {
 
         let summary = ConversationSummary {
             id: conversation_id.to_string(),
-            agent_type: AgentType::OpenClaw,
+            agent_type: AgentType::Generic,
             folder_path,
             folder_name,
             title,
@@ -805,7 +805,7 @@ impl OpenClawParser {
     }
 }
 
-impl AgentParser for OpenClawParser {
+impl AgentParser for GenericParser {
     fn list_conversations(&self) -> Result<Vec<ConversationSummary>, ParseError> {
         let mut conversations = Vec::new();
 
@@ -917,7 +917,7 @@ fn extract_user_content(value: &serde_json::Value) -> Vec<ContentBlock> {
             let block_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
             if block_type == "text" {
                 if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
-                    let cleaned = strip_openclaw_user_prefix(text);
+                    let cleaned = strip_generic_user_prefix(text);
                     if !cleaned.is_empty() {
                         blocks.push(ContentBlock::Text { text: cleaned });
                     }
@@ -1141,13 +1141,13 @@ mod tests {
     #[test]
     fn strips_sender_block_and_timestamp() {
         let input = "Sender (untrusted metadata):\n```json\n{\"label\": \"test\"}\n```\n\n[Tue 2026-03-17 12:56 GMT+8] Hello world";
-        assert_eq!(strip_openclaw_user_prefix(input), "Hello world");
+        assert_eq!(strip_generic_user_prefix(input), "Hello world");
     }
 
     #[test]
     fn strips_timestamp_only() {
         let input = "[Tue 2026-03-17 12:56 GMT+8] Hello";
-        assert_eq!(strip_openclaw_user_prefix(input), "Hello");
+        assert_eq!(strip_generic_user_prefix(input), "Hello");
     }
 
     #[test]
@@ -1167,17 +1167,17 @@ mod tests {
     #[test]
     fn strips_working_dir_prefix() {
         let input = "[Tue 2026-03-17 12:58 GMT+8] [Working directory: ~/projects/test]\n\nHello";
-        let result = strip_openclaw_user_prefix(input);
+        let result = strip_generic_user_prefix(input);
         assert_eq!(result, "Hello");
     }
 
     #[test]
     fn preserves_plain_text() {
-        assert_eq!(strip_openclaw_user_prefix("Hello world"), "Hello world");
+        assert_eq!(strip_generic_user_prefix("Hello world"), "Hello world");
     }
 
     #[test]
-    fn extracts_usage_from_openclaw_format() {
+    fn extracts_usage_from_generic_format() {
         let value = json!({
             "message": {
                 "usage": {
@@ -1242,9 +1242,9 @@ mod tests {
     }
 
     #[test]
-    fn parses_openclaw_conversation_detail_with_tree() {
+    fn parses_generic_conversation_detail_with_tree() {
         let path = std::env::temp_dir().join(format!(
-            "codeg-openclaw-tree-{}.jsonl",
+            "codeg-generic-tree-{}.jsonl",
             uuid::Uuid::new_v4()
         ));
         let mut file = fs::File::create(&path).expect("create temp jsonl");
@@ -1268,7 +1268,7 @@ mod tests {
         ).unwrap();
 
         let detail =
-            OpenClawParser::parse_conversation_detail(&path, "test/test-session", None, None)
+            GenericParser::parse_conversation_detail(&path, "test/test-session", None, None)
                 .expect("parse detail");
         fs::remove_file(&path).unwrap();
 
@@ -1305,7 +1305,7 @@ mod tests {
         //   u1 → a1 → u2 → a2  (branch 1: "Hello" conversation)
         //              ↘ u3 → a3  (branch 2: "Bye" conversation, forked from a1)
         let path = std::env::temp_dir().join(format!(
-            "codeg-openclaw-branches-{}.jsonl",
+            "codeg-generic-branches-{}.jsonl",
             uuid::Uuid::new_v4()
         ));
         let mut file = fs::File::create(&path).expect("create temp jsonl");

--- a/src-tauri/src/parsers/generic.rs
+++ b/src-tauri/src/parsers/generic.rs
@@ -1243,10 +1243,8 @@ mod tests {
 
     #[test]
     fn parses_generic_conversation_detail_with_tree() {
-        let path = std::env::temp_dir().join(format!(
-            "codeg-generic-tree-{}.jsonl",
-            uuid::Uuid::new_v4()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("codeg-generic-tree-{}.jsonl", uuid::Uuid::new_v4()));
         let mut file = fs::File::create(&path).expect("create temp jsonl");
 
         writeln!(

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -2,7 +2,7 @@ pub mod claude;
 pub mod cline;
 pub mod codex;
 pub mod gemini;
-pub mod openclaw;
+pub mod generic;
 pub mod opencode;
 
 use std::collections::{HashMap, HashSet};

--- a/src-tauri/src/runtime_monitor.rs
+++ b/src-tauri/src/runtime_monitor.rs
@@ -1,0 +1,99 @@
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use chrono::Utc;
+use serde::Serialize;
+
+use crate::build_info::{BuildConsistencyInfo, RuntimeSecurityInfo};
+
+const DEFAULT_LOG_CAPACITY: usize = 200;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeLogEntry {
+    pub timestamp: String,
+    pub level: String,
+    pub scope: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Default)]
+struct RuntimeMonitorState {
+    entries: VecDeque<RuntimeLogEntry>,
+    build: Option<BuildConsistencyInfo>,
+    security: Option<RuntimeSecurityInfo>,
+}
+
+pub struct RuntimeMonitor {
+    inner: Mutex<RuntimeMonitorState>,
+}
+
+impl Default for RuntimeMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeMonitor {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(RuntimeMonitorState::default()),
+        }
+    }
+
+    pub fn record(
+        &self,
+        level: &str,
+        scope: &str,
+        message: impl Into<String>,
+        data: Option<serde_json::Value>,
+    ) {
+        let mut guard = self.inner.lock().unwrap();
+        guard.entries.push_back(RuntimeLogEntry {
+            timestamp: Utc::now().to_rfc3339(),
+            level: level.to_string(),
+            scope: scope.to_string(),
+            message: message.into(),
+            data,
+        });
+        while guard.entries.len() > DEFAULT_LOG_CAPACITY {
+            guard.entries.pop_front();
+        }
+    }
+
+    pub fn recent_entries(&self, limit: usize) -> Vec<RuntimeLogEntry> {
+        let guard = self.inner.lock().unwrap();
+        let count = if limit == 0 {
+            guard.entries.len()
+        } else {
+            limit.min(guard.entries.len())
+        };
+        guard
+            .entries
+            .iter()
+            .rev()
+            .take(count)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect()
+    }
+
+    pub fn set_build_consistency(&self, info: BuildConsistencyInfo) {
+        self.inner.lock().unwrap().build = Some(info);
+    }
+
+    pub fn build_consistency(&self) -> Option<BuildConsistencyInfo> {
+        self.inner.lock().unwrap().build.clone()
+    }
+
+    pub fn set_security(&self, info: RuntimeSecurityInfo) {
+        self.inner.lock().unwrap().security = Some(info);
+    }
+
+    pub fn security(&self) -> Option<RuntimeSecurityInfo> {
+        self.inner.lock().unwrap().security.clone()
+    }
+}

--- a/src-tauri/src/squad/conductor_parser.rs
+++ b/src-tauri/src/squad/conductor_parser.rs
@@ -1,0 +1,322 @@
+//! Parses a Conductor's free-form output into a structured task list.
+//!
+//! Conductors emit task plans in two stable shapes that we accept:
+//!
+//! 1. **Fenced JSON block** — the canonical structured format:
+//!
+//!    ```text
+//!    ```json
+//!    [
+//!      {"role": "frontend", "title": "...", "description": "..."},
+//!      {"role": "backend",  "title": "...", "description": "..."}
+//!    ]
+//!    ```
+//!    ```
+//!
+//! 2. **Markdown checklist** — fallback when the model resists JSON:
+//!
+//!    ```text
+//!    - [ ] [frontend] Update settings panel — wire mode toggle to backend
+//!    - [ ] [backend] Add /squad/mode endpoint — accept run_id + new mode
+//!    ```
+//!
+//! Anything we can't parse cleanly is dropped with a reason in
+//! [`ParseReport::skipped`] so callers can surface it.
+
+use serde::Deserialize;
+
+use crate::models::squad::SquadRoleKind;
+
+/// One task as recovered from the Conductor's reply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedConductorTask {
+    pub role: SquadRoleKind,
+    pub title: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParseReport {
+    pub tasks: Vec<ParsedConductorTask>,
+    /// Lines/blocks that *looked* task-shaped but failed validation.
+    pub skipped: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct JsonTask {
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default, alias = "role_kind", alias = "roleKind")]
+    role_kind: Option<String>,
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+}
+
+/// Parse a Conductor's full reply text. Tries fenced JSON first; if no
+/// usable JSON is found, falls back to the markdown-checklist scanner.
+pub fn parse_conductor_output(raw: &str) -> ParseReport {
+    if let Some(report) = parse_fenced_json(raw) {
+        if !report.tasks.is_empty() || !report.skipped.is_empty() {
+            return report;
+        }
+    }
+    parse_markdown_checklist(raw)
+}
+
+fn parse_fenced_json(raw: &str) -> Option<ParseReport> {
+    let block = extract_json_array(raw)?;
+    let parsed: Result<Vec<JsonTask>, _> = serde_json::from_str(&block);
+    let mut report = ParseReport::default();
+    match parsed {
+        Ok(items) => {
+            for item in items {
+                let role_str = item
+                    .role_kind
+                    .as_deref()
+                    .or(item.role.as_deref())
+                    .unwrap_or("");
+                let Some(role) = parse_role(role_str) else {
+                    report.skipped.push(format!(
+                        "unknown role '{role_str}' for task '{}'",
+                        item.title
+                    ));
+                    continue;
+                };
+                let title = item.title.trim().to_string();
+                if title.is_empty() {
+                    report.skipped.push("empty title".into());
+                    continue;
+                }
+                let description = item
+                    .description
+                    .or(item.summary)
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_default();
+                report.tasks.push(ParsedConductorTask {
+                    role,
+                    title,
+                    description,
+                });
+            }
+            Some(report)
+        }
+        Err(err) => {
+            report
+                .skipped
+                .push(format!("fenced JSON did not deserialize: {err}"));
+            Some(report)
+        }
+    }
+}
+
+fn extract_json_array(raw: &str) -> Option<String> {
+    // Look for ```json ... ``` first, then any ``` ... ``` containing an array.
+    let mut search_from = 0usize;
+    while let Some(open_rel) = raw[search_from..].find("```") {
+        let open = search_from + open_rel;
+        let after_open = open + 3;
+        // skip optional language tag
+        let after_lang = raw[after_open..]
+            .find('\n')
+            .map(|n| after_open + n + 1)
+            .unwrap_or(after_open);
+        let close_rel = raw[after_lang..].find("```")?;
+        let close = after_lang + close_rel;
+        let body = raw[after_lang..close].trim();
+        if body.starts_with('[') && body.ends_with(']') {
+            return Some(body.to_string());
+        }
+        search_from = close + 3;
+    }
+    // Last-ditch: a bare top-level array.
+    let trimmed = raw.trim();
+    if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        return Some(trimmed.to_string());
+    }
+    None
+}
+
+fn parse_markdown_checklist(raw: &str) -> ParseReport {
+    let mut report = ParseReport::default();
+    for line in raw.lines() {
+        let trimmed = line.trim_start();
+        if !(trimmed.starts_with("- [ ]")
+            || trimmed.starts_with("- [x]")
+            || trimmed.starts_with("* [ ]"))
+        {
+            continue;
+        }
+        // strip checkbox prefix
+        let after_box = trimmed
+            .split_once(']')
+            .map(|(_, rest)| rest.trim_start())
+            .unwrap_or("");
+        // role tag: "[frontend] ..." or "(frontend) ..."
+        let (role_str, rest) = match after_box.strip_prefix('[') {
+            Some(s) => match s.split_once(']') {
+                Some((role, rest)) => (role.trim(), rest.trim()),
+                None => {
+                    report
+                        .skipped
+                        .push(format!("malformed role tag in line: {line}"));
+                    continue;
+                }
+            },
+            None => match after_box.strip_prefix('(') {
+                Some(s) => match s.split_once(')') {
+                    Some((role, rest)) => (role.trim(), rest.trim()),
+                    None => {
+                        report
+                            .skipped
+                            .push(format!("malformed role tag in line: {line}"));
+                        continue;
+                    }
+                },
+                None => {
+                    report
+                        .skipped
+                        .push(format!("missing role tag in line: {line}"));
+                    continue;
+                }
+            },
+        };
+        let Some(role) = parse_role(role_str) else {
+            report
+                .skipped
+                .push(format!("unknown role '{role_str}' in line: {line}"));
+            continue;
+        };
+
+        // title — description (em-dash, en-dash, or plain --)
+        let (title, description) = split_title_description(rest);
+        if title.is_empty() {
+            report.skipped.push(format!("empty title in line: {line}"));
+            continue;
+        }
+        report.tasks.push(ParsedConductorTask {
+            role,
+            title: title.to_string(),
+            description: description.to_string(),
+        });
+    }
+    report
+}
+
+fn split_title_description(text: &str) -> (&str, &str) {
+    for sep in [" — ", " – ", " -- ", ": "] {
+        if let Some((t, d)) = text.split_once(sep) {
+            return (t.trim(), d.trim());
+        }
+    }
+    (text.trim(), "")
+}
+
+fn parse_role(raw: &str) -> Option<SquadRoleKind> {
+    let s = raw.trim().to_ascii_lowercase();
+    // Try the snake_case serde form first via JSON round-trip so the parser
+    // automatically picks up new variants.
+    let quoted = format!("\"{s}\"");
+    if let Ok(role) = serde_json::from_str::<SquadRoleKind>(&quoted) {
+        return Some(role);
+    }
+    // Friendly aliases the model often produces.
+    match s.as_str() {
+        "fe" | "front" | "front-end" | "front_end" => Some(SquadRoleKind::Frontend),
+        "be" | "back" | "back-end" | "back_end" | "server" => Some(SquadRoleKind::Backend),
+        "exec" | "engineer" | "impl" | "implementation" => Some(SquadRoleKind::Worker),
+        "lead" | "pm" | "planner" | "orchestrator" => Some(SquadRoleKind::Conductor),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_fenced_json_array() {
+        let raw = r#"
+Here's the plan:
+
+```json
+[
+  {"role": "frontend", "title": "Settings panel toggle", "description": "wire UI"},
+  {"role": "backend",  "title": "API endpoint",          "description": "accept payload"}
+]
+```
+
+Let me know.
+"#;
+        let report = parse_conductor_output(raw);
+        assert_eq!(report.skipped.len(), 0, "skipped: {:?}", report.skipped);
+        assert_eq!(report.tasks.len(), 2);
+        assert_eq!(report.tasks[0].role, SquadRoleKind::Frontend);
+        assert_eq!(report.tasks[0].title, "Settings panel toggle");
+        assert_eq!(report.tasks[1].role, SquadRoleKind::Backend);
+    }
+
+    #[test]
+    fn accepts_role_kind_alias_and_summary_fallback() {
+        let raw = r#"```json
+[{"roleKind": "worker", "title": "Refactor module", "summary": "split file"}]
+```"#;
+        let report = parse_conductor_output(raw);
+        assert_eq!(report.tasks.len(), 1);
+        assert_eq!(report.tasks[0].role, SquadRoleKind::Worker);
+        assert_eq!(report.tasks[0].description, "split file");
+    }
+
+    #[test]
+    fn parses_markdown_checklist_fallback() {
+        let raw = "\
+Plan:
+- [ ] [frontend] Toggle button — wire mode change
+- [ ] [backend] /squad/mode -- accept run_id + new mode
+- [ ] [worker] Migrate tests: split into per-mode files
+";
+        let report = parse_conductor_output(raw);
+        assert_eq!(report.skipped.len(), 0, "skipped: {:?}", report.skipped);
+        assert_eq!(report.tasks.len(), 3);
+        assert_eq!(report.tasks[0].role, SquadRoleKind::Frontend);
+        assert_eq!(report.tasks[0].description, "wire mode change");
+        assert_eq!(report.tasks[1].role, SquadRoleKind::Backend);
+        assert_eq!(report.tasks[1].description, "accept run_id + new mode");
+        assert_eq!(report.tasks[2].description, "split into per-mode files");
+    }
+
+    #[test]
+    fn reports_unknown_role_without_panicking() {
+        let raw = r#"```json
+[{"role": "wizard", "title": "Cast spell"}]
+```"#;
+        let report = parse_conductor_output(raw);
+        assert_eq!(report.tasks.len(), 0);
+        assert_eq!(report.skipped.len(), 1);
+        assert!(report.skipped[0].contains("wizard"));
+    }
+
+    #[test]
+    fn empty_input_yields_empty_report() {
+        let report = parse_conductor_output("");
+        assert!(report.tasks.is_empty());
+        assert!(report.skipped.is_empty());
+    }
+
+    #[test]
+    fn ignores_chatter_without_blocks() {
+        let report = parse_conductor_output("I think we should split this work nicely.");
+        assert!(report.tasks.is_empty());
+    }
+
+    #[test]
+    fn role_aliases_resolve() {
+        assert_eq!(parse_role("fe"), Some(SquadRoleKind::Frontend));
+        assert_eq!(parse_role("BE"), Some(SquadRoleKind::Backend));
+        assert_eq!(parse_role("planner"), Some(SquadRoleKind::Conductor));
+        assert_eq!(parse_role("impl"), Some(SquadRoleKind::Worker));
+        assert_eq!(parse_role("frontend"), Some(SquadRoleKind::Frontend));
+    }
+}

--- a/src-tauri/src/squad/conductor_parser.rs
+++ b/src-tauri/src/squad/conductor_parser.rs
@@ -319,4 +319,93 @@ Plan:
         assert_eq!(parse_role("impl"), Some(SquadRoleKind::Worker));
         assert_eq!(parse_role("frontend"), Some(SquadRoleKind::Frontend));
     }
+
+    #[test]
+    fn parses_cjk_titles_and_descriptions() {
+        // Conductors will often plan in the user's language. CJK chars
+        // should round-trip cleanly through both parsers.
+        let raw = r#"```json
+[
+  {"role": "frontend", "title": "设置面板开关", "description": "接入 UI"},
+  {"role": "backend",  "title": "API 端点",     "description": "接受 payload"}
+]
+```"#;
+        let report = parse_conductor_output(raw);
+        assert_eq!(report.skipped.len(), 0);
+        assert_eq!(report.tasks.len(), 2);
+        assert_eq!(report.tasks[0].title, "设置面板开关");
+        assert_eq!(report.tasks[1].description, "接受 payload");
+    }
+
+    #[test]
+    fn checklist_skips_lines_without_role_tag() {
+        // Lines that don't carry a [role] prefix should be silently
+        // skipped — the conductor often interleaves prose with the list.
+        let raw = "\
+Plan:
+- [ ] [frontend] Toggle button — wire mode change
+- [ ] just a note about the layout
+- [ ] [worker] Migrate tests
+";
+        let report = parse_conductor_output(raw);
+        assert_eq!(
+            report.tasks.len(),
+            2,
+            "untagged lines are skipped, tagged ones kept"
+        );
+        assert_eq!(report.tasks[0].role, SquadRoleKind::Frontend);
+        assert_eq!(report.tasks[1].role, SquadRoleKind::Worker);
+    }
+
+    #[test]
+    fn json_takes_precedence_over_checklist_when_both_present() {
+        // If a fenced JSON array parses successfully, the checklist
+        // fallback should not also run — otherwise we'd double-count.
+        let raw = r#"
+- [ ] [worker] checklist task
+
+```json
+[{"role": "frontend", "title": "json task", "description": "from json"}]
+```
+"#;
+        let report = parse_conductor_output(raw);
+        assert_eq!(
+            report.tasks.len(),
+            1,
+            "JSON wins; checklist must not also fire"
+        );
+        assert_eq!(report.tasks[0].title, "json task");
+    }
+
+    #[test]
+    fn malformed_json_falls_through_to_checklist() {
+        // A fenced block that fails to parse as JSON shouldn't poison
+        // the rest of the message — the markdown fallback should still
+        // pick up checklist items elsewhere in the body.
+        let raw = "\
+```json
+{this is not valid JSON
+```
+
+- [ ] [backend] still got picked up
+";
+        let report = parse_conductor_output(raw);
+        assert_eq!(report.tasks.len(), 1);
+        assert_eq!(report.tasks[0].role, SquadRoleKind::Backend);
+    }
+
+    #[test]
+    fn json_object_with_tasks_array_supported() {
+        // Some Conductors will wrap the array in a top-level object.
+        // We require a literal array; an object is unparseable for the
+        // array shape, so this should fall through to no tasks.
+        let raw = r#"```json
+{"tasks": [{"role": "worker", "title": "x", "description": "y"}]}
+```"#;
+        let report = parse_conductor_output(raw);
+        // We don't currently destructure {tasks: [...]}, so we expect
+        // zero tasks; this guards against accidentally accepting the
+        // wrong shape later.
+        assert_eq!(report.tasks.len(), 0);
+    }
 }

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -46,12 +46,14 @@ pub async fn connect_role(
         .ok_or_else(|| AcpError::protocol("squad role run not found"))?;
     let profile = parse_profile(&role_run)?;
 
-    let role_workspace = worktree_manager::role_workspace_path(
+    let role_workspace = worktree_manager::ensure_role_workspace(
         working_dir.as_deref(),
         run_id,
         role_kind,
         profile.workspace_policy,
-    );
+    )
+    .await
+    .map_err(|e| AcpError::protocol(format!("failed to materialize role workspace: {e}")))?;
     let role_run =
         squad_service::update_role_workspace(&db.conn, role_run.id, role_workspace.clone(), None)
             .await

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -976,4 +976,59 @@ mod tests {
         assert_eq!(synthesize_summary_title(""), "(empty turn)");
         assert_eq!(synthesize_summary_title("   \n  "), "(empty turn)");
     }
+
+    #[test]
+    fn summary_title_handles_multibyte_truncation() {
+        // 100 CJK chars — each is one char but multiple bytes. We
+        // count chars not bytes, so 77 chars + ellipsis.
+        let text = "你".repeat(100);
+        let title = synthesize_summary_title(&text);
+        assert_eq!(title.chars().count(), 78);
+        assert!(title.ends_with('…'));
+        // No trailing UTF-8 boundary panic.
+        assert!(title.is_char_boundary(title.len()));
+    }
+
+    #[test]
+    fn summary_title_exactly_80_chars_no_truncation() {
+        let text = "a".repeat(80);
+        let title = synthesize_summary_title(&text);
+        assert_eq!(title.chars().count(), 80);
+        assert!(!title.ends_with('…'));
+    }
+
+    #[test]
+    fn summary_title_strips_leading_blank_lines_and_whitespace() {
+        let text = "\n\n\n   \n\n  hello world  \n   trailing";
+        assert_eq!(synthesize_summary_title(text), "hello world");
+    }
+
+    #[test]
+    fn deps_blocked_when_dep_failed() {
+        // A failed dependency should still block — the parent task
+        // can't reasonably run on top of incomplete work.
+        let task = task_with_deps(5, SquadTaskStatus::Pending, Some("[1]"));
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert(1, SquadTaskStatus::Failed);
+        assert!(!deps_satisfied(&task, &statuses));
+    }
+
+    #[test]
+    fn deps_mixed_completed_and_failed_blocks() {
+        let task = task_with_deps(5, SquadTaskStatus::Pending, Some("[1, 2, 3]"));
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert(1, SquadTaskStatus::Completed);
+        statuses.insert(2, SquadTaskStatus::Failed);
+        statuses.insert(3, SquadTaskStatus::Completed);
+        assert!(!deps_satisfied(&task, &statuses));
+    }
+
+    #[test]
+    fn deps_object_form_treated_as_satisfied() {
+        // depends_on_json that's a JSON object (not an array of ids) is
+        // unparseable for the array shape and falls through to "no deps".
+        let task = task_with_deps(5, SquadTaskStatus::Pending, Some(r#"{"after":[1]}"#));
+        let statuses = std::collections::HashMap::new();
+        assert!(deps_satisfied(&task, &statuses));
+    }
 }

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -1,0 +1,396 @@
+use std::collections::BTreeMap;
+
+use crate::acp::error::AcpError;
+use crate::acp::manager::ConnectionManager;
+use crate::commands::acp as acp_commands;
+use crate::db::service::{agent_setting_service, squad_service};
+use crate::db::AppDatabase;
+use crate::models::agent::AgentType;
+use crate::models::squad::{
+    SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunStatus,
+    SquadTaskInfo,
+};
+use crate::squad::events::{emit_payload, RoleConnectionAttachedPayload};
+use crate::squad::prompt_builder;
+use crate::squad::worktree_manager;
+use crate::web::event_bridge::EventEmitter;
+
+fn parse_profile(role_run: &SquadRoleRunInfo) -> Result<SquadRoleProfileInfo, AcpError> {
+    squad_service::role_profile_from_snapshot(&role_run.role_profile_snapshot_json)
+        .map_err(|e| AcpError::protocol(e.to_string()))
+}
+
+fn parse_profile_env(raw: Option<&str>) -> Result<BTreeMap<String, String>, AcpError> {
+    let Some(raw) = raw else {
+        return Ok(BTreeMap::new());
+    };
+    serde_json::from_str::<BTreeMap<String, String>>(raw)
+        .map_err(|e| AcpError::protocol(format!("invalid squad role env_json: {e}")))
+}
+
+pub async fn connect_role(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    run_id: i32,
+    role_kind: SquadRoleKind,
+    working_dir: Option<String>,
+) -> Result<SquadRoleRunInfo, AcpError> {
+    let snapshot = squad_service::get_run(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    let role_run = snapshot
+        .roles
+        .into_iter()
+        .find(|role| role.role_kind == role_kind)
+        .ok_or_else(|| AcpError::protocol("squad role run not found"))?;
+    let profile = parse_profile(&role_run)?;
+
+    let role_workspace = worktree_manager::role_workspace_path(
+        working_dir.as_deref(),
+        run_id,
+        role_kind,
+        profile.workspace_policy,
+    );
+    let role_run =
+        squad_service::update_role_workspace(&db.conn, role_run.id, role_workspace.clone(), None)
+            .await
+            .map_err(|e| AcpError::protocol(e.to_string()))?;
+
+    let connecting = squad_service::update_role_connection(
+        &db.conn,
+        role_run.id,
+        None,
+        None,
+        SquadRoleRunStatus::Connecting,
+        None,
+    )
+    .await
+    .map_err(|e| AcpError::protocol(e.to_string()))?;
+    emit_payload(
+        emitter,
+        "squad_role_status_changed",
+        run_id,
+        Some(role_kind),
+        &connecting,
+    );
+
+    let setting = agent_setting_service::get_by_agent_type(&db.conn, profile.agent_type)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    if setting.as_ref().map(|row| !row.enabled).unwrap_or(false) {
+        let err = AcpError::protocol(format!("{} is disabled in settings", profile.agent_type));
+        let failed = squad_service::update_role_connection(
+            &db.conn,
+            role_run.id,
+            None,
+            None,
+            SquadRoleRunStatus::Failed,
+            Some(err.to_string()),
+        )
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+        emit_payload(
+            emitter,
+            "squad_role_status_changed",
+            run_id,
+            Some(role_kind),
+            &failed,
+        );
+        return Err(err);
+    }
+
+    if let Err(err) = acp_commands::verify_agent_installed(profile.agent_type) {
+        let failed = squad_service::update_role_connection(
+            &db.conn,
+            role_run.id,
+            None,
+            None,
+            SquadRoleRunStatus::Failed,
+            Some(err.to_string()),
+        )
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+        emit_payload(
+            emitter,
+            "squad_role_status_changed",
+            run_id,
+            Some(role_kind),
+            &failed,
+        );
+        return Err(err);
+    }
+
+    let local_config_json = acp_commands::load_agent_local_config_json(profile.agent_type);
+    let mut runtime_env = acp_commands::build_runtime_env_from_setting(
+        profile.agent_type,
+        setting.as_ref(),
+        local_config_json.as_deref(),
+    );
+    acp_commands::apply_model_provider_env(
+        profile.agent_type,
+        setting.as_ref(),
+        profile.model_provider_id,
+        &mut runtime_env,
+        &db.conn,
+    )
+    .await;
+    let profile_env = match parse_profile_env(profile.env_json.as_deref()) {
+        Ok(env) => env,
+        Err(err) => {
+            let failed = squad_service::update_role_connection(
+                &db.conn,
+                role_run.id,
+                None,
+                None,
+                SquadRoleRunStatus::Failed,
+                Some(err.to_string()),
+            )
+            .await
+            .map_err(|e| AcpError::protocol(e.to_string()))?;
+            emit_payload(
+                emitter,
+                "squad_role_status_changed",
+                run_id,
+                Some(role_kind),
+                &failed,
+            );
+            return Err(err);
+        }
+    };
+    for (key, value) in profile_env {
+        runtime_env.insert(key, value);
+    }
+    runtime_env.insert("CODEG_SQUAD_RUN_ID".into(), run_id.to_string());
+    runtime_env.insert(
+        "CODEG_SQUAD_ROLE_KIND".into(),
+        serde_json::to_string(&role_kind)
+            .unwrap_or_default()
+            .trim_matches('"')
+            .to_string(),
+    );
+    if let Some(path) = &role_workspace {
+        runtime_env.insert("CODEG_SQUAD_WORKSPACE_PATH".into(), path.clone());
+    }
+
+    let connection_id = match manager
+        .spawn_agent(
+            profile.agent_type,
+            role_workspace.clone(),
+            None,
+            runtime_env,
+            format!("squad:{run_id}"),
+            emitter.clone(),
+        )
+        .await
+    {
+        Ok(connection_id) => connection_id,
+        Err(err) => {
+            let failed = squad_service::update_role_connection(
+                &db.conn,
+                role_run.id,
+                None,
+                None,
+                SquadRoleRunStatus::Failed,
+                Some(err.to_string()),
+            )
+            .await
+            .map_err(|e| AcpError::protocol(e.to_string()))?;
+            emit_payload(
+                emitter,
+                "squad_role_status_changed",
+                run_id,
+                Some(role_kind),
+                &failed,
+            );
+            return Err(err);
+        }
+    };
+
+    let connected = squad_service::update_role_connection(
+        &db.conn,
+        role_run.id,
+        Some(connection_id.clone()),
+        None,
+        SquadRoleRunStatus::Connected,
+        None,
+    )
+    .await
+    .map_err(|e| AcpError::protocol(e.to_string()))?;
+    emit_payload(
+        emitter,
+        "squad_role_status_changed",
+        run_id,
+        Some(role_kind),
+        &connected,
+    );
+    emit_payload(
+        emitter,
+        "squad_role_connection_attached",
+        run_id,
+        Some(role_kind),
+        &RoleConnectionAttachedPayload {
+            connection_id,
+            agent_type: profile.agent_type,
+            working_dir: role_workspace,
+            session_id: None,
+        },
+    );
+    Ok(connected)
+}
+
+pub async fn prompt_role(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    run_id: i32,
+    role_kind: SquadRoleKind,
+    task: Option<SquadTaskInfo>,
+) -> Result<SquadRoleRunInfo, AcpError> {
+    let snapshot = squad_service::get_run(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    let role_run = snapshot
+        .roles
+        .into_iter()
+        .find(|role| role.role_kind == role_kind)
+        .ok_or_else(|| AcpError::protocol("squad role run not found"))?;
+    let connection_id = role_run
+        .connection_id
+        .clone()
+        .ok_or_else(|| AcpError::protocol("squad role is not connected"))?;
+    let profile = parse_profile(&role_run)?;
+    let blocks = prompt_builder::build_role_prompt(
+        &profile,
+        &snapshot.run.goal_summary,
+        task.as_ref(),
+        role_run.workspace_path.as_deref(),
+    );
+    manager.send_prompt(&connection_id, blocks).await?;
+    let prompted = squad_service::update_role_connection(
+        &db.conn,
+        role_run.id,
+        Some(connection_id),
+        role_run.session_id,
+        SquadRoleRunStatus::Prompting,
+        None,
+    )
+    .await
+    .map_err(|e| AcpError::protocol(e.to_string()))?;
+    emit_payload(
+        emitter,
+        "squad_role_status_changed",
+        run_id,
+        Some(role_kind),
+        &prompted,
+    );
+    Ok(prompted)
+}
+
+pub async fn start_run(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    run_id: i32,
+    working_dir: Option<String>,
+) -> Result<(), AcpError> {
+    let snapshot = squad_service::get_run(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    let run = squad_service::set_run_status(&db.conn, run_id, SquadRunStatus::Running, None)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    emit_payload(emitter, "squad_run_status_changed", run_id, None, &run);
+
+    let mut failures = Vec::new();
+    for role in snapshot.roles {
+        let profile = parse_profile(&role)?;
+        if !profile.enabled {
+            continue;
+        }
+        match connect_role(
+            db,
+            manager,
+            emitter,
+            run_id,
+            role.role_kind,
+            working_dir.clone(),
+        )
+        .await
+        {
+            Ok(_) => {
+                if matches!(role.role_kind, SquadRoleKind::Conductor) {
+                    if let Err(err) =
+                        prompt_role(db, manager, emitter, run_id, role.role_kind, None).await
+                    {
+                        failures.push(format!(
+                            "{} prompt failed: {err}",
+                            profile.role_kind.as_str()
+                        ));
+                    }
+                }
+            }
+            Err(err) => failures.push(format!(
+                "{} connect failed: {err}",
+                profile.role_kind.as_str()
+            )),
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        let run = squad_service::set_run_status(
+            &db.conn,
+            run_id,
+            SquadRunStatus::Blocked,
+            Some(failures.join("\n")),
+        )
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+        emit_payload(emitter, "squad_run_status_changed", run_id, None, &run);
+        Ok(())
+    }
+}
+
+pub async fn stop_run(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    run_id: i32,
+) -> Result<(), AcpError> {
+    let roles = squad_service::list_role_runs(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    for role in roles {
+        if let Some(connection_id) = role.connection_id.clone() {
+            let _ = manager.disconnect(&connection_id).await;
+        }
+        let stopped = squad_service::update_role_connection(
+            &db.conn,
+            role.id,
+            None,
+            role.session_id,
+            SquadRoleRunStatus::Stopped,
+            None,
+        )
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+        emit_payload(
+            emitter,
+            "squad_role_status_changed",
+            run_id,
+            Some(role.role_kind),
+            &stopped,
+        );
+    }
+    let run = squad_service::set_run_status(&db.conn, run_id, SquadRunStatus::Cancelled, None)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+    emit_payload(emitter, "squad_run_status_changed", run_id, None, &run);
+    Ok(())
+}
+
+pub fn _agent_type_for_profile(profile: &SquadRoleProfileInfo) -> AgentType {
+    profile.agent_type
+}

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -8,7 +8,7 @@ use crate::db::AppDatabase;
 use crate::models::agent::AgentType;
 use crate::models::squad::{
     SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunMode,
-    SquadRunStatus, SquadTaskInfo,
+    SquadRunStatus, SquadTaskInfo, SquadTaskStatus,
 };
 use crate::squad::conductor_parser::{parse_conductor_output, ParseReport};
 use crate::squad::events::{emit_payload, emit_squad_event, RoleConnectionAttachedPayload};
@@ -487,4 +487,275 @@ pub async fn apply_conductor_output(
         created_tasks: created,
         skipped_reasons: skipped,
     })
+}
+
+/// Per-task dispatch outcome — useful for tests, logs, and the UI summary.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DispatchedTask {
+    pub task_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub outcome: DispatchOutcome,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchOutcome {
+    /// Task was prompted to its role; status moved Pending → Assigned.
+    Dispatched,
+    /// Skipped this round because at least one dependency hasn't completed yet.
+    BlockedOnDeps,
+    /// The assigned role isn't connected (or not enabled) — left Pending.
+    RoleNotConnected,
+    /// Already in flight (Assigned/Running); not re-dispatched.
+    AlreadyInFlight,
+    /// Failed to prompt the role; task moved Pending → Failed with note.
+    PromptFailed,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DispatchPendingTasksResult {
+    pub run_id: i32,
+    pub considered: usize,
+    pub dispatched: Vec<DispatchedTask>,
+}
+
+/// Walk every task on a run and prompt each Pending task whose dependencies
+/// are satisfied. Idempotent: re-running won't re-dispatch tasks already in
+/// flight, and tasks blocked on deps will simply be reported and tried again
+/// next call. Intended to be invoked after `apply_conductor_output` and again
+/// each time a task transitions to Completed.
+pub async fn dispatch_pending_tasks(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    run_id: i32,
+) -> Result<DispatchPendingTasksResult, AcpError> {
+    let snapshot = squad_service::get_run(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+
+    // Build a quick lookup of which roles are currently connected so we don't
+    // try to prompt a role that isn't even up.
+    let connected_roles: std::collections::HashSet<SquadRoleKind> = snapshot
+        .roles
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.status,
+                SquadRoleRunStatus::Connected | SquadRoleRunStatus::Prompting
+            )
+        })
+        .map(|r| r.role_kind)
+        .collect();
+
+    // Index task statuses for dependency checks.
+    let task_status: std::collections::HashMap<i32, SquadTaskStatus> =
+        snapshot.tasks.iter().map(|t| (t.id, t.status)).collect();
+
+    let mut dispatched = Vec::new();
+    let considered = snapshot.tasks.len();
+
+    for task in &snapshot.tasks {
+        match task.status {
+            SquadTaskStatus::Pending => {}
+            SquadTaskStatus::Assigned | SquadTaskStatus::Running => {
+                dispatched.push(DispatchedTask {
+                    task_id: task.id,
+                    role_kind: task.assigned_role_kind,
+                    outcome: DispatchOutcome::AlreadyInFlight,
+                    note: None,
+                });
+                continue;
+            }
+            // Blocked / Completed / Failed / Cancelled: nothing to do this pass.
+            _ => continue,
+        }
+
+        if !deps_satisfied(task, &task_status) {
+            dispatched.push(DispatchedTask {
+                task_id: task.id,
+                role_kind: task.assigned_role_kind,
+                outcome: DispatchOutcome::BlockedOnDeps,
+                note: None,
+            });
+            continue;
+        }
+
+        if !connected_roles.contains(&task.assigned_role_kind) {
+            dispatched.push(DispatchedTask {
+                task_id: task.id,
+                role_kind: task.assigned_role_kind,
+                outcome: DispatchOutcome::RoleNotConnected,
+                note: None,
+            });
+            continue;
+        }
+
+        // Move to Assigned *before* prompting so a parallel dispatch_pending_tasks
+        // call can't double-fire.
+        let assigned =
+            squad_service::update_task_status(&db.conn, task.id, SquadTaskStatus::Assigned)
+                .await
+                .map_err(|e| AcpError::protocol(e.to_string()))?;
+        emit_payload(
+            emitter,
+            "squad_task_status_changed",
+            run_id,
+            Some(task.assigned_role_kind),
+            &assigned,
+        );
+
+        match prompt_role(
+            db,
+            manager,
+            emitter,
+            run_id,
+            task.assigned_role_kind,
+            Some(assigned.clone()),
+        )
+        .await
+        {
+            Ok(_) => {
+                dispatched.push(DispatchedTask {
+                    task_id: task.id,
+                    role_kind: task.assigned_role_kind,
+                    outcome: DispatchOutcome::Dispatched,
+                    note: None,
+                });
+            }
+            Err(err) => {
+                let note = err.to_string();
+                let failed =
+                    squad_service::update_task_status(&db.conn, task.id, SquadTaskStatus::Failed)
+                        .await
+                        .map_err(|e| AcpError::protocol(e.to_string()))?;
+                emit_payload(
+                    emitter,
+                    "squad_task_status_changed",
+                    run_id,
+                    Some(task.assigned_role_kind),
+                    &failed,
+                );
+                dispatched.push(DispatchedTask {
+                    task_id: task.id,
+                    role_kind: task.assigned_role_kind,
+                    outcome: DispatchOutcome::PromptFailed,
+                    note: Some(note),
+                });
+            }
+        }
+    }
+
+    let summary = serde_json::json!({
+        "considered": considered,
+        "dispatched": &dispatched,
+    });
+    emit_squad_event(
+        emitter,
+        "squad_dispatch_round_completed",
+        run_id,
+        None,
+        Some(summary),
+    );
+
+    Ok(DispatchPendingTasksResult {
+        run_id,
+        considered,
+        dispatched,
+    })
+}
+
+/// Returns true when every task id in `task.depends_on_json` (if any) has
+/// status Completed. Missing/unparsable dep lists are treated as "no deps"
+/// rather than failing — the parser is best-effort.
+fn deps_satisfied(
+    task: &SquadTaskInfo,
+    statuses: &std::collections::HashMap<i32, SquadTaskStatus>,
+) -> bool {
+    let Some(raw) = task.depends_on_json.as_deref() else {
+        return true;
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    let deps: Vec<i32> = match serde_json::from_str(trimmed) {
+        Ok(deps) => deps,
+        Err(_) => return true,
+    };
+    deps.iter()
+        .all(|dep_id| matches!(statuses.get(dep_id), Some(SquadTaskStatus::Completed)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task_with_deps(id: i32, status: SquadTaskStatus, deps: Option<&str>) -> SquadTaskInfo {
+        SquadTaskInfo {
+            id,
+            squad_run_id: 1,
+            assigned_role_kind: SquadRoleKind::Worker,
+            title: format!("t{id}"),
+            description: String::new(),
+            input_summary: None,
+            status,
+            depends_on_json: deps.map(str::to_string),
+            priority: 0,
+            created_at: String::new(),
+            updated_at: String::new(),
+            completed_at: None,
+            error_message: None,
+        }
+    }
+
+    #[test]
+    fn deps_none_means_satisfied() {
+        let t = task_with_deps(1, SquadTaskStatus::Pending, None);
+        let map = std::collections::HashMap::new();
+        assert!(deps_satisfied(&t, &map));
+    }
+
+    #[test]
+    fn deps_empty_array_means_satisfied() {
+        let t = task_with_deps(1, SquadTaskStatus::Pending, Some("[]"));
+        let map = std::collections::HashMap::new();
+        assert!(deps_satisfied(&t, &map));
+    }
+
+    #[test]
+    fn deps_unparsable_treated_as_satisfied() {
+        let t = task_with_deps(1, SquadTaskStatus::Pending, Some("not json"));
+        let map = std::collections::HashMap::new();
+        assert!(deps_satisfied(&t, &map));
+    }
+
+    #[test]
+    fn deps_block_when_any_incomplete() {
+        let t = task_with_deps(3, SquadTaskStatus::Pending, Some("[1, 2]"));
+        let mut map = std::collections::HashMap::new();
+        map.insert(1, SquadTaskStatus::Completed);
+        map.insert(2, SquadTaskStatus::Running);
+        assert!(!deps_satisfied(&t, &map));
+    }
+
+    #[test]
+    fn deps_all_completed_unblocks() {
+        let t = task_with_deps(3, SquadTaskStatus::Pending, Some("[1, 2]"));
+        let mut map = std::collections::HashMap::new();
+        map.insert(1, SquadTaskStatus::Completed);
+        map.insert(2, SquadTaskStatus::Completed);
+        assert!(deps_satisfied(&t, &map));
+    }
+
+    #[test]
+    fn deps_missing_id_blocks() {
+        // dep id we have no record of — be conservative and block.
+        let t = task_with_deps(3, SquadTaskStatus::Pending, Some("[99]"));
+        let map = std::collections::HashMap::new();
+        assert!(!deps_satisfied(&t, &map));
+    }
 }

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -210,11 +210,20 @@ pub async fn connect_role(
         }
     };
 
+    // Wait briefly for the agent's SessionStarted handshake so we can
+    // persist the session_id back onto the squad_role_run row. The
+    // agent process is freshly spawned; in practice the session_id
+    // lands in connection metadata within tens of ms. If it doesn't,
+    // we proceed without — `prompt_role` doesn't require it on the
+    // squad row, the connection's own metadata is the source of
+    // truth for ACP-level session bookkeeping.
+    let session_id = wait_for_session_id(manager, &connection_id).await;
+
     let connected = squad_service::update_role_connection(
         &db.conn,
         role_run.id,
         Some(connection_id.clone()),
-        None,
+        session_id.clone(),
         SquadRoleRunStatus::Connected,
         None,
     )
@@ -236,10 +245,32 @@ pub async fn connect_role(
             connection_id,
             agent_type: profile.agent_type,
             working_dir: role_workspace,
-            session_id: None,
+            session_id,
         },
     );
     Ok(connected)
+}
+
+/// Poll the connection metadata for up to ~1.5s waiting for the agent's
+/// SessionStarted handshake to populate `session_id`. Returns `None` if
+/// the agent never reports a session within the budget — `connect_role`
+/// continues without it; it is recoverable later (the ACP layer caches
+/// it on connection metadata regardless).
+async fn wait_for_session_id(manager: &ConnectionManager, conn_id: &str) -> Option<String> {
+    const POLL_INTERVAL_MS: u64 = 50;
+    const MAX_ATTEMPTS: u32 = 30; // 30 * 50ms = 1.5s
+    for _ in 0..MAX_ATTEMPTS {
+        if let Some(info) = manager.connection_info(conn_id).await {
+            if let Some(sid) = info.session_id {
+                return Some(sid);
+            }
+        } else {
+            // Connection vanished (process exited / disconnected). Bail.
+            return None;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+    }
+    None
 }
 
 pub async fn prompt_role(

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -10,7 +10,8 @@ use crate::models::squad::{
     SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunMode,
     SquadRunStatus, SquadTaskInfo,
 };
-use crate::squad::events::{emit_payload, RoleConnectionAttachedPayload};
+use crate::squad::conductor_parser::{parse_conductor_output, ParseReport};
+use crate::squad::events::{emit_payload, emit_squad_event, RoleConnectionAttachedPayload};
 use crate::squad::prompt_builder;
 use crate::squad::worktree_manager;
 use crate::web::event_bridge::EventEmitter;
@@ -417,4 +418,73 @@ pub async fn stop_run(
 
 pub fn _agent_type_for_profile(profile: &SquadRoleProfileInfo) -> AgentType {
     profile.agent_type
+}
+
+/// Outcome of feeding a Conductor reply through the parser + task-writer pipeline.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyConductorOutputResult {
+    pub created_tasks: Vec<SquadTaskInfo>,
+    pub skipped_reasons: Vec<String>,
+}
+
+/// Parse a Conductor's free-form reply into a task list and persist each
+/// recovered item as a `squad_task` row. Emits `squad_task_created` per task
+/// and a single trailing `squad_conductor_plan_applied` summary event so the
+/// UI can refresh once instead of N times.
+///
+/// This is intentionally callable from any layer (Tauri command, Web handler,
+/// or — eventually — an ACP TurnComplete listener) so the pipeline doesn't
+/// have to be re-implemented when the live stream gets wired up.
+pub async fn apply_conductor_output(
+    db: &AppDatabase,
+    emitter: &EventEmitter,
+    run_id: i32,
+    raw_text: &str,
+) -> Result<ApplyConductorOutputResult, AcpError> {
+    // Validate the run exists so we don't write orphan tasks.
+    let _ = squad_service::get_run(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+
+    let ParseReport { tasks, skipped } = parse_conductor_output(raw_text);
+
+    let mut created = Vec::with_capacity(tasks.len());
+    for parsed in tasks {
+        let task = squad_service::create_task(
+            &db.conn,
+            run_id,
+            parsed.role,
+            parsed.title,
+            parsed.description,
+        )
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+        emit_payload(
+            emitter,
+            "squad_task_created",
+            run_id,
+            Some(parsed.role),
+            &task,
+        );
+        created.push(task);
+    }
+
+    let summary = serde_json::json!({
+        "createdCount": created.len(),
+        "skippedCount": skipped.len(),
+        "skippedReasons": &skipped,
+    });
+    emit_squad_event(
+        emitter,
+        "squad_conductor_plan_applied",
+        run_id,
+        None,
+        Some(summary),
+    );
+
+    Ok(ApplyConductorOutputResult {
+        created_tasks: created,
+        skipped_reasons: skipped,
+    })
 }

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -378,6 +378,15 @@ pub async fn start_run(
     }
 }
 
+/// Grace period to let each ACP connection loop observe `Disconnect`,
+/// release terminals and pending permission responders, and exit
+/// cleanly before we flip the squad role row to `Stopped`. The
+/// connection task itself doesn't expose a "terminated" handle, so
+/// this drain window is the closest we can get without restructuring
+/// `acp::manager`. Tuned conservatively — disconnect handling in
+/// `acp::connection` is non-blocking aside from `release_all_for_session`.
+const STOP_RUN_DRAIN_MS: u64 = 250;
+
 pub async fn stop_run(
     db: &AppDatabase,
     manager: &ConnectionManager,
@@ -387,10 +396,36 @@ pub async fn stop_run(
     let roles = squad_service::list_role_runs(&db.conn, run_id)
         .await
         .map_err(|e| AcpError::protocol(e.to_string()))?;
+
+    // Phase 1: fan-out disconnect requests in parallel. We don't flip
+    // role status to Stopped yet — the ACP connection loop is still
+    // tearing down terminals and responding to in-flight permission
+    // requests. Doing the status flip here would race the UI into
+    // showing "Stopped" while the agent process is still emitting
+    // events.
+    let disconnect_futures = roles
+        .iter()
+        .filter_map(|role| role.connection_id.clone())
+        .map(|conn_id| {
+            let manager = manager.clone();
+            async move {
+                let _ = manager.disconnect(&conn_id).await;
+            }
+        });
+    futures::future::join_all(disconnect_futures).await;
+
+    // Phase 2: brief drain window so the per-connection event loop
+    // can observe the Disconnect command, run its cleanup branch in
+    // `acp::connection`, and break out before we record the terminal
+    // state. Fixed-duration; if the agent is wedged we proceed anyway
+    // — the connection task is detached on its own runtime and the DB
+    // row is what the user sees.
+    if !roles.is_empty() {
+        tokio::time::sleep(std::time::Duration::from_millis(STOP_RUN_DRAIN_MS)).await;
+    }
+
+    // Phase 3: now record terminal status per role and emit events.
     for role in roles {
-        if let Some(connection_id) = role.connection_id.clone() {
-            let _ = manager.disconnect(&connection_id).await;
-        }
         let stopped = squad_service::update_role_connection(
             &db.conn,
             role.id,
@@ -409,6 +444,7 @@ pub async fn stop_run(
             &stopped,
         );
     }
+
     let run = squad_service::set_run_status(&db.conn, run_id, SquadRunStatus::Cancelled, None)
         .await
         .map_err(|e| AcpError::protocol(e.to_string()))?;

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -7,8 +7,8 @@ use crate::db::service::{agent_setting_service, squad_service};
 use crate::db::AppDatabase;
 use crate::models::agent::AgentType;
 use crate::models::squad::{
-    SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunStatus,
-    SquadTaskInfo,
+    SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunMode,
+    SquadRunStatus, SquadTaskInfo,
 };
 use crate::squad::events::{emit_payload, RoleConnectionAttachedPayload};
 use crate::squad::prompt_builder;
@@ -299,12 +299,14 @@ pub async fn start_run(
     let snapshot = squad_service::get_run(&db.conn, run_id)
         .await
         .map_err(|e| AcpError::protocol(e.to_string()))?;
+    let mode = snapshot.run.mode;
     let run = squad_service::set_run_status(&db.conn, run_id, SquadRunStatus::Running, None)
         .await
         .map_err(|e| AcpError::protocol(e.to_string()))?;
     emit_payload(emitter, "squad_run_status_changed", run_id, None, &run);
 
     let mut failures = Vec::new();
+    let mut connected_enabled: Vec<SquadRoleKind> = Vec::new();
     for role in snapshot.roles {
         let profile = parse_profile(&role)?;
         if !profile.enabled {
@@ -320,22 +322,42 @@ pub async fn start_run(
         )
         .await
         {
-            Ok(_) => {
-                if matches!(role.role_kind, SquadRoleKind::Conductor) {
-                    if let Err(err) =
-                        prompt_role(db, manager, emitter, run_id, role.role_kind, None).await
-                    {
-                        failures.push(format!(
-                            "{} prompt failed: {err}",
-                            profile.role_kind.as_str()
-                        ));
-                    }
-                }
-            }
+            Ok(_) => connected_enabled.push(role.role_kind),
             Err(err) => failures.push(format!(
                 "{} connect failed: {err}",
                 profile.role_kind.as_str()
             )),
+        }
+    }
+
+    // Mode-specific dispatch policy. connect_role above is shared; only the
+    // *who gets prompted automatically* part differs.
+    match mode {
+        SquadRunMode::Manual => {
+            // No auto-prompt. The user drives prompts via squad_prompt_role.
+        }
+        SquadRunMode::ConductorDispatch => {
+            // Conductor plans the task list; workers wait for dispatch_pending_tasks.
+            if connected_enabled.contains(&SquadRoleKind::Conductor) {
+                if let Err(err) =
+                    prompt_role(db, manager, emitter, run_id, SquadRoleKind::Conductor, None).await
+                {
+                    failures.push(format!("conductor prompt failed: {err}"));
+                }
+            } else {
+                failures.push(
+                    "conductor_dispatch mode requires a connected Conductor role".to_string(),
+                );
+            }
+        }
+        SquadRunMode::AllHandsReview => {
+            // Every connected role gets prompted once for an independent review pass.
+            for role_kind in &connected_enabled {
+                if let Err(err) = prompt_role(db, manager, emitter, run_id, *role_kind, None).await
+                {
+                    failures.push(format!("{} prompt failed: {err}", role_kind.as_str()));
+                }
+            }
         }
     }
 

--- a/src-tauri/src/squad/dispatcher.rs
+++ b/src-tauri/src/squad/dispatcher.rs
@@ -7,8 +7,8 @@ use crate::db::service::{agent_setting_service, squad_service};
 use crate::db::AppDatabase;
 use crate::models::agent::AgentType;
 use crate::models::squad::{
-    SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo, SquadRoleRunStatus, SquadRunMode,
-    SquadRunStatus, SquadTaskInfo, SquadTaskStatus,
+    SquadArtifactInfo, SquadArtifactType, SquadRoleKind, SquadRoleProfileInfo, SquadRoleRunInfo,
+    SquadRoleRunStatus, SquadRunMode, SquadRunStatus, SquadTaskInfo, SquadTaskStatus,
 };
 use crate::squad::conductor_parser::{parse_conductor_output, ParseReport};
 use crate::squad::events::{emit_payload, emit_squad_event, RoleConnectionAttachedPayload};
@@ -420,6 +420,136 @@ pub fn _agent_type_for_profile(profile: &SquadRoleProfileInfo) -> AgentType {
     profile.agent_type
 }
 
+/// Persist an artifact for a squad role and emit `squad_artifact_created`
+/// so any subscriber (UI, log tail, future analytics) reacts in one place.
+/// Re-used by every artifact-writing path (frontend command, conductor
+/// pipeline, future ACP listener) so events never get skipped.
+#[allow(clippy::too_many_arguments)]
+pub async fn record_role_artifact(
+    db: &AppDatabase,
+    emitter: &EventEmitter,
+    run_id: i32,
+    role_kind: Option<SquadRoleKind>,
+    task_id: Option<i32>,
+    artifact_type: SquadArtifactType,
+    title: String,
+    content_json: String,
+) -> Result<SquadArtifactInfo, AcpError> {
+    let artifact = squad_service::create_artifact(
+        &db.conn,
+        run_id,
+        role_kind,
+        task_id,
+        artifact_type,
+        title,
+        content_json,
+    )
+    .await
+    .map_err(|e| AcpError::protocol(e.to_string()))?;
+    emit_payload(
+        emitter,
+        "squad_artifact_created",
+        run_id,
+        role_kind,
+        &artifact,
+    );
+    Ok(artifact)
+}
+
+/// What a single ACP turn produced as squad artifacts.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnArtifactsResult {
+    pub summary: Option<SquadArtifactInfo>,
+    pub plan: Option<SquadArtifactInfo>,
+}
+
+/// Capture an ACP turn's output as squad artifacts. Frontends that already
+/// receive `acp://event` chunks can call this on `TurnComplete` with the
+/// accumulated agent text + the latest plan JSON. Both inputs are optional:
+///
+/// - `agent_text` — when non-empty (after trim), persisted as an artifact
+///   of type `Summary`. Stored under a JSON envelope `{"text": "..."}` so
+///   future fields (token usage, cwd, etc.) can be added without a schema
+///   bump.
+/// - `plan_json` — when present, persisted as-is as an artifact of type
+///   `Plan`. The service layer validates JSON shape, so malformed input
+///   surfaces a clear error.
+pub async fn record_turn_artifacts(
+    db: &AppDatabase,
+    emitter: &EventEmitter,
+    run_id: i32,
+    role_kind: SquadRoleKind,
+    task_id: Option<i32>,
+    agent_text: String,
+    plan_json: Option<String>,
+) -> Result<TurnArtifactsResult, AcpError> {
+    // Validate the run exists once up front.
+    let _ = squad_service::get_run(&db.conn, run_id)
+        .await
+        .map_err(|e| AcpError::protocol(e.to_string()))?;
+
+    let summary = if !agent_text.trim().is_empty() {
+        let envelope = serde_json::json!({ "text": agent_text }).to_string();
+        let title = synthesize_summary_title(&agent_text);
+        Some(
+            record_role_artifact(
+                db,
+                emitter,
+                run_id,
+                Some(role_kind),
+                task_id,
+                SquadArtifactType::Summary,
+                title,
+                envelope,
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    let plan = match plan_json
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(raw) => Some(
+            record_role_artifact(
+                db,
+                emitter,
+                run_id,
+                Some(role_kind),
+                task_id,
+                SquadArtifactType::Plan,
+                "Plan update".to_string(),
+                raw.to_string(),
+            )
+            .await?,
+        ),
+        None => None,
+    };
+
+    Ok(TurnArtifactsResult { summary, plan })
+}
+
+/// Build a short title from the first non-empty line of a turn's text,
+/// trimmed to 80 chars so artifact lists stay readable.
+fn synthesize_summary_title(text: &str) -> String {
+    let first = text
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("(empty turn)");
+    if first.chars().count() > 80 {
+        let mut out: String = first.chars().take(77).collect();
+        out.push('…');
+        out
+    } else {
+        first.to_string()
+    }
+}
+
 /// Outcome of feeding a Conductor reply through the parser + task-writer pipeline.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -757,5 +887,26 @@ mod tests {
         let t = task_with_deps(3, SquadTaskStatus::Pending, Some("[99]"));
         let map = std::collections::HashMap::new();
         assert!(!deps_satisfied(&t, &map));
+    }
+
+    #[test]
+    fn summary_title_truncates_long_first_line() {
+        let long = "a".repeat(200);
+        let title = synthesize_summary_title(&long);
+        // 77 chars + ellipsis
+        assert_eq!(title.chars().count(), 78);
+        assert!(title.ends_with('…'));
+    }
+
+    #[test]
+    fn summary_title_uses_first_non_empty_line() {
+        let text = "\n\n  Hello, world!  \nsecond line";
+        assert_eq!(synthesize_summary_title(text), "Hello, world!");
+    }
+
+    #[test]
+    fn summary_title_handles_empty() {
+        assert_eq!(synthesize_summary_title(""), "(empty turn)");
+        assert_eq!(synthesize_summary_title("   \n  "), "(empty turn)");
     }
 }

--- a/src-tauri/src/squad/events.rs
+++ b/src-tauri/src/squad/events.rs
@@ -1,0 +1,52 @@
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use chrono::Utc;
+use serde::Serialize;
+
+use crate::models::squad::{SquadEvent, SquadRoleKind};
+use crate::web::event_bridge::{emit_event, EventEmitter};
+
+pub const SQUAD_EVENT_CHANNEL: &str = "squad://event";
+
+static SEQ: AtomicI64 = AtomicI64::new(1);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleConnectionAttachedPayload {
+    pub connection_id: String,
+    pub agent_type: crate::models::agent::AgentType,
+    pub working_dir: Option<String>,
+    pub session_id: Option<String>,
+}
+
+pub fn emit_squad_event(
+    emitter: &EventEmitter,
+    event_type: impl Into<String>,
+    squad_run_id: i32,
+    role_kind: Option<SquadRoleKind>,
+    payload: Option<serde_json::Value>,
+) {
+    emit_event(
+        emitter,
+        SQUAD_EVENT_CHANNEL,
+        SquadEvent {
+            event_type: event_type.into(),
+            squad_run_id,
+            seq: SEQ.fetch_add(1, Ordering::Relaxed),
+            at: Utc::now(),
+            role_kind,
+            payload,
+        },
+    );
+}
+
+pub fn emit_payload<T: Serialize>(
+    emitter: &EventEmitter,
+    event_type: impl Into<String>,
+    squad_run_id: i32,
+    role_kind: Option<SquadRoleKind>,
+    payload: &T,
+) {
+    let value = serde_json::to_value(payload).ok();
+    emit_squad_event(emitter, event_type, squad_run_id, role_kind, value);
+}

--- a/src-tauri/src/squad/mod.rs
+++ b/src-tauri/src/squad/mod.rs
@@ -1,3 +1,4 @@
+pub mod conductor_parser;
 pub mod dispatcher;
 pub mod events;
 pub mod prompt_builder;

--- a/src-tauri/src/squad/mod.rs
+++ b/src-tauri/src/squad/mod.rs
@@ -1,0 +1,4 @@
+pub mod dispatcher;
+pub mod events;
+pub mod prompt_builder;
+pub mod worktree_manager;

--- a/src-tauri/src/squad/mod.rs
+++ b/src-tauri/src/squad/mod.rs
@@ -2,4 +2,5 @@ pub mod conductor_parser;
 pub mod dispatcher;
 pub mod events;
 pub mod prompt_builder;
+pub mod turn_listener;
 pub mod worktree_manager;

--- a/src-tauri/src/squad/prompt_builder.rs
+++ b/src-tauri/src/squad/prompt_builder.rs
@@ -1,0 +1,34 @@
+use crate::acp::types::PromptInputBlock;
+use crate::models::squad::{SquadRoleKind, SquadRoleProfileInfo, SquadTaskInfo};
+
+pub fn build_role_prompt(
+    profile: &SquadRoleProfileInfo,
+    goal_summary: &str,
+    task: Option<&SquadTaskInfo>,
+    workspace_path: Option<&str>,
+) -> Vec<PromptInputBlock> {
+    let role_name = match profile.role_kind {
+        SquadRoleKind::Conductor => "conductor",
+        SquadRoleKind::Frontend => "frontend",
+        SquadRoleKind::Backend => "backend",
+        SquadRoleKind::Worker => "worker",
+    };
+    let task_text = task
+        .map(|task| {
+            format!(
+                "\nTask:\nTitle: {}\nDescription: {}\n",
+                task.title, task.description
+            )
+        })
+        .unwrap_or_default();
+    let workspace_text = workspace_path
+        .map(|path| format!("\nWorkspace boundary: work only inside `{path}` unless explicitly instructed.\n"))
+        .unwrap_or_else(|| "\nWorkspace boundary: treat this role as read-only unless a task explicitly authorizes edits.\n".to_string());
+
+    let text = format!(
+        "You are the Codeg role-squad {role_name} role.\n\nRole policy:\n{}\n\nUser goal:\n{}{}{}\nReporting contract:\n- Keep updates concise.\n- Report changed files, blockers, risks, and validation results.\n- Do not perform destructive git operations without explicit instruction.\n",
+        profile.system_prompt, goal_summary, task_text, workspace_text
+    );
+
+    vec![PromptInputBlock::Text { text }]
+}

--- a/src-tauri/src/squad/turn_listener.rs
+++ b/src-tauri/src/squad/turn_listener.rs
@@ -1,0 +1,248 @@
+//! Subscribes to ACP events on the broadcast bus and turns them into
+//! squad pipeline actions.
+//!
+//! Why not call dispatcher directly from `acp::connection`? The ACP
+//! conversation loop has no notion of squad roles — all it knows is a
+//! `connection_id`. Wiring squad-specific bookkeeping into that loop
+//! would couple unrelated subsystems on a hot path. Instead we
+//! eavesdrop on the existing event broadcast and react out-of-band:
+//!
+//!   - `content_delta` / `thinking` text is accumulated per connection.
+//!   - `plan_update` snapshots the latest plan per connection.
+//!   - `turn_complete` / `turn_idle_timeout` resolves the connection
+//!     to a squad role; if it matches one, fan out to:
+//!       * `dispatcher::record_turn_artifacts` (Summary + Plan)
+//!       * for the Conductor role: `apply_conductor_output`, then
+//!         `dispatch_pending_tasks` to fan tasks out to other roles
+//!       * for any other role: `dispatch_pending_tasks` is still
+//!         re-run because a worker may have just unblocked dependents.
+//!
+//! Failure modes are logged but never propagated — losing a single
+//! turn capture is not worth taking down the listener task.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::acp::manager::ConnectionManager;
+use crate::db::service::squad_service;
+use crate::db::AppDatabase;
+use crate::models::squad::SquadRoleKind;
+use crate::squad::dispatcher;
+use crate::web::event_bridge::{EventEmitter, WebEventBroadcaster};
+
+/// Buffer of streaming text + plan accumulated for a single ACP turn,
+/// keyed by `connection_id`.
+#[derive(Default)]
+struct TurnBuffer {
+    /// Concatenated agent text content (`content_delta` events).
+    text: String,
+    /// Latest plan snapshot, serialized as JSON. We replace rather than
+    /// append because `plan_update` events carry the full plan each
+    /// time, not deltas.
+    plan_json: Option<String>,
+}
+
+#[derive(Default)]
+struct BufferStore {
+    buffers: HashMap<String, TurnBuffer>,
+}
+
+impl BufferStore {
+    fn append_text(&mut self, conn_id: &str, text: &str) {
+        let entry = self.buffers.entry(conn_id.to_string()).or_default();
+        entry.text.push_str(text);
+    }
+
+    fn set_plan(&mut self, conn_id: &str, plan_json: String) {
+        let entry = self.buffers.entry(conn_id.to_string()).or_default();
+        entry.plan_json = Some(plan_json);
+    }
+
+    fn take(&mut self, conn_id: &str) -> Option<TurnBuffer> {
+        self.buffers.remove(conn_id)
+    }
+}
+
+/// Spawn the long-running ACP→squad bridge. Idempotent if you only
+/// call it once per `AppState`. Returns immediately; the listener
+/// runs detached on a Tokio task.
+pub fn spawn(
+    db: AppDatabase,
+    manager: ConnectionManager,
+    emitter: EventEmitter,
+    broadcaster: Arc<WebEventBroadcaster>,
+) {
+    let store: Arc<Mutex<BufferStore>> = Arc::new(Mutex::new(BufferStore::default()));
+    let mut rx = broadcaster.subscribe();
+
+    tokio::spawn(async move {
+        loop {
+            let event = match rx.recv().await {
+                Ok(e) => e,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    eprintln!(
+                        "[squad/turn_listener] broadcast lag: dropped {n} event(s); continuing"
+                    );
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    eprintln!("[squad/turn_listener] broadcast closed; exiting");
+                    break;
+                }
+            };
+
+            // Only ACP events carry per-connection turn signals.
+            if event.channel != "acp://event" {
+                continue;
+            }
+            handle_acp_event(&db, &manager, &emitter, &store, &event.payload).await;
+        }
+    });
+}
+
+async fn handle_acp_event(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    store: &Arc<Mutex<BufferStore>>,
+    payload: &serde_json::Value,
+) {
+    let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) else {
+        return;
+    };
+    let Some(conn_id) = payload.get("connection_id").and_then(|v| v.as_str()) else {
+        return;
+    };
+
+    match event_type {
+        "content_delta" | "thinking" => {
+            if let Some(text) = payload.get("text").and_then(|v| v.as_str()) {
+                store.lock().await.append_text(conn_id, text);
+            }
+        }
+        "plan_update" => {
+            if let Some(entries) = payload.get("entries") {
+                if let Ok(plan_json) = serde_json::to_string(entries) {
+                    store.lock().await.set_plan(conn_id, plan_json);
+                }
+            }
+        }
+        "turn_complete" | "turn_idle_timeout" => {
+            // Drain the buffer regardless of whether this connection
+            // turns out to belong to a squad — keeping it around would
+            // leak memory across long-lived chats.
+            let buffer = store.lock().await.take(conn_id).unwrap_or_default();
+            on_turn_finished(db, manager, emitter, conn_id, buffer).await;
+        }
+        _ => {}
+    }
+}
+
+async fn on_turn_finished(
+    db: &AppDatabase,
+    manager: &ConnectionManager,
+    emitter: &EventEmitter,
+    conn_id: &str,
+    buffer: TurnBuffer,
+) {
+    // Quick reject: is this connection bound to a squad role at all?
+    let role_run = match squad_service::find_role_run_by_connection_id(&db.conn, conn_id).await {
+        Ok(Some(role)) => role,
+        Ok(None) => return, // Not a squad connection. Common case.
+        Err(err) => {
+            eprintln!("[squad/turn_listener] DB lookup failed for {conn_id}: {err}");
+            return;
+        }
+    };
+
+    let run_id = role_run.squad_run_id;
+    let role_kind = role_run.role_kind;
+    let TurnBuffer { text, plan_json } = buffer;
+
+    // Persist the turn artifacts (Summary + Plan). Always attempt this
+    // first so a partial failure of the conductor pipeline below
+    // doesn't drop the captured text.
+    if !text.trim().is_empty() || plan_json.is_some() {
+        if let Err(err) =
+            dispatcher::record_turn_artifacts(db, emitter, run_id, role_kind, None, text.clone(), plan_json)
+                .await
+        {
+            eprintln!(
+                "[squad/turn_listener] record_turn_artifacts failed run={run_id} role={role_kind:?}: {err}"
+            );
+        }
+    }
+
+    // Conductor turns may carry a fresh task plan; parse + persist.
+    if matches!(role_kind, SquadRoleKind::Conductor) && !text.trim().is_empty() {
+        match dispatcher::apply_conductor_output(db, emitter, run_id, &text).await {
+            Ok(result) => {
+                if !result.skipped_reasons.is_empty() {
+                    eprintln!(
+                        "[squad/turn_listener] conductor plan applied run={run_id} created={} skipped={:?}",
+                        result.created_tasks.len(),
+                        result.skipped_reasons
+                    );
+                }
+            }
+            Err(err) => {
+                eprintln!(
+                    "[squad/turn_listener] apply_conductor_output failed run={run_id}: {err}"
+                );
+            }
+        }
+    }
+
+    // Any role completing a turn may have unblocked dependents — try
+    // to dispatch the next round. Idempotent: tasks already in flight
+    // are reported as `AlreadyInFlight` and not re-prompted.
+    if let Err(err) = dispatcher::dispatch_pending_tasks(db, manager, emitter, run_id).await {
+        eprintln!(
+            "[squad/turn_listener] dispatch_pending_tasks failed run={run_id}: {err}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_appends_text_and_replaces_plan() {
+        let mut store = BufferStore::default();
+        store.append_text("conn-1", "hello ");
+        store.append_text("conn-1", "world");
+        store.set_plan("conn-1", r#"[{"id":1}]"#.into());
+        store.set_plan("conn-1", r#"[{"id":2}]"#.into());
+        let buf = store.take("conn-1").unwrap();
+        assert_eq!(buf.text, "hello world");
+        assert_eq!(buf.plan_json.as_deref(), Some(r#"[{"id":2}]"#));
+    }
+
+    #[test]
+    fn buffer_take_clears_entry() {
+        let mut store = BufferStore::default();
+        store.append_text("conn-1", "x");
+        assert!(store.take("conn-1").is_some());
+        assert!(store.take("conn-1").is_none());
+    }
+
+    #[test]
+    fn buffer_per_connection_isolation() {
+        let mut store = BufferStore::default();
+        store.append_text("a", "alpha");
+        store.append_text("b", "beta");
+        let a = store.take("a").unwrap();
+        let b = store.take("b").unwrap();
+        assert_eq!(a.text, "alpha");
+        assert_eq!(b.text, "beta");
+    }
+
+    #[test]
+    fn buffer_take_missing_returns_none() {
+        let mut store = BufferStore::default();
+        assert!(store.take("never-seen").is_none());
+    }
+}

--- a/src-tauri/src/squad/worktree_manager.rs
+++ b/src-tauri/src/squad/worktree_manager.rs
@@ -240,4 +240,61 @@ mod tests {
         let path = res.expect("workspace path");
         assert!(Path::new(&path).is_dir());
     }
+
+    #[tokio::test]
+    async fn write_shared_returns_base_unchanged() {
+        let res = ensure_role_workspace(
+            Some("/tmp/shared-base"),
+            1,
+            SquadRoleKind::Worker,
+            SquadWorkspacePolicy::WriteShared,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res.as_deref(), Some("/tmp/shared-base"));
+    }
+
+    #[tokio::test]
+    async fn none_base_returns_none_for_every_policy() {
+        for policy in [
+            SquadWorkspacePolicy::ReadOnly,
+            SquadWorkspacePolicy::WriteShared,
+            SquadWorkspacePolicy::WriteIsolated,
+        ] {
+            let res = ensure_role_workspace(None, 1, SquadRoleKind::Worker, policy)
+                .await
+                .unwrap();
+            assert!(res.is_none(), "policy {policy:?} should yield None");
+        }
+    }
+
+    #[test]
+    fn planned_path_distinguishes_run_and_role() {
+        let base = Path::new("/tmp/myrepo");
+        let p1 = planned_worktree_path(base, 42, SquadRoleKind::Worker);
+        let p2 = planned_worktree_path(base, 42, SquadRoleKind::Frontend);
+        let p3 = planned_worktree_path(base, 43, SquadRoleKind::Worker);
+        assert_ne!(p1, p2, "different roles must produce different paths");
+        assert_ne!(p1, p3, "different runs must produce different paths");
+    }
+
+    #[test]
+    fn branch_name_distinguishes_run_and_role() {
+        assert_ne!(
+            role_branch_name(1, SquadRoleKind::Worker),
+            role_branch_name(1, SquadRoleKind::Frontend)
+        );
+        assert_ne!(
+            role_branch_name(1, SquadRoleKind::Worker),
+            role_branch_name(2, SquadRoleKind::Worker)
+        );
+    }
+
+    #[test]
+    fn planned_path_handles_base_without_filename() {
+        // A base path that has no terminal filename component (e.g. `/`)
+        // shouldn't panic — fall back to "workspace".
+        let p = planned_worktree_path(Path::new("/"), 1, SquadRoleKind::Worker);
+        assert!(p.display().to_string().contains("workspace"));
+    }
 }

--- a/src-tauri/src/squad/worktree_manager.rs
+++ b/src-tauri/src/squad/worktree_manager.rs
@@ -1,26 +1,75 @@
+use std::io;
 use std::path::{Path, PathBuf};
+
+use tokio::fs;
 
 use crate::models::squad::{SquadRoleKind, SquadWorkspacePolicy};
 
-pub fn role_workspace_path(
+/// Materialize the workspace on disk if needed.
+///
+/// - `ReadOnly` / `WriteShared` → returns the base path unchanged.
+/// - `WriteIsolated`:
+///   - if the planned path already exists, reuse it (idempotent reconnect).
+///   - else, if base is a git repo, run `git worktree add -B <branch> <path> HEAD` to create it.
+///   - else, fall back to a plain directory so non-git folders still work.
+pub async fn ensure_role_workspace(
     base_working_dir: Option<&str>,
     run_id: i32,
     role_kind: SquadRoleKind,
     policy: SquadWorkspacePolicy,
-) -> Option<String> {
-    let base = base_working_dir?.trim();
-    if base.is_empty() {
-        return None;
-    }
+) -> io::Result<Option<String>> {
+    let Some(base_str) = base_working_dir.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
     match policy {
         SquadWorkspacePolicy::ReadOnly | SquadWorkspacePolicy::WriteShared => {
-            Some(base.to_string())
+            Ok(Some(base_str.to_string()))
         }
-        SquadWorkspacePolicy::WriteIsolated => Some(
-            planned_worktree_path(Path::new(base), run_id, role_kind)
-                .display()
-                .to_string(),
-        ),
+        SquadWorkspacePolicy::WriteIsolated => {
+            let base = Path::new(base_str);
+            let planned = planned_worktree_path(base, run_id, role_kind);
+
+            if planned.exists() {
+                // Reuse on reconnect — don't fail if the worktree (or plain dir) is already there.
+                return Ok(Some(planned.display().to_string()));
+            }
+
+            if let Some(parent) = planned.parent() {
+                fs::create_dir_all(parent).await.map_err(|e| {
+                    io::Error::new(
+                        e.kind(),
+                        format!("creating worktree parent {}: {e}", parent.display()),
+                    )
+                })?;
+            }
+
+            if is_git_repo(base).await {
+                let branch = role_branch_name(run_id, role_kind);
+                git_worktree_add(base, &branch, &planned)
+                    .await
+                    .map_err(|e| {
+                        io::Error::other(format!(
+                            "git worktree add -B {branch} {} (from {}): {e}",
+                            planned.display(),
+                            base.display()
+                        ))
+                    })?;
+            } else {
+                eprintln!(
+                    "[squad/worktree] base {} is not a git repo; falling back to plain dir at {}",
+                    base.display(),
+                    planned.display()
+                );
+                fs::create_dir_all(&planned).await.map_err(|e| {
+                    io::Error::new(
+                        e.kind(),
+                        format!("creating fallback dir {}: {e}", planned.display()),
+                    )
+                })?;
+            }
+
+            Ok(Some(planned.display().to_string()))
+        }
     }
 }
 
@@ -30,14 +79,165 @@ fn planned_worktree_path(base: &Path, run_id: i32, role_kind: SquadRoleKind) -> 
         .and_then(|name| name.to_str())
         .filter(|name| !name.is_empty())
         .unwrap_or("workspace");
-    let role = serde_json::to_string(&role_kind)
-        .unwrap_or_else(|_| "worker".to_string())
-        .trim_matches('"')
-        .to_string();
     let parent = base.parent().unwrap_or_else(|| Path::new("."));
     parent
         .join(".codeg-worktrees")
         .join(repo_name)
         .join(run_id.to_string())
-        .join(role)
+        .join(role_slug(role_kind))
+}
+
+fn role_slug(role_kind: SquadRoleKind) -> String {
+    serde_json::to_string(&role_kind)
+        .unwrap_or_else(|_| "\"worker\"".to_string())
+        .trim_matches('"')
+        .to_string()
+}
+
+fn role_branch_name(run_id: i32, role_kind: SquadRoleKind) -> String {
+    format!("codeg/squad/{run_id}/{}", role_slug(role_kind))
+}
+
+async fn is_git_repo(base: &Path) -> bool {
+    crate::process::tokio_command("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(base)
+        .output()
+        .await
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+async fn git_worktree_add(base: &Path, branch: &str, target: &Path) -> io::Result<()> {
+    let target_str = target.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "worktree target path is not valid UTF-8",
+        )
+    })?;
+    let output = crate::process::tokio_command("git")
+        .args(["worktree", "add", "-B", branch, target_str, "HEAD"])
+        .current_dir(base)
+        .output()
+        .await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(io::Error::other(format!(
+            "git worktree add failed: {}",
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    #[test]
+    fn planned_path_components() {
+        let base = Path::new("/tmp/myrepo");
+        let p = planned_worktree_path(base, 42, SquadRoleKind::Worker);
+        let s = p.display().to_string();
+        assert!(s.contains(".codeg-worktrees/myrepo/42/"));
+    }
+
+    #[test]
+    fn branch_name_includes_run_and_role() {
+        let b = role_branch_name(7, SquadRoleKind::Worker);
+        assert!(b.starts_with("codeg/squad/7/"));
+    }
+
+    #[tokio::test]
+    async fn read_only_returns_base() {
+        let res = ensure_role_workspace(
+            Some("/tmp/some-base"),
+            1,
+            SquadRoleKind::Worker,
+            SquadWorkspacePolicy::ReadOnly,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res.as_deref(), Some("/tmp/some-base"));
+    }
+
+    #[tokio::test]
+    async fn empty_base_returns_none() {
+        let res = ensure_role_workspace(
+            Some("   "),
+            1,
+            SquadRoleKind::Worker,
+            SquadWorkspacePolicy::WriteIsolated,
+        )
+        .await
+        .unwrap();
+        assert!(res.is_none());
+    }
+
+    #[tokio::test]
+    async fn isolated_creates_git_worktree_when_repo() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-q", "-b", "main"]);
+        run(&["config", "user.email", "t@t"]);
+        run(&["config", "user.name", "t"]);
+        std::fs::write(repo.join("a.txt"), "hi").unwrap();
+        run(&["add", "a.txt"]);
+        run(&["commit", "-q", "-m", "init"]);
+
+        let res = ensure_role_workspace(
+            repo.to_str(),
+            99,
+            SquadRoleKind::Worker,
+            SquadWorkspacePolicy::WriteIsolated,
+        )
+        .await
+        .unwrap();
+        let path = res.expect("workspace path");
+        assert!(Path::new(&path).join("a.txt").exists());
+
+        // second call must be idempotent
+        let res2 = ensure_role_workspace(
+            repo.to_str(),
+            99,
+            SquadRoleKind::Worker,
+            SquadWorkspacePolicy::WriteIsolated,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res2.as_deref(), Some(path.as_str()));
+    }
+
+    #[tokio::test]
+    async fn isolated_falls_back_for_non_git_base() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join("plain");
+        std::fs::create_dir_all(&base).unwrap();
+
+        let res = ensure_role_workspace(
+            base.to_str(),
+            1,
+            SquadRoleKind::Worker,
+            SquadWorkspacePolicy::WriteIsolated,
+        )
+        .await
+        .unwrap();
+        let path = res.expect("workspace path");
+        assert!(Path::new(&path).is_dir());
+    }
 }

--- a/src-tauri/src/squad/worktree_manager.rs
+++ b/src-tauri/src/squad/worktree_manager.rs
@@ -1,0 +1,43 @@
+use std::path::{Path, PathBuf};
+
+use crate::models::squad::{SquadRoleKind, SquadWorkspacePolicy};
+
+pub fn role_workspace_path(
+    base_working_dir: Option<&str>,
+    run_id: i32,
+    role_kind: SquadRoleKind,
+    policy: SquadWorkspacePolicy,
+) -> Option<String> {
+    let base = base_working_dir?.trim();
+    if base.is_empty() {
+        return None;
+    }
+    match policy {
+        SquadWorkspacePolicy::ReadOnly | SquadWorkspacePolicy::WriteShared => {
+            Some(base.to_string())
+        }
+        SquadWorkspacePolicy::WriteIsolated => Some(
+            planned_worktree_path(Path::new(base), run_id, role_kind)
+                .display()
+                .to_string(),
+        ),
+    }
+}
+
+fn planned_worktree_path(base: &Path, run_id: i32, role_kind: SquadRoleKind) -> PathBuf {
+    let repo_name = base
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("workspace");
+    let role = serde_json::to_string(&role_kind)
+        .unwrap_or_else(|_| "worker".to_string())
+        .trim_matches('"')
+        .to_string();
+    let parent = base.parent().unwrap_or_else(|| Path::new("."));
+    parent
+        .join(".codeg-worktrees")
+        .join(repo_name)
+        .join(run_id.to_string())
+        .join(role)
+}

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
+use chrono::Utc;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 
 use super::error::TerminalError;
@@ -16,7 +17,9 @@ struct TerminalInstance {
     master: Box<dyn MasterPty + Send>,
     _child: Box<dyn portable_pty::Child + Send>,
     title: String,
+    working_dir: String,
     owner_window_label: String,
+    created_at: String,
     /// Temp files (credential store + helper script) to clean up on exit.
     temp_files: Vec<std::path::PathBuf>,
 }
@@ -250,7 +253,9 @@ impl TerminalManager {
             master: pair.master,
             _child: child,
             title: "Terminal".to_string(),
+            working_dir: opts.working_dir,
             owner_window_label: opts.owner_window_label,
+            created_at: Utc::now().to_rfc3339(),
             temp_files: opts.temp_files,
         };
 
@@ -350,6 +355,9 @@ impl TerminalManager {
             .map(|(id, inst)| TerminalInfo {
                 id: id.clone(),
                 title: inst.title.clone(),
+                working_dir: inst.working_dir.clone(),
+                owner_window_label: inst.owner_window_label.clone(),
+                created_at: inst.created_at.clone(),
             })
             .collect();
 

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -417,8 +417,37 @@ impl TerminalManager {
 }
 
 fn terminate_terminal(instance: &mut TerminalInstance) {
+    // Capture the child PID before killing so we can also reap any
+    // descendants the shell spawned (cargo, node, long-running tools).
+    // Without this, those orphans get re-parented to PID 1 on Linux/macOS
+    // and continue burning CPU after the user "closed" the terminal.
+    let pid = instance._child.process_id();
     let _ = instance._child.kill();
     let _ = instance._child.wait();
+    if let Some(pid) = pid {
+        match kill_tree::blocking::kill_tree(pid) {
+            Ok(outputs) => {
+                if !outputs.is_empty() {
+                    let killed: Vec<u32> = outputs
+                        .iter()
+                        .filter_map(|o| match o {
+                            kill_tree::Output::Killed { process_id, .. } => Some(*process_id),
+                            _ => None,
+                        })
+                        .collect();
+                    if !killed.is_empty() {
+                        eprintln!(
+                            "[TERM] kill_tree pid={} descendants_killed={:?}",
+                            pid, killed
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!("[TERM] kill_tree pid={} failed: {}", pid, err);
+            }
+        }
+    }
     cleanup_temp_files(&mut instance.temp_files);
 }
 

--- a/src-tauri/src/terminal/types.rs
+++ b/src-tauri/src/terminal/types.rs
@@ -10,4 +10,7 @@ pub struct TerminalEvent {
 pub struct TerminalInfo {
     pub id: String,
     pub title: String,
+    pub working_dir: String,
+    pub owner_window_label: String,
+    pub created_at: String,
 }

--- a/src-tauri/src/web/auth.rs
+++ b/src-tauri/src/web/auth.rs
@@ -4,6 +4,14 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use subtle::ConstantTimeEq;
+
+/// Constant-time comparison of two strings to prevent timing attacks.
+/// Always compares full lengths to avoid leaking length information via early-exit timing.
+#[inline]
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
 
 pub async fn require_token(request: Request, next: Next, token: String) -> Response {
     // Allow WebSocket upgrade requests to authenticate via query param.
@@ -17,7 +25,7 @@ pub async fn require_token(request: Request, next: Next, token: String) -> Respo
                 continue;
             }
             if let Ok(decoded) = urlencoding::decode(value) {
-                if decoded == token {
+                if constant_time_eq(&decoded, &token) {
                     return next.run(request).await;
                 }
             }
@@ -27,8 +35,10 @@ pub async fn require_token(request: Request, next: Next, token: String) -> Respo
     // Check Authorization header
     if let Some(auth_header) = request.headers().get("authorization") {
         if let Ok(auth_str) = auth_header.to_str() {
-            if auth_str.strip_prefix("Bearer ").is_some_and(|t| t == token) {
-                return next.run(request).await;
+            if let Some(t) = auth_str.strip_prefix("Bearer ") {
+                if constant_time_eq(t, &token) {
+                    return next.run(request).await;
+                }
             }
         }
     }

--- a/src-tauri/src/web/client_owner.rs
+++ b/src-tauri/src/web/client_owner.rs
@@ -105,7 +105,9 @@ impl WebClientRegistry {
 
     pub async fn has_active_client(&self, client_id: &str) -> bool {
         let inner = self.inner.lock().await;
-        inner.get(client_id).is_some_and(|entry| entry.active_sockets > 0)
+        inner
+            .get(client_id)
+            .is_some_and(|entry| entry.active_sockets > 0)
     }
 
     pub async fn list_clients(&self) -> Vec<WebClientInfo> {

--- a/src-tauri/src/web/client_owner.rs
+++ b/src-tauri/src/web/client_owner.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use axum::http::HeaderMap;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+pub const WEB_CLIENT_ID_HEADER: &str = "x-codeg-client-id";
+pub const WEB_CLIENT_CLEANUP_DELAY: Duration = Duration::from_secs(10);
+
+const WEB_OWNER_FALLBACK: &str = "web";
+const WEB_OWNER_PREFIX: &str = "web:";
+const MAX_WEB_CLIENT_ID_LEN: usize = 128;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct WebClientInfo {
+    pub client_id: String,
+    pub active_sockets: usize,
+    pub connected_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+struct ClientLeaseState {
+    active_sockets: usize,
+    generation: u64,
+    connected_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl Default for ClientLeaseState {
+    fn default() -> Self {
+        let now = Utc::now();
+        Self {
+            active_sockets: 0,
+            generation: 0,
+            connected_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct WebClientRegistry {
+    inner: Mutex<HashMap<String, ClientLeaseState>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CleanupLease {
+    pub client_id: String,
+    generation: u64,
+}
+
+impl WebClientRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn register_socket(&self, client_id: &str) {
+        let mut inner = self.inner.lock().await;
+        let entry = inner.entry(client_id.to_string()).or_default();
+        if entry.active_sockets == 0 {
+            entry.connected_at = Utc::now();
+        }
+        entry.active_sockets += 1;
+        entry.generation = entry.generation.saturating_add(1);
+        entry.updated_at = Utc::now();
+    }
+
+    pub async fn unregister_socket(&self, client_id: &str) -> Option<CleanupLease> {
+        let mut inner = self.inner.lock().await;
+        let entry = inner.get_mut(client_id)?;
+        if entry.active_sockets > 0 {
+            entry.active_sockets -= 1;
+        }
+        entry.generation = entry.generation.saturating_add(1);
+        entry.updated_at = Utc::now();
+        if entry.active_sockets == 0 {
+            Some(CleanupLease {
+                client_id: client_id.to_string(),
+                generation: entry.generation,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub async fn should_cleanup(&self, cleanup_lease: &CleanupLease) -> bool {
+        let inner = self.inner.lock().await;
+        inner.get(&cleanup_lease.client_id).is_some_and(|entry| {
+            entry.active_sockets == 0 && entry.generation == cleanup_lease.generation
+        })
+    }
+
+    pub async fn finish_cleanup(&self, cleanup_lease: &CleanupLease) {
+        let mut inner = self.inner.lock().await;
+        let should_remove = inner.get(&cleanup_lease.client_id).is_some_and(|entry| {
+            entry.active_sockets == 0 && entry.generation == cleanup_lease.generation
+        });
+        if should_remove {
+            inner.remove(&cleanup_lease.client_id);
+        }
+    }
+
+    pub async fn has_active_client(&self, client_id: &str) -> bool {
+        let inner = self.inner.lock().await;
+        inner.get(client_id).is_some_and(|entry| entry.active_sockets > 0)
+    }
+
+    pub async fn list_clients(&self) -> Vec<WebClientInfo> {
+        let inner = self.inner.lock().await;
+        inner
+            .iter()
+            .map(|(client_id, entry)| WebClientInfo {
+                client_id: client_id.clone(),
+                active_sockets: entry.active_sockets,
+                connected_at: entry.connected_at,
+                updated_at: entry.updated_at,
+            })
+            .collect()
+    }
+}
+
+pub fn owner_label_from_headers(headers: &HeaderMap) -> String {
+    extract_web_client_id(headers)
+        .map(|client_id| owner_label_for_client(&client_id))
+        .unwrap_or_else(|| WEB_OWNER_FALLBACK.to_string())
+}
+
+pub fn owner_label_for_client(client_id: &str) -> String {
+    format!("{WEB_OWNER_PREFIX}{client_id}")
+}
+
+pub fn extract_web_client_id(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(WEB_CLIENT_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(normalize_web_client_id)
+}
+
+pub fn normalize_web_client_id(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_WEB_CLIENT_ID_LEN {
+        return None;
+    }
+
+    if trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}

--- a/src-tauri/src/web/event_bridge.rs
+++ b/src-tauri/src/web/event_bridge.rs
@@ -21,7 +21,11 @@ impl Default for WebEventBroadcaster {
 
 impl WebEventBroadcaster {
     pub fn new() -> Self {
-        let (sender, _) = broadcast::channel(4096);
+        // Capacity tuned for bursty ACP/terminal output. Slow clients can
+        // still overrun this; when that happens the WS handler emits a
+        // `__resync` event so the client refetches state instead of
+        // silently missing transitions.
+        let (sender, _) = broadcast::channel(8192);
         Self { sender }
     }
 

--- a/src-tauri/src/web/handlers/acp.rs
+++ b/src-tauri/src/web/handlers/acp.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use axum::{extract::Extension, Json};
+use axum::{extract::Extension, http::HeaderMap, Json};
 use serde::Deserialize;
 
 use crate::acp::opencode_plugins::PluginCheckSummary;
@@ -14,6 +14,7 @@ use crate::app_error::AppCommandError;
 use crate::app_state::AppState;
 use crate::commands::acp as acp_commands;
 use crate::db::service::agent_setting_service;
+use crate::db::service::folder_service;
 use crate::models::agent::AgentType;
 
 #[derive(Deserialize)]
@@ -53,6 +54,7 @@ pub struct AcpConnectParams {
 
 pub async fn acp_connect(
     Extension(state): Extension<Arc<AppState>>,
+    headers: HeaderMap,
     Json(params): Json<AcpConnectParams>,
 ) -> Result<Json<String>, AppCommandError> {
     let db = &state.db;
@@ -80,16 +82,38 @@ pub async fn acp_connect(
     );
 
     // Resolve model provider credentials if configured.
+    let workspace_preset = match params
+        .working_dir
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+    {
+        Some(path) => folder_service::get_folder_by_path(&db.conn, path)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|folder| folder.workspace_preset),
+        None => None,
+    };
+    let preset_model_provider_id = workspace_preset
+        .as_ref()
+        .and_then(|preset| preset.model_provider_id);
     acp_commands::apply_model_provider_env(
         params.agent_type,
         setting.as_ref(),
+        preset_model_provider_id,
         &mut runtime_env,
         &db.conn,
     )
     .await;
 
-    if params.agent_type == AgentType::OpenClaw && params.session_id.is_none() {
-        runtime_env.insert("OPENCLAW_RESET_SESSION".into(), "1".into());
+    if let Some(preset) = workspace_preset.as_ref() {
+        for (key, value) in &preset.env_overrides {
+            runtime_env.insert(key.clone(), value.clone());
+        }
+    }
+
+    if params.agent_type == AgentType::Generic && params.session_id.is_none() {
+        runtime_env.insert("GENERIC_RESET_SESSION".into(), "1".into());
     }
 
     // Guard: the session page must never trigger a download or install.
@@ -99,13 +123,14 @@ pub async fn acp_connect(
         .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))?;
 
     let emitter = state.emitter.clone();
+    let owner_window_label = crate::web::client_owner::owner_label_from_headers(&headers);
     let connection_id = manager
         .spawn_agent(
             params.agent_type,
             params.working_dir,
             params.session_id,
             runtime_env,
-            "web".to_string(),
+            owner_window_label,
             emitter,
         )
         .await

--- a/src-tauri/src/web/handlers/folders.rs
+++ b/src-tauri/src/web/handlers/folders.rs
@@ -15,6 +15,13 @@ pub struct FolderIdParams {
     pub folder_id: i32,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateFolderWorkspacePresetParams {
+    pub folder_id: i32,
+    pub workspace_preset: Option<WorkspacePreset>,
+}
+
 pub async fn load_folder_history(
     Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<Vec<FolderHistoryEntry>>, AppCommandError> {
@@ -121,6 +128,18 @@ pub async fn remove_folder_from_workspace(
         .await
         .map_err(AppCommandError::from)?;
     Ok(Json(()))
+}
+
+pub async fn update_folder_workspace_preset(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<UpdateFolderWorkspacePresetParams>,
+) -> Result<Json<FolderDetail>, AppCommandError> {
+    let db = &state.db;
+    let result =
+        folder_service::update_workspace_preset(&db.conn, params.folder_id, params.workspace_preset)
+            .await
+            .map_err(AppCommandError::from)?;
+    Ok(Json(result))
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/web/handlers/folders.rs
+++ b/src-tauri/src/web/handlers/folders.rs
@@ -135,10 +135,13 @@ pub async fn update_folder_workspace_preset(
     Json(params): Json<UpdateFolderWorkspacePresetParams>,
 ) -> Result<Json<FolderDetail>, AppCommandError> {
     let db = &state.db;
-    let result =
-        folder_service::update_workspace_preset(&db.conn, params.folder_id, params.workspace_preset)
-            .await
-            .map_err(AppCommandError::from)?;
+    let result = folder_service::update_workspace_preset(
+        &db.conn,
+        params.folder_id,
+        params.workspace_preset,
+    )
+    .await
+    .map_err(AppCommandError::from)?;
     Ok(Json(result))
 }
 

--- a/src-tauri/src/web/handlers/mod.rs
+++ b/src-tauri/src/web/handlers/mod.rs
@@ -10,6 +10,7 @@ pub mod git;
 pub mod mcp;
 pub mod model_provider;
 pub mod project_boot;
+pub mod runtime;
 pub mod system_settings;
 pub mod terminal;
 pub mod version_control;

--- a/src-tauri/src/web/handlers/mod.rs
+++ b/src-tauri/src/web/handlers/mod.rs
@@ -11,6 +11,7 @@ pub mod mcp;
 pub mod model_provider;
 pub mod project_boot;
 pub mod runtime;
+pub mod squad;
 pub mod system_settings;
 pub mod terminal;
 pub mod version_control;

--- a/src-tauri/src/web/handlers/runtime.rs
+++ b/src-tauri/src/web/handlers/runtime.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use axum::{extract::Extension, Json};
+
+use crate::app_error::AppCommandError;
+use crate::app_state::AppState;
+use crate::commands::runtime as runtime_commands;
+
+pub async fn get_runtime_diagnostics(
+    Extension(state): Extension<Arc<AppState>>,
+) -> Result<Json<runtime_commands::RuntimeDiagnostics>, AppCommandError> {
+    let result = runtime_commands::get_runtime_diagnostics_core(
+        &state.connection_manager,
+        &state.terminal_manager,
+        &state.web_client_registry,
+        &state.runtime_monitor,
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+pub async fn get_acp_cache_inventory(
+) -> Result<Json<crate::acp::binary_cache::AcpCacheInventory>, AppCommandError> {
+    let result = crate::acp::binary_cache::inventory_agent_caches()
+        .map_err(|error| AppCommandError::task_execution_failed(error.to_string()))?;
+    Ok(Json(result))
+}

--- a/src-tauri/src/web/handlers/squad.rs
+++ b/src-tauri/src/web/handlers/squad.rs
@@ -98,6 +98,23 @@ pub struct CreateArtifactParams {
     pub content_json: String,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyConductorOutputParams {
+    pub squad_run_id: i32,
+    pub raw_text: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordTurnArtifactsParams {
+    pub squad_run_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub task_id: Option<i32>,
+    pub agent_text: String,
+    pub plan_json: Option<String>,
+}
+
 pub async fn squad_get_role_profiles(
     Extension(state): Extension<Arc<AppState>>,
     Json(params): Json<FolderIdParams>,
@@ -284,6 +301,7 @@ pub async fn squad_create_artifact(
     Ok(Json(
         squad_commands::squad_create_artifact_core(
             &state.db,
+            &state.emitter,
             params.squad_run_id,
             params.role_kind,
             params.task_id,
@@ -301,5 +319,53 @@ pub async fn squad_list_artifacts(
 ) -> Result<Json<Vec<SquadArtifactInfo>>, AppCommandError> {
     Ok(Json(
         squad_commands::squad_list_artifacts_core(&state.db, params.squad_run_id).await?,
+    ))
+}
+
+pub async fn squad_apply_conductor_output(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<ApplyConductorOutputParams>,
+) -> Result<Json<crate::squad::dispatcher::ApplyConductorOutputResult>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_apply_conductor_output_core(
+            &state.db,
+            &state.emitter,
+            params.squad_run_id,
+            params.raw_text,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_dispatch_pending_tasks(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RunIdParams>,
+) -> Result<Json<crate::squad::dispatcher::DispatchPendingTasksResult>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_dispatch_pending_tasks_core(
+            &state.db,
+            &state.connection_manager,
+            &state.emitter,
+            params.squad_run_id,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_record_turn_artifacts(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RecordTurnArtifactsParams>,
+) -> Result<Json<crate::squad::dispatcher::TurnArtifactsResult>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_record_turn_artifacts_core(
+            &state.db,
+            &state.emitter,
+            params.squad_run_id,
+            params.role_kind,
+            params.task_id,
+            params.agent_text,
+            params.plan_json,
+        )
+        .await?,
     ))
 }

--- a/src-tauri/src/web/handlers/squad.rs
+++ b/src-tauri/src/web/handlers/squad.rs
@@ -1,0 +1,305 @@
+use std::sync::Arc;
+
+use axum::{extract::Extension, Json};
+use serde::Deserialize;
+
+use crate::app_error::AppCommandError;
+use crate::app_state::AppState;
+use crate::commands::squad as squad_commands;
+use crate::models::squad::{
+    SquadArtifactInfo, SquadArtifactType, SquadRoleKind, SquadRoleProfileInfo,
+    SquadRoleProfilePatch, SquadRoleRunInfo, SquadRunInfo, SquadRunMode, SquadRunSnapshot,
+    SquadTaskInfo, SquadTaskStatus,
+};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderIdParams {
+    pub folder_id: i32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleProfileParams {
+    pub folder_id: i32,
+    pub role_kind: SquadRoleKind,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateRoleProfileParams {
+    pub folder_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub patch: SquadRoleProfilePatch,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateRunParams {
+    pub folder_id: i32,
+    pub origin_conversation_id: Option<i32>,
+    pub mode: SquadRunMode,
+    pub goal_summary: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunIdParams {
+    pub squad_run_id: i32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartRunParams {
+    pub squad_run_id: i32,
+    pub working_dir: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleRuntimeParams {
+    pub squad_run_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub working_dir: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptRoleParams {
+    pub squad_run_id: i32,
+    pub role_kind: SquadRoleKind,
+    pub task_id: Option<i32>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTaskParams {
+    pub squad_run_id: i32,
+    pub assigned_role_kind: SquadRoleKind,
+    pub title: String,
+    pub description: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTaskStatusParams {
+    pub task_id: i32,
+    pub status: SquadTaskStatus,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateArtifactParams {
+    pub squad_run_id: i32,
+    pub role_kind: Option<SquadRoleKind>,
+    pub task_id: Option<i32>,
+    pub artifact_type: SquadArtifactType,
+    pub title: String,
+    pub content_json: String,
+}
+
+pub async fn squad_get_role_profiles(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<FolderIdParams>,
+) -> Result<Json<Vec<SquadRoleProfileInfo>>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_get_role_profiles_core(&state.db, params.folder_id).await?,
+    ))
+}
+
+pub async fn squad_seed_role_profiles(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<FolderIdParams>,
+) -> Result<Json<Vec<SquadRoleProfileInfo>>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_seed_role_profiles_core(&state.db, params.folder_id).await?,
+    ))
+}
+
+pub async fn squad_update_role_profile(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<UpdateRoleProfileParams>,
+) -> Result<Json<SquadRoleProfileInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_update_role_profile_core(
+            &state.db,
+            params.folder_id,
+            params.role_kind,
+            params.patch,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_reset_role_profile(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RoleProfileParams>,
+) -> Result<Json<SquadRoleProfileInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_reset_role_profile_core(
+            &state.db,
+            params.folder_id,
+            params.role_kind,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_create_run(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<CreateRunParams>,
+) -> Result<Json<SquadRunSnapshot>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_create_run_core(
+            &state.db,
+            params.folder_id,
+            params.origin_conversation_id,
+            params.mode,
+            params.goal_summary,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_get_run(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RunIdParams>,
+) -> Result<Json<SquadRunSnapshot>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_get_run_core(&state.db, params.squad_run_id).await?,
+    ))
+}
+
+pub async fn squad_list_runs(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<FolderIdParams>,
+) -> Result<Json<Vec<SquadRunInfo>>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_list_runs_core(&state.db, params.folder_id).await?,
+    ))
+}
+
+pub async fn squad_start_run(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<StartRunParams>,
+) -> Result<Json<()>, AppCommandError> {
+    squad_commands::squad_start_run_core(
+        &state.db,
+        &state.connection_manager,
+        &state.emitter,
+        params.squad_run_id,
+        params.working_dir,
+    )
+    .await?;
+    Ok(Json(()))
+}
+
+pub async fn squad_stop_run(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RunIdParams>,
+) -> Result<Json<()>, AppCommandError> {
+    squad_commands::squad_stop_run_core(
+        &state.db,
+        &state.connection_manager,
+        &state.emitter,
+        params.squad_run_id,
+    )
+    .await?;
+    Ok(Json(()))
+}
+
+pub async fn squad_connect_role(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RoleRuntimeParams>,
+) -> Result<Json<SquadRoleRunInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_connect_role_core(
+            &state.db,
+            &state.connection_manager,
+            &state.emitter,
+            params.squad_run_id,
+            params.role_kind,
+            params.working_dir,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_prompt_role(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<PromptRoleParams>,
+) -> Result<Json<SquadRoleRunInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_prompt_role_core(
+            &state.db,
+            &state.connection_manager,
+            &state.emitter,
+            params.squad_run_id,
+            params.role_kind,
+            params.task_id,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_create_task(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<CreateTaskParams>,
+) -> Result<Json<SquadTaskInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_create_task_core(
+            &state.db,
+            params.squad_run_id,
+            params.assigned_role_kind,
+            params.title,
+            params.description,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_update_task_status(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<UpdateTaskStatusParams>,
+) -> Result<Json<SquadTaskInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_update_task_status_core(&state.db, params.task_id, params.status)
+            .await?,
+    ))
+}
+
+pub async fn squad_list_tasks(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RunIdParams>,
+) -> Result<Json<Vec<SquadTaskInfo>>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_list_tasks_core(&state.db, params.squad_run_id).await?,
+    ))
+}
+
+pub async fn squad_create_artifact(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<CreateArtifactParams>,
+) -> Result<Json<SquadArtifactInfo>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_create_artifact_core(
+            &state.db,
+            params.squad_run_id,
+            params.role_kind,
+            params.task_id,
+            params.artifact_type,
+            params.title,
+            params.content_json,
+        )
+        .await?,
+    ))
+}
+
+pub async fn squad_list_artifacts(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<RunIdParams>,
+) -> Result<Json<Vec<SquadArtifactInfo>>, AppCommandError> {
+    Ok(Json(
+        squad_commands::squad_list_artifacts_core(&state.db, params.squad_run_id).await?,
+    ))
+}

--- a/src-tauri/src/web/handlers/terminal.rs
+++ b/src-tauri/src/web/handlers/terminal.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::{extract::Extension, Json};
+use axum::{extract::Extension, http::HeaderMap, Json};
 use serde::Deserialize;
 
 use crate::app_error::AppCommandError;
@@ -48,6 +48,7 @@ pub struct TerminalResizeParams {
 
 pub async fn terminal_spawn(
     Extension(state): Extension<Arc<AppState>>,
+    headers: HeaderMap,
     Json(params): Json<TerminalSpawnParams>,
 ) -> Result<Json<String>, AppCommandError> {
     let manager = &state.terminal_manager;
@@ -57,13 +58,14 @@ pub async fn terminal_spawn(
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
     let extra_env = prepare_credential_env(&state.data_dir);
+    let owner_window_label = crate::web::client_owner::owner_label_from_headers(&headers);
 
     let id = manager
         .spawn_with_id(
             SpawnOptions {
                 terminal_id,
                 working_dir: params.working_dir,
-                owner_window_label: "web".to_string(),
+                owner_window_label,
                 initial_command: params.initial_command,
                 extra_env,
                 temp_files: vec![],

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -505,6 +505,7 @@ pub async fn start_web_server(
         runtime_monitor,
         web_server_state: WebServerState::new(), // placeholder; not used by handlers
         chat_channel_manager: crate::app_state::default_chat_channel_manager(),
+        task_tracker: tokio_util::task::TaskTracker::new(),
     });
 
     let router = router::build_router(app_state, token.clone(), static_dir);

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod client_owner;
 pub mod event_bridge;
 pub mod handlers;
 pub mod router;
@@ -302,6 +303,39 @@ pub(crate) async fn do_start_web_server_with_state(
     let port = resolve_web_service_port(&app_state.db.conn, port).await?;
     let host = host.unwrap_or_else(|| "0.0.0.0".to_string());
     let token = resolve_web_service_token(&app_state.db.conn, token).await?;
+    let auth_enabled = !token.is_empty();
+
+    let build_consistency = crate::build_info::enforce_build_consistency(&static_dir)?;
+    app_state
+        .runtime_monitor
+        .set_build_consistency(build_consistency.clone());
+    app_state.runtime_monitor.record(
+        if build_consistency.status == "ok" {
+            "info"
+        } else {
+            "warn"
+        },
+        "web",
+        build_consistency.message.clone(),
+        None,
+    );
+
+    let security = crate::build_info::enforce_startup_security(
+        "embedded_web",
+        &host,
+        auth_enabled,
+        Some(&static_dir),
+        Some(&app_state.data_dir),
+    )?;
+    app_state.runtime_monitor.set_security(security.clone());
+    if security.insecure && security.override_active {
+        app_state.runtime_monitor.record(
+            "warn",
+            "web",
+            "Insecure remote web-server override is active",
+            None,
+        );
+    }
 
     let addr: SocketAddr =
         format!("{}:{}", host, port)
@@ -398,6 +432,7 @@ pub async fn start_web_server(
     let port_val = resolve_web_service_port(&db.conn, port).await?;
     let host_val = host.unwrap_or_else(|| "0.0.0.0".to_string());
     let token = resolve_web_service_token(&db.conn, token).await?;
+    let auth_enabled = !token.is_empty();
 
     let addr: SocketAddr =
         format!("{}:{}", host_val, port_val)
@@ -415,6 +450,40 @@ pub async fn start_web_server(
     persist_web_service_config(&db.conn, &token, port_val).await?;
 
     let static_dir = find_static_dir_tauri(&app);
+    let runtime_monitor = app
+        .state::<std::sync::Arc<crate::runtime_monitor::RuntimeMonitor>>()
+        .inner()
+        .clone();
+    let build_consistency = crate::build_info::enforce_build_consistency(&static_dir)?;
+    runtime_monitor.set_build_consistency(build_consistency.clone());
+    runtime_monitor.record(
+        if build_consistency.status == "ok" {
+            "info"
+        } else {
+            "warn"
+        },
+        "web",
+        build_consistency.message.clone(),
+        None,
+    );
+
+    let data_dir = app.path().app_data_dir().unwrap_or_default();
+    let security = crate::build_info::enforce_startup_security(
+        "embedded_web",
+        &host_val,
+        auth_enabled,
+        Some(&static_dir),
+        Some(&data_dir),
+    )?;
+    runtime_monitor.set_security(security.clone());
+    if security.insecure && security.override_active {
+        runtime_monitor.record(
+            "warn",
+            "web",
+            "Insecure remote web-server override is active",
+            None,
+        );
+    }
 
     // Build AppState for the router
     let app_state = Arc::new(AppState {
@@ -423,12 +492,17 @@ pub async fn start_web_server(
         },
         connection_manager: (*app.state::<crate::acp::manager::ConnectionManager>()).clone_ref(),
         terminal_manager: (*app.state::<crate::terminal::manager::TerminalManager>()).clone_ref(),
+        web_client_registry: app
+            .state::<Arc<crate::web::client_owner::WebClientRegistry>>()
+            .inner()
+            .clone(),
         event_broadcaster: app
             .state::<Arc<crate::web::event_bridge::WebEventBroadcaster>>()
             .inner()
             .clone(),
         emitter: crate::web::event_bridge::EventEmitter::Tauri(app.clone()),
-        data_dir: app.path().app_data_dir().unwrap_or_default(),
+        data_dir,
+        runtime_monitor,
         web_server_state: WebServerState::new(), // placeholder; not used by handlers
         chat_channel_manager: crate::app_state::default_chat_channel_manager(),
     });

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -687,6 +687,18 @@ pub fn build_router(state: Arc<AppState>, token: String, static_dir: std::path::
             "/squad_list_artifacts",
             post(handlers::squad::squad_list_artifacts),
         )
+        .route(
+            "/squad_apply_conductor_output",
+            post(handlers::squad::squad_apply_conductor_output),
+        )
+        .route(
+            "/squad_dispatch_pending_tasks",
+            post(handlers::squad::squad_dispatch_pending_tasks),
+        )
+        .route(
+            "/squad_record_turn_artifacts",
+            post(handlers::squad::squad_record_turn_artifacts),
+        )
         // ─── Terminal ───
         .route("/terminal_spawn", post(handlers::terminal::terminal_spawn))
         .route("/terminal_write", post(handlers::terminal::terminal_write))

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -21,6 +21,7 @@ pub fn build_router(state: Arc<AppState>, token: String, static_dir: std::path::
         .allow_headers(Any);
 
     let token_for_ws = token.clone();
+    let auth_enabled = !token.is_empty();
 
     let api = Router::new()
         .route("/health", post(health_check))
@@ -79,6 +80,14 @@ pub fn build_router(state: Arc<AppState>, token: String, static_dir: std::path::
             "/update_conversation_external_id",
             post(handlers::conversations::update_conversation_external_id),
         )
+        .route(
+            "/get_runtime_diagnostics",
+            post(handlers::runtime::get_runtime_diagnostics),
+        )
+        .route(
+            "/get_acp_cache_inventory",
+            post(handlers::runtime::get_acp_cache_inventory),
+        )
         // ─── Folders ───
         .route(
             "/load_folder_history",
@@ -105,6 +114,10 @@ pub fn build_router(state: Arc<AppState>, token: String, static_dir: std::path::
         .route(
             "/remove_folder_from_workspace",
             post(handlers::folders::remove_folder_from_workspace),
+        )
+        .route(
+            "/update_folder_workspace_preset",
+            post(handlers::folders::update_folder_workspace_preset),
         )
         .route("/reorder_folders", post(handlers::folders::reorder_folders))
         .route(
@@ -637,17 +650,26 @@ pub fn build_router(state: Arc<AppState>, token: String, static_dir: std::path::
         .route("/terminal_kill", post(handlers::terminal::terminal_kill))
         .route("/terminal_list", post(handlers::terminal::terminal_list))
         // Catch-all
-        .fallback(api_not_found)
-        .layer(middleware::from_fn(move |req, next| {
+        .fallback(api_not_found);
+
+    let api = if auth_enabled {
+        api.layer(middleware::from_fn(move |req, next| {
             auth::require_token(req, next, token.clone())
-        }));
+        }))
+    } else {
+        api
+    };
 
     // WebSocket route (auth via query param)
-    let ws_route = Router::new()
-        .route("/ws/events", get(ws::ws_handler))
-        .layer(middleware::from_fn(move |req, next| {
+    let ws_route = Router::new().route("/ws/events", get(ws::ws_handler));
+
+    let ws_route = if auth_enabled {
+        ws_route.layer(middleware::from_fn(move |req, next| {
             auth::require_token(req, next, token_for_ws.clone())
-        }));
+        }))
+    } else {
+        ws_route
+    };
 
     // Static file serving.
     // Next.js static export produces "folder.html" for "/folder" route.

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -640,6 +640,53 @@ pub fn build_router(state: Arc<AppState>, token: String, static_dir: std::path::
             "/delete_model_provider",
             post(handlers::model_provider::delete_model_provider),
         )
+        // ─── Squad ───
+        .route(
+            "/squad_get_role_profiles",
+            post(handlers::squad::squad_get_role_profiles),
+        )
+        .route(
+            "/squad_seed_role_profiles",
+            post(handlers::squad::squad_seed_role_profiles),
+        )
+        .route(
+            "/squad_update_role_profile",
+            post(handlers::squad::squad_update_role_profile),
+        )
+        .route(
+            "/squad_reset_role_profile",
+            post(handlers::squad::squad_reset_role_profile),
+        )
+        .route("/squad_create_run", post(handlers::squad::squad_create_run))
+        .route("/squad_get_run", post(handlers::squad::squad_get_run))
+        .route("/squad_list_runs", post(handlers::squad::squad_list_runs))
+        .route("/squad_start_run", post(handlers::squad::squad_start_run))
+        .route("/squad_stop_run", post(handlers::squad::squad_stop_run))
+        .route(
+            "/squad_connect_role",
+            post(handlers::squad::squad_connect_role),
+        )
+        .route(
+            "/squad_prompt_role",
+            post(handlers::squad::squad_prompt_role),
+        )
+        .route(
+            "/squad_create_task",
+            post(handlers::squad::squad_create_task),
+        )
+        .route(
+            "/squad_update_task_status",
+            post(handlers::squad::squad_update_task_status),
+        )
+        .route("/squad_list_tasks", post(handlers::squad::squad_list_tasks))
+        .route(
+            "/squad_create_artifact",
+            post(handlers::squad::squad_create_artifact),
+        )
+        .route(
+            "/squad_list_artifacts",
+            post(handlers::squad::squad_list_artifacts),
+        )
         // ─── Terminal ───
         .route("/terminal_spawn", post(handlers::terminal::terminal_spawn))
         .route("/terminal_write", post(handlers::terminal::terminal_write))

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -2,20 +2,41 @@ use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket};
 use axum::{
-    extract::{Extension, WebSocketUpgrade},
+    extract::{Extension, Query, WebSocketUpgrade},
     response::IntoResponse,
 };
+use serde::Deserialize;
+use tokio::time::sleep;
 
 use crate::app_state::AppState;
+use crate::web::client_owner::{
+    normalize_web_client_id, owner_label_for_client, CleanupLease, WEB_CLIENT_CLEANUP_DELAY,
+};
 
-pub async fn ws_handler(
-    ws: WebSocketUpgrade,
-    Extension(state): Extension<Arc<AppState>>,
-) -> impl IntoResponse {
-    ws.on_upgrade(|socket| handle_ws_connection(socket, state))
+#[derive(Deserialize)]
+pub(crate) struct WsQueryParams {
+    #[serde(alias = "client_id")]
+    client_id: Option<String>,
 }
 
-async fn handle_ws_connection(mut socket: WebSocket, state: Arc<AppState>) {
+pub(crate) async fn ws_handler(
+    ws: WebSocketUpgrade,
+    Query(params): Query<WsQueryParams>,
+    Extension(state): Extension<Arc<AppState>>,
+) -> impl IntoResponse {
+    let client_id = params.client_id.and_then(|value| normalize_web_client_id(&value));
+    ws.on_upgrade(|socket| handle_ws_connection(socket, state, client_id))
+}
+
+async fn handle_ws_connection(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    client_id: Option<String>,
+) {
+    if let Some(client_id) = client_id.as_deref() {
+        state.web_client_registry.register_socket(client_id).await;
+    }
+
     let mut rx = state.event_broadcaster.subscribe();
 
     loop {
@@ -47,4 +68,44 @@ async fn handle_ws_connection(mut socket: WebSocket, state: Arc<AppState>) {
             }
         }
     }
+
+    if let Some(client_id) = client_id {
+        if let Some(cleanup_lease) = state.web_client_registry.unregister_socket(&client_id).await {
+            schedule_web_client_cleanup(state, cleanup_lease);
+        }
+    }
+}
+
+fn schedule_web_client_cleanup(state: Arc<AppState>, cleanup_lease: CleanupLease) {
+    tokio::spawn(async move {
+        sleep(WEB_CLIENT_CLEANUP_DELAY).await;
+        if !state
+            .web_client_registry
+            .should_cleanup(&cleanup_lease)
+            .await
+        {
+            return;
+        }
+
+        let owner_window_label = owner_label_for_client(&cleanup_lease.client_id);
+        let disconnected = state
+            .connection_manager
+            .disconnect_by_owner_window(&owner_window_label)
+            .await;
+        let killed = state
+            .terminal_manager
+            .kill_by_owner_window(&owner_window_label);
+
+        state
+            .web_client_registry
+            .finish_cleanup(&cleanup_lease)
+            .await;
+
+        if disconnected > 0 || killed > 0 {
+            eprintln!(
+                "[WS] cleaned up owner_window={} disconnected_connections={} killed_terminals={}",
+                owner_window_label, disconnected, killed
+            );
+        }
+    });
 }

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -53,7 +53,21 @@ async fn handle_ws_connection(
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        // The broadcast buffer overflowed for this socket.
+                        // Tell the client to resync: it should re-fetch the
+                        // active conversation/connection state since it may
+                        // have missed transitions (e.g. a connection going
+                        // from running → idle).
                         eprintln!("[WS] receiver lagged, skipped {n} events");
+                        let resync = serde_json::json!({
+                            "channel": "__resync",
+                            "payload": { "skipped": n }
+                        });
+                        if let Ok(msg) = serde_json::to_string(&resync) {
+                            if socket.send(Message::Text(msg.into())).await.is_err() {
+                                break;
+                            }
+                        }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                         break;

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -24,7 +24,9 @@ pub(crate) async fn ws_handler(
     Query(params): Query<WsQueryParams>,
     Extension(state): Extension<Arc<AppState>>,
 ) -> impl IntoResponse {
-    let client_id = params.client_id.and_then(|value| normalize_web_client_id(&value));
+    let client_id = params
+        .client_id
+        .and_then(|value| normalize_web_client_id(&value));
     ws.on_upgrade(|socket| handle_ws_connection(socket, state, client_id))
 }
 
@@ -70,7 +72,11 @@ async fn handle_ws_connection(
     }
 
     if let Some(client_id) = client_id {
-        if let Some(cleanup_lease) = state.web_client_registry.unregister_socket(&client_id).await {
+        if let Some(cleanup_lease) = state
+            .web_client_registry
+            .unregister_socket(&client_id)
+            .await
+        {
             schedule_web_client_cleanup(state, cleanup_lease);
         }
     }

--- a/src-tauri/src/web/ws.rs
+++ b/src-tauri/src/web/ws.rs
@@ -77,7 +77,12 @@ async fn handle_ws_connection(
 }
 
 fn schedule_web_client_cleanup(state: Arc<AppState>, cleanup_lease: CleanupLease) {
-    tokio::spawn(async move {
+    // Track the cleanup task so server shutdown can await pending cleanups
+    // instead of dropping them mid-sleep.
+    let tracker = state.task_tracker.clone();
+    let state_for_task = state.clone();
+    tracker.spawn(async move {
+        let state = state_for_task;
         sleep(WEB_CLIENT_CLEANUP_DELAY).await;
         if !state
             .web_client_registry

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,7 +12,23 @@ export default function LoginPage() {
 
   useEffect(() => {
     document.title = "Login - codeg"
-  }, [])
+    fetch("/api/health", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    })
+      .then((res) => {
+        if (res.ok) {
+          localStorage.removeItem("codeg_token")
+          router.replace("/workspace")
+        }
+      })
+      .catch(() => {
+        // keep login form for protected mode or unreachable server
+      })
+  }, [router])
 
   // Desktop users skip login entirely
   if (isDesktop()) {
@@ -29,15 +45,23 @@ export default function LoginPage() {
       // Validate token by calling a lightweight API endpoint
       const res = await fetch("/api/health", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
+        headers: token
+          ? {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            }
+          : {
+              "Content-Type": "application/json",
+            },
         body: "{}",
       })
 
       if (res.ok) {
-        localStorage.setItem("codeg_token", token)
+        if (token) {
+          localStorage.setItem("codeg_token", token)
+        } else {
+          localStorage.removeItem("codeg_token")
+        }
         router.replace("/workspace")
       } else if (res.status === 401) {
         setError("Token 无效，请检查后重试")
@@ -77,7 +101,7 @@ export default function LoginPage() {
 
           <button
             type="submit"
-            disabled={!token || loading}
+            disabled={loading}
             className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground ring-offset-background transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
           >
             {loading ? "连接中..." : "连接"}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,19 +11,16 @@ export default function Page() {
       router.replace("/workspace")
       return
     }
-    // Web mode: validate token before entering app
     const token = localStorage.getItem("codeg_token")
-    if (!token) {
-      router.replace("/login")
-      return
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
     }
-    // Verify token is still valid
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
     fetch("/api/health", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      headers,
       body: "{}",
     })
       .then((res) => {

--- a/src/app/workspace/layout.tsx
+++ b/src/app/workspace/layout.tsx
@@ -27,6 +27,8 @@ import { ConversationRuntimeProvider } from "@/contexts/conversation-runtime-con
 import { TabProvider, useTabContext } from "@/contexts/tab-context"
 import { SessionStatsProvider } from "@/contexts/session-stats-context"
 import { SidebarProvider, useSidebarContext } from "@/contexts/sidebar-context"
+import { SquadProvider } from "@/contexts/squad-context"
+import { TabBar } from "@/components/tabs/tab-bar"
 import {
   AuxPanelProvider,
   useAuxPanelContext,
@@ -40,9 +42,8 @@ import {
   WorkspaceProvider,
   useWorkspaceContext,
 } from "@/contexts/workspace-context"
-import { TabBar } from "@/components/tabs/tab-bar"
-import { TerminalPanel } from "@/components/terminal/terminal-panel"
 import { AuxPanel } from "@/components/layout/aux-panel"
+import { TerminalPanel } from "@/components/terminal/terminal-panel"
 import { FileWorkspaceTabBar } from "@/components/files/file-workspace-tab-bar"
 import { FileWorkspacePanel } from "@/components/files/file-workspace-panel"
 import { AppToaster } from "@/components/ui/app-toaster"
@@ -782,11 +783,15 @@ function WorkspaceLayoutInner({ children }: { children: React.ReactNode }) {
                       <DeepLinkBootstrap />
                       <SessionStatsProvider>
                         <SidebarProvider>
-                          <AuxPanelProvider>
-                            <TerminalProvider>
-                              <FolderLayoutShell>{children}</FolderLayoutShell>
-                            </TerminalProvider>
-                          </AuxPanelProvider>
+                          <SquadProvider>
+                            <AuxPanelProvider>
+                              <TerminalProvider>
+                                <FolderLayoutShell>
+                                  {children}
+                                </FolderLayoutShell>
+                              </TerminalProvider>
+                            </AuxPanelProvider>
+                          </SquadProvider>
                         </SidebarProvider>
                       </SessionStatsProvider>
                     </TabProvider>

--- a/src/components/agent-icon.tsx
+++ b/src/components/agent-icon.tsx
@@ -4,12 +4,7 @@ import type { AgentType } from "@/lib/types"
 import { AGENT_COLORS } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
-import {
-  ClaudeCode,
-  Cline,
-  GeminiCLI,
-  OpenCode,
-} from "@lobehub/icons"
+import { ClaudeCode, Cline, GeminiCLI, OpenCode } from "@lobehub/icons"
 
 interface AgentIconProps {
   agentType: AgentType
@@ -70,12 +65,7 @@ const GenericColorIcon = memo(function GenericColorIcon({
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>Generic</title>
-      <rect
-        fill="#475569"
-        height="24"
-        rx="4"
-        width="24"
-      />
+      <rect fill="#475569" height="24" rx="4" width="24" />
       <text
         dominantBaseline="central"
         fill="white"

--- a/src/components/agent-icon.tsx
+++ b/src/components/agent-icon.tsx
@@ -8,7 +8,6 @@ import {
   ClaudeCode,
   Cline,
   GeminiCLI,
-  OpenClaw,
   OpenCode,
 } from "@lobehub/icons"
 
@@ -57,17 +56,53 @@ const CodexColorIcon = memo(function CodexColorIcon({
   )
 })
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyIcon = React.ComponentType<any>
+const GenericColorIcon = memo(function GenericColorIcon({
+  size = "1em",
+}: {
+  size?: string | number
+}) {
+  return (
+    <svg
+      height={size}
+      style={{ flex: "none", lineHeight: 1 }}
+      viewBox="0 0 24 24"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>Generic</title>
+      <rect
+        fill="#475569"
+        height="24"
+        rx="4"
+        width="24"
+      />
+      <text
+        dominantBaseline="central"
+        fill="white"
+        fontFamily="system-ui, sans-serif"
+        fontSize="14"
+        fontWeight="bold"
+        textAnchor="middle"
+        x="12"
+        y="12.5"
+      >
+        G
+      </text>
+    </svg>
+  )
+})
 
-const COLOR_ICONS: Partial<Record<AgentType, AnyIcon>> = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyIcon2 = React.ComponentType<any>
+
+const COLOR_ICONS: Partial<Record<AgentType, AnyIcon2>> = {
   claude_code: ClaudeCode.Color,
   codex: CodexColorIcon,
   gemini: GeminiCLI.Color,
-  open_claw: OpenClaw.Color,
+  generic: GenericColorIcon,
 }
 
-const MONO_ICONS: Partial<Record<AgentType, AnyIcon>> = {
+const MONO_ICONS: Partial<Record<AgentType, AnyIcon2>> = {
   open_code: OpenCode,
   cline: Cline,
 }

--- a/src/components/chat/conversation-shell.tsx
+++ b/src/components/chat/conversation-shell.tsx
@@ -27,6 +27,9 @@ interface ConversationShellProps {
   agentName?: string
   error: string | null
   claudeApiRetry: ClaudeApiRetryState | null
+  /** True while the agent is compressing context mid-turn. Surfaced as
+   * a hint so the user understands why streaming is paused. */
+  compacting?: boolean
   pendingPermission: PendingPermission | null
   pendingQuestion: PendingQuestion | null
   onFocus: () => void
@@ -69,6 +72,7 @@ export function ConversationShell({
   agentName,
   error,
   claudeApiRetry,
+  compacting = false,
   pendingPermission,
   pendingQuestion,
   onFocus,
@@ -212,6 +216,17 @@ export function ConversationShell({
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
             <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
               {retryLineText}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {compacting && !retryLineText && (
+        <div className="border-t border-muted-foreground/20 bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-2 font-medium">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+              {tAcp("compacting")}
             </span>
           </div>
         </div>

--- a/src/components/conversations/conversation-detail-panel.tsx
+++ b/src/components/conversations/conversation-detail-panel.tsx
@@ -202,7 +202,7 @@ const ConversationTabView = memo(function ConversationTabView({
   const [hasSentMessage, setHasSentMessage] = useState(false)
 
   const hasPersistedConversation = dbConversationId != null
-  const canAutoConnect =
+  const canUseAgent =
     hasPersistedConversation || (agentsLoaded && usableAgentCount > 0)
 
   // Expose the runtime session key to the tab so the aux panel (Diff sidebar)
@@ -266,6 +266,13 @@ const ConversationTabView = memo(function ConversationTabView({
   }, [effectiveSessionStats, isActive, setSessionStats])
 
   const externalId = detail?.summary.external_id ?? undefined
+  const requiresResumeSessionResolution =
+    conversationId != null && selectedAgent !== "cline"
+  const resumeSessionId = requiresResumeSessionResolution
+    ? externalId
+    : undefined
+  const canAutoConnect =
+    canUseAgent && (!requiresResumeSessionResolution || detail != null)
   const draftStorageKey = useMemo(() => {
     if (dbConversationId != null) {
       return buildConversationDraftStorageKey(selectedAgent, dbConversationId)
@@ -294,10 +301,7 @@ const ConversationTabView = memo(function ConversationTabView({
     agentType: selectedAgent,
     isActive: isActive && canAutoConnect,
     workingDir: workingDirForConnection,
-    sessionId:
-      dbConversationId != null && selectedAgent !== "cline"
-        ? externalId
-        : undefined,
+    sessionId: resumeSessionId,
   })
   const {
     status: connStatus,
@@ -889,6 +893,7 @@ const ConversationTabView = memo(function ConversationTabView({
       agentName={AGENT_LABELS[selectedAgent]}
       error={conn.error}
       claudeApiRetry={conn.claudeApiRetry}
+      compacting={conn.compacting}
       pendingPermission={conn.pendingPermission}
       pendingQuestion={conn.pendingQuestion}
       onFocus={handleFocus}

--- a/src/components/conversations/search-command-dialog.tsx
+++ b/src/components/conversations/search-command-dialog.tsx
@@ -62,6 +62,7 @@ export function SearchCommandDialog({
   const [activeTab, setActiveTab] = useState<SearchTab>("conversations")
   const [query, setQuery] = useState("")
   const [agentFilter, setAgentFilter] = useState<AgentType | null>(null)
+  const [searchAllFolders, setSearchAllFolders] = useState(activeFolderId == null)
   const [results, setResults] = useState<DbConversationSummary[]>([])
   const [searching, setSearching] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -80,7 +81,11 @@ export function SearchCommandDialog({
 
   // Compute which agent types exist in current folder
   const availableAgents = Array.from(
-    new Set(conversations.map((c) => c.agent_type))
+    new Set(
+      (searchAllFolders ? allConversations : conversations).map(
+        (conversation) => conversation.agent_type
+      )
+    )
   ).sort(compareAgentType)
 
   // Filter files by query using pre-computed lowercase fields
@@ -108,7 +113,8 @@ export function SearchCommandDialog({
       setSearching(true)
       try {
         const data = await listAllConversations({
-          folder_ids: folderId > 0 ? [folderId] : null,
+          folder_ids:
+            !searchAllFolders && folderId > 0 ? [folderId] : null,
           search: q.trim() || null,
           agent_type: agent,
         })
@@ -119,7 +125,7 @@ export function SearchCommandDialog({
         setSearching(false)
       }
     },
-    [folderId]
+    [folderId, searchAllFolders]
   )
 
   // Debounced search on query change (conversations tab only)
@@ -132,18 +138,25 @@ export function SearchCommandDialog({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
     }
-  }, [query, agentFilter, doSearch, activeTab])
+  }, [query, agentFilter, doSearch, activeTab, searchAllFolders])
 
   // Reset state when dialog closes
   useEffect(() => {
     if (!open) {
       setQuery("")
       setAgentFilter(null)
+      setSearchAllFolders(activeFolderId == null)
       setResults([])
       setActiveTab("conversations")
       resetFileTree()
     }
-  }, [open, resetFileTree])
+  }, [activeFolderId, open, resetFileTree])
+
+  useEffect(() => {
+    if (activeFolderId == null) {
+      setSearchAllFolders(true)
+    }
+  }, [activeFolderId])
 
   const handleSelectConversation = useCallback(
     (conv: DbConversationSummary) => {
@@ -233,34 +246,64 @@ export function SearchCommandDialog({
       />
 
       {/* Agent filter (conversations tab only) */}
-      {activeTab === "conversations" && availableAgents.length > 1 && (
-        <div className="flex items-center gap-1 px-3 py-2 border-b">
-          <button
-            onClick={() => setAgentFilter(null)}
-            className={cn(
-              "h-6 text-xs px-2 rounded-md transition-colors",
-              agentFilter === null
-                ? "bg-secondary text-secondary-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {t("allAgents")}
-          </button>
-          {availableAgents.map((at) => (
-            <button
-              key={at}
-              onClick={() => setAgentFilter(at)}
-              className={cn(
-                "flex items-center gap-1.5 h-6 text-xs px-2 rounded-md transition-colors",
-                agentFilter === at
-                  ? "bg-secondary text-secondary-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              <AgentIcon agentType={at} className="w-3.5 h-3.5" />
-              {AGENT_LABELS[at]}
-            </button>
-          ))}
+      {activeTab === "conversations" && (
+        <div className="flex flex-wrap items-center gap-1 px-3 py-2 border-b">
+          {folder && (
+            <>
+              <button
+                onClick={() => setSearchAllFolders(false)}
+                className={cn(
+                  "h-6 text-xs px-2 rounded-md transition-colors",
+                  !searchAllFolders
+                    ? "bg-secondary text-secondary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {folder.name}
+              </button>
+              <button
+                onClick={() => setSearchAllFolders(true)}
+                className={cn(
+                  "h-6 text-xs px-2 rounded-md transition-colors",
+                  searchAllFolders
+                    ? "bg-secondary text-secondary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                All workspaces
+              </button>
+            </>
+          )}
+          {availableAgents.length > 1 && (
+            <>
+              <button
+                onClick={() => setAgentFilter(null)}
+                className={cn(
+                  "h-6 text-xs px-2 rounded-md transition-colors",
+                  agentFilter === null
+                    ? "bg-secondary text-secondary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {t("allAgents")}
+              </button>
+              {availableAgents.map((at) => (
+                <button
+                  key={at}
+                  onClick={() => setAgentFilter(at)}
+                  className={cn(
+                    "flex items-center gap-1.5 h-6 text-xs px-2 rounded-md transition-colors",
+                    agentFilter === at
+                      ? "bg-secondary text-secondary-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <AgentIcon agentType={at} className="w-3.5 h-3.5" />
+                  {AGENT_LABELS[at]}
+                </button>
+              ))}
+            </>
+          )}
         </div>
       )}
 
@@ -280,25 +323,32 @@ export function SearchCommandDialog({
                 {results.map((conv) => (
                   <CommandItem
                     key={conv.id}
-                    value={`${conv.id}-${conv.title ?? ""}`}
+                    value={`${conv.id}-${conv.title ?? ""}-${conv.folder_name ?? ""}-${conv.folder_path ?? ""}`}
                     onSelect={() => handleSelectConversation(conv)}
                   >
                     <ConversationStatusIcon
                       status={conv.status as ConversationStatus}
                       className={cn(
-                        "h-4 w-4",
+                        "h-4 w-4 self-start mt-0.5",
                         STATUS_ICON_COLORS[conv.status as ConversationStatus] ??
                           "text-muted-foreground"
                       )}
                     />
-                    <span className="flex-1 truncate">
-                      {conv.title || t("untitledConversation")}
-                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="truncate">
+                        {conv.title || t("untitledConversation")}
+                      </span>
+                      {searchAllFolders && (
+                        <span className="truncate text-[11px] text-muted-foreground">
+                          {conv.folder_name ?? conv.folder_path ?? "Unknown workspace"}
+                        </span>
+                      )}
+                    </div>
                     <span className="text-xs text-muted-foreground shrink-0">
                       {AGENT_LABELS[conv.agent_type]}
                     </span>
                     <span className="text-xs text-muted-foreground shrink-0">
-                      {formatDistanceToNow(new Date(conv.created_at), {
+                      {formatDistanceToNow(new Date(conv.updated_at), {
                         addSuffix: true,
                         locale: dateFnsLocale,
                       })}

--- a/src/components/conversations/search-command-dialog.tsx
+++ b/src/components/conversations/search-command-dialog.tsx
@@ -62,7 +62,9 @@ export function SearchCommandDialog({
   const [activeTab, setActiveTab] = useState<SearchTab>("conversations")
   const [query, setQuery] = useState("")
   const [agentFilter, setAgentFilter] = useState<AgentType | null>(null)
-  const [searchAllFolders, setSearchAllFolders] = useState(activeFolderId == null)
+  const [searchAllFolders, setSearchAllFolders] = useState(
+    activeFolderId == null
+  )
   const [results, setResults] = useState<DbConversationSummary[]>([])
   const [searching, setSearching] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -113,8 +115,7 @@ export function SearchCommandDialog({
       setSearching(true)
       try {
         const data = await listAllConversations({
-          folder_ids:
-            !searchAllFolders && folderId > 0 ? [folderId] : null,
+          folder_ids: !searchAllFolders && folderId > 0 ? [folderId] : null,
           search: q.trim() || null,
           agent_type: agent,
         })
@@ -340,7 +341,9 @@ export function SearchCommandDialog({
                       </span>
                       {searchAllFolders && (
                         <span className="truncate text-[11px] text-muted-foreground">
-                          {conv.folder_name ?? conv.folder_path ?? "Unknown workspace"}
+                          {conv.folder_name ??
+                            conv.folder_path ??
+                            "Unknown workspace"}
                         </span>
                       )}
                     </div>

--- a/src/components/layout/aux-panel-squad-tab.tsx
+++ b/src/components/layout/aux-panel-squad-tab.tsx
@@ -1,0 +1,434 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Play, Send, Square, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
+import { useActiveFolder } from "@/contexts/active-folder-context"
+import { useSquadContext } from "@/contexts/squad-context"
+import type {
+  AgentType,
+  SquadRoleKind,
+  SquadRoleProfileInfo,
+  SquadTaskInfo,
+  SquadWorkspacePolicy,
+} from "@/lib/types"
+
+const ROLE_LABELS: Record<SquadRoleKind, string> = {
+  conductor: "Conductor",
+  frontend: "Frontend",
+  backend: "Backend",
+  worker: "Worker",
+}
+
+const AGENT_LABELS: Record<AgentType, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  open_code: "OpenCode",
+  gemini: "Gemini CLI",
+  generic: "Generic",
+  cline: "Cline",
+}
+
+const WORKSPACE_POLICY_LABELS: Record<SquadWorkspacePolicy, string> = {
+  read_only: "Read only",
+  write_isolated: "Isolated writes",
+  write_shared: "Shared workspace",
+}
+
+const ROLE_ORDER: SquadRoleKind[] = [
+  "conductor",
+  "frontend",
+  "backend",
+  "worker",
+]
+const AGENT_TYPES = Object.keys(AGENT_LABELS) as AgentType[]
+const WORKSPACE_POLICIES = Object.keys(
+  WORKSPACE_POLICY_LABELS
+) as SquadWorkspacePolicy[]
+
+function sortProfiles(profiles: SquadRoleProfileInfo[]) {
+  return [...profiles].sort(
+    (a, b) => ROLE_ORDER.indexOf(a.roleKind) - ROLE_ORDER.indexOf(b.roleKind)
+  )
+}
+
+function taskLabel(task: SquadTaskInfo) {
+  return `#${task.id} ${ROLE_LABELS[task.assignedRoleKind]} · ${task.title}`
+}
+
+export function SquadPanelTab() {
+  const { activeFolder } = useActiveFolder()
+  const {
+    profiles,
+    activeRun,
+    loading,
+    error,
+    loadForFolder,
+    createRun,
+    startRun,
+    stopRun,
+    updateRoleProfile,
+    createTask,
+    updateTaskStatus,
+    promptRole,
+  } = useSquadContext()
+  const [goal, setGoal] = useState("")
+  const [taskTitle, setTaskTitle] = useState("")
+  const [taskDescription, setTaskDescription] = useState("")
+  const [taskRole, setTaskRole] = useState<SquadRoleKind>("worker")
+  const [busy, setBusy] = useState(false)
+  const sortedProfiles = useMemo(() => sortProfiles(profiles), [profiles])
+
+  useEffect(() => {
+    if (activeFolder?.id) {
+      void loadForFolder(activeFolder.id)
+    }
+  }, [activeFolder?.id, loadForFolder])
+
+  const runAction = async (action: () => Promise<void>) => {
+    setBusy(true)
+    try {
+      await action()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCreateRun = async () => {
+    if (!activeFolder || !goal.trim()) return
+    await runAction(async () => {
+      await createRun({
+        folderId: activeFolder.id,
+        mode: "conductor_dispatch",
+        goalSummary: goal.trim(),
+      })
+    })
+  }
+
+  const handleStartRun = async () => {
+    if (!activeRun || !activeFolder) return
+    await runAction(async () => {
+      await startRun(activeRun.run.id, activeFolder.path)
+    })
+  }
+
+  const handleStopRun = async () => {
+    if (!activeRun) return
+    await runAction(async () => {
+      await stopRun(activeRun.run.id)
+    })
+  }
+
+  const handleCreateTask = async () => {
+    if (!activeRun || !taskTitle.trim()) return
+    await runAction(async () => {
+      await createTask({
+        squadRunId: activeRun.run.id,
+        assignedRoleKind: taskRole,
+        title: taskTitle.trim(),
+        description: taskDescription.trim(),
+      })
+      setTaskTitle("")
+      setTaskDescription("")
+    })
+  }
+
+  const handlePromptTask = async (task: SquadTaskInfo) => {
+    if (!activeRun) return
+    await runAction(async () => {
+      await promptRole({
+        squadRunId: activeRun.run.id,
+        roleKind: task.assignedRoleKind,
+        taskId: task.id,
+      })
+      await updateTaskStatus({ taskId: task.id, status: "running" })
+    })
+  }
+
+  const handleProfileEnabled = async (
+    profile: SquadRoleProfileInfo,
+    enabled: boolean
+  ) => {
+    if (!activeFolder) return
+    await runAction(async () => {
+      await updateRoleProfile({
+        folderId: activeFolder.id,
+        roleKind: profile.roleKind,
+        patch: { enabled },
+      })
+    })
+  }
+
+  const handleProfileAgent = async (
+    profile: SquadRoleProfileInfo,
+    agentType: AgentType
+  ) => {
+    if (!activeFolder) return
+    await runAction(async () => {
+      await updateRoleProfile({
+        folderId: activeFolder.id,
+        roleKind: profile.roleKind,
+        patch: { agentType },
+      })
+    })
+  }
+
+  const handleProfileWorkspace = async (
+    profile: SquadRoleProfileInfo,
+    workspacePolicy: SquadWorkspacePolicy
+  ) => {
+    if (!activeFolder) return
+    await runAction(async () => {
+      await updateRoleProfile({
+        folderId: activeFolder.id,
+        roleKind: profile.roleKind,
+        patch: { workspacePolicy },
+      })
+    })
+  }
+
+  if (!activeFolder) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
+        Open a folder to use role squads.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-3 text-sm">
+      <div className="flex items-center gap-2 font-medium">
+        <Users className="h-4 w-4" />
+        Role Squad
+      </div>
+
+      {error ? <div className="text-xs text-destructive">{error}</div> : null}
+
+      <section className="space-y-2 rounded-md border border-border p-2">
+        <div className="text-xs font-medium text-muted-foreground">Goal</div>
+        <Textarea
+          id="squad-goal"
+          name="squad-goal"
+          value={goal}
+          onChange={(event) => setGoal(event.target.value)}
+          placeholder="Describe the goal for the squad..."
+          className="min-h-24 resize-none"
+        />
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            onClick={handleCreateRun}
+            disabled={busy || loading || !goal.trim()}
+          >
+            Create run
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={handleStartRun}
+            disabled={busy || !activeRun || activeRun.run.status === "running"}
+          >
+            <Play className="mr-1 h-3.5 w-3.5" />
+            Start
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleStopRun}
+            disabled={busy || !activeRun}
+          >
+            <Square className="mr-1 h-3.5 w-3.5" />
+            Stop
+          </Button>
+        </div>
+      </section>
+
+      <section className="rounded-md border border-border p-2">
+        <div className="mb-2 text-xs font-medium text-muted-foreground">
+          Active run
+        </div>
+        {activeRun ? (
+          <div className="space-y-1">
+            <div className="font-medium">#{activeRun.run.id}</div>
+            <div className="text-xs text-muted-foreground">
+              {activeRun.run.status} · {activeRun.run.goalSummary}
+            </div>
+          </div>
+        ) : (
+          <div className="text-xs text-muted-foreground">No squad run yet.</div>
+        )}
+      </section>
+
+      <section className="space-y-2 rounded-md border border-border p-2">
+        <div className="text-xs font-medium text-muted-foreground">Roles</div>
+        {sortedProfiles.map((profile) => {
+          const roleRun = activeRun?.roles.find(
+            (role) => role.roleKind === profile.roleKind
+          )
+          return (
+            <div
+              key={profile.id}
+              className="space-y-2 rounded-md bg-muted/30 p-2"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <div className="font-medium">
+                    {ROLE_LABELS[profile.roleKind]}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {roleRun?.status ?? "profile"}
+                  </div>
+                </div>
+                <Switch
+                  checked={profile.enabled}
+                  disabled={busy}
+                  onCheckedChange={(checked) =>
+                    void handleProfileEnabled(profile, checked)
+                  }
+                  aria-label={`Enable ${ROLE_LABELS[profile.roleKind]}`}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Select
+                  value={profile.agentType}
+                  onValueChange={(value) =>
+                    void handleProfileAgent(profile, value as AgentType)
+                  }
+                  disabled={busy || !profile.enabled}
+                >
+                  <SelectTrigger className="w-full" size="sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent align="start">
+                    {AGENT_TYPES.map((agentType) => (
+                      <SelectItem key={agentType} value={agentType}>
+                        {AGENT_LABELS[agentType]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={profile.workspacePolicy}
+                  onValueChange={(value) =>
+                    void handleProfileWorkspace(
+                      profile,
+                      value as SquadWorkspacePolicy
+                    )
+                  }
+                  disabled={busy || !profile.enabled}
+                >
+                  <SelectTrigger className="w-full" size="sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent align="start">
+                    {WORKSPACE_POLICIES.map((policy) => (
+                      <SelectItem key={policy} value={policy}>
+                        {WORKSPACE_POLICY_LABELS[policy]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {roleRun?.connectionId ? (
+                <div className="truncate text-xs text-muted-foreground">
+                  {roleRun.connectionId}
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
+      </section>
+
+      <section className="space-y-2 rounded-md border border-border p-2">
+        <div className="text-xs font-medium text-muted-foreground">Tasks</div>
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Select
+              value={taskRole}
+              onValueChange={(value) => setTaskRole(value as SquadRoleKind)}
+              disabled={busy || !activeRun}
+            >
+              <SelectTrigger className="w-32" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="start">
+                {ROLE_ORDER.map((roleKind) => (
+                  <SelectItem key={roleKind} value={roleKind}>
+                    {ROLE_LABELS[roleKind]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              id="squad-task-title"
+              name="squad-task-title"
+              value={taskTitle}
+              onChange={(event) => setTaskTitle(event.target.value)}
+              placeholder="Task title"
+              disabled={busy || !activeRun}
+            />
+          </div>
+          <Textarea
+            id="squad-task-description"
+            name="squad-task-description"
+            value={taskDescription}
+            onChange={(event) => setTaskDescription(event.target.value)}
+            placeholder="Task details for the selected role..."
+            className="min-h-20 resize-none"
+            disabled={busy || !activeRun}
+          />
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={handleCreateTask}
+            disabled={busy || !activeRun || !taskTitle.trim()}
+          >
+            Add task
+          </Button>
+        </div>
+
+        <div className="space-y-2">
+          {(activeRun?.tasks ?? []).map((task) => (
+            <div key={task.id} className="rounded-md bg-muted/30 p-2">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{taskLabel(task)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {task.status}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => void handlePromptTask(task)}
+                  disabled={busy || task.status === "completed"}
+                >
+                  <Send className="mr-1 h-3.5 w-3.5" />
+                  Prompt
+                </Button>
+              </div>
+              {task.description ? (
+                <div className="mt-1 line-clamp-3 text-xs text-muted-foreground">
+                  {task.description}
+                </div>
+              ) : null}
+            </div>
+          ))}
+          {activeRun && activeRun.tasks.length === 0 ? (
+            <div className="text-xs text-muted-foreground">No tasks yet.</div>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/layout/aux-panel.tsx
+++ b/src/components/layout/aux-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useState } from "react"
-import { FileDiff, Folder, FolderPen, GitCommit } from "lucide-react"
+import { FileDiff, Folder, FolderPen, GitCommit, Users } from "lucide-react"
 import { useTranslations } from "next-intl"
 import {
   useAuxPanelContext,
@@ -12,6 +12,7 @@ import { FileTreeTab } from "./aux-panel-file-tree-tab"
 import { GitChangesTab } from "./aux-panel-git-changes-tab"
 import { GitLogTab } from "./aux-panel-git-log-tab"
 import { SessionFilesTab } from "./aux-panel-session-files-tab"
+import { SquadPanelTab } from "./aux-panel-squad-tab"
 
 const LAZY_TABS: AuxPanelTab[] = ["file_tree", "changes", "git_log"]
 
@@ -75,6 +76,9 @@ export function AuxPanel() {
           >
             <GitCommit className="h-3.5 w-3.5" />
           </TabsTrigger>
+          <TabsTrigger value="squad" title="Squad" aria-label="Squad">
+            <Users className="h-3.5 w-3.5" />
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent
@@ -103,6 +107,12 @@ export function AuxPanel() {
           className="mt-0 flex-1 min-h-0 overflow-hidden"
         >
           {mountedTabs.has("git_log") ? <GitLogTab /> : null}
+        </TabsContent>
+        <TabsContent
+          value="squad"
+          className="mt-0 flex-1 min-h-0 overflow-hidden"
+        >
+          <SquadPanelTab />
         </TabsContent>
       </Tabs>
     </aside>

--- a/src/components/layout/folder-title-bar.tsx
+++ b/src/components/layout/folder-title-bar.tsx
@@ -355,11 +355,11 @@ export function FolderTitleBar() {
                     {tTitleBar("toggleAuxPanel")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                  onClick={() => toggleTerminal()}
-                  disabled={!activeFolder}
-                >
-                  <SquareTerminal className="h-3.5 w-3.5" />
-                  {tTitleBar("toggleTerminal")}
+                    onClick={() => toggleTerminal()}
+                    disabled={!activeFolder}
+                  >
+                    <SquareTerminal className="h-3.5 w-3.5" />
+                    {tTitleBar("toggleTerminal")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() => setWorkspacePresetOpen(true)}

--- a/src/components/layout/folder-title-bar.tsx
+++ b/src/components/layout/folder-title-bar.tsx
@@ -17,6 +17,7 @@ import {
   PanelRight,
   Search,
   Settings,
+  SlidersHorizontal,
   SquareTerminal,
 } from "lucide-react"
 import { useTranslations } from "next-intl"
@@ -44,6 +45,7 @@ import { SearchCommandDialog } from "@/components/conversations/search-command-d
 import { DirectoryBrowserDialog } from "@/components/shared/directory-browser-dialog"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { WorkspacePresetDialog } from "@/components/layout/workspace-preset-dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -83,6 +85,7 @@ export function FolderTitleBar() {
   const { shortcuts } = useShortcutSettings()
   const [searchOpen, setSearchOpen] = useState(false)
   const [browserOpen, setBrowserOpen] = useState(false)
+  const [workspacePresetOpen, setWorkspacePresetOpen] = useState(false)
 
   const handleOpenFolder = useCallback(async () => {
     if (isDesktop()) {
@@ -352,11 +355,18 @@ export function FolderTitleBar() {
                     {tTitleBar("toggleAuxPanel")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
-                    onClick={() => toggleTerminal()}
+                  onClick={() => toggleTerminal()}
+                  disabled={!activeFolder}
+                >
+                  <SquareTerminal className="h-3.5 w-3.5" />
+                  {tTitleBar("toggleTerminal")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setWorkspacePresetOpen(true)}
                     disabled={!activeFolder}
                   >
-                    <SquareTerminal className="h-3.5 w-3.5" />
-                    {tTitleBar("toggleTerminal")}
+                    <SlidersHorizontal className="h-3.5 w-3.5" />
+                    Workspace preset
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={handleOpenSettings}>
                     <Settings className="h-3.5 w-3.5" />
@@ -407,6 +417,16 @@ export function FolderTitleBar() {
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 hover:text-foreground/80"
+                  onClick={() => setWorkspacePresetOpen(true)}
+                  disabled={!activeFolder}
+                  title="Workspace preset"
+                >
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 hover:text-foreground/80"
                   onClick={() => setSearchOpen(true)}
                   title={tTitleBar("withShortcut", {
                     label: tTitleBar("search"),
@@ -439,6 +459,11 @@ export function FolderTitleBar() {
         }
       />
       <SearchCommandDialog open={searchOpen} onOpenChange={setSearchOpen} />
+      <WorkspacePresetDialog
+        open={workspacePresetOpen}
+        onOpenChange={setWorkspacePresetOpen}
+        folder={activeFolder}
+      />
       <DirectoryBrowserDialog
         open={browserOpen}
         onOpenChange={setBrowserOpen}

--- a/src/components/layout/workspace-preset-dialog.tsx
+++ b/src/components/layout/workspace-preset-dialog.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Loader2, SlidersHorizontal } from "lucide-react"
+import { toast } from "sonner"
+import { useAppWorkspace } from "@/contexts/app-workspace-context"
+import { listModelProviders, updateFolderWorkspacePreset } from "@/lib/api"
+import {
+  AGENT_LABELS,
+  ALL_AGENT_TYPES,
+  type FolderDetail,
+  type ModelProviderInfo,
+  type WorkspacePreset,
+} from "@/lib/types"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+interface WorkspacePresetDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  folder: FolderDetail | null
+}
+
+function parseListInput(value: string): string[] {
+  return value
+    .split(/\r?\n|,/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function parseEnvOverrides(value: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const line of value.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const separator = trimmed.indexOf("=")
+    if (separator <= 0) continue
+    const key = trimmed.slice(0, separator).trim()
+    const envValue = trimmed.slice(separator + 1).trim()
+    if (!key) continue
+    result[key] = envValue
+  }
+  return result
+}
+
+function formatEnvOverrides(value: Record<string, string>): string {
+  return Object.entries(value)
+    .map(([key, entryValue]) => `${key}=${entryValue}`)
+    .join("\n")
+}
+
+function isPresetEmpty(preset: WorkspacePreset): boolean {
+  return (
+    !preset.default_agent_type &&
+    preset.model_provider_id == null &&
+    !preset.approval_policy &&
+    preset.skill_ids.length === 0 &&
+    preset.mcp_server_ids.length === 0 &&
+    Object.keys(preset.env_overrides).length === 0
+  )
+}
+
+export function WorkspacePresetDialog({
+  open,
+  onOpenChange,
+  folder,
+}: WorkspacePresetDialogProps) {
+  const { refreshFolder } = useAppWorkspace()
+  const [providers, setProviders] = useState<ModelProviderInfo[]>([])
+  const [loadingProviders, setLoadingProviders] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [defaultAgent, setDefaultAgent] = useState<string>("none")
+  const [modelProviderId, setModelProviderId] = useState<string>("none")
+  const [approvalPolicy, setApprovalPolicy] = useState("")
+  const [skillIds, setSkillIds] = useState("")
+  const [mcpServerIds, setMcpServerIds] = useState("")
+  const [envOverrides, setEnvOverrides] = useState("")
+
+  const hydrate = useCallback(() => {
+    const preset = folder?.workspace_preset
+    setDefaultAgent(preset?.default_agent_type ?? "none")
+    setModelProviderId(
+      preset?.model_provider_id != null ? String(preset.model_provider_id) : "none"
+    )
+    setApprovalPolicy(preset?.approval_policy ?? "")
+    setSkillIds((preset?.skill_ids ?? []).join("\n"))
+    setMcpServerIds((preset?.mcp_server_ids ?? []).join("\n"))
+    setEnvOverrides(formatEnvOverrides(preset?.env_overrides ?? {}))
+  }, [folder])
+
+  useEffect(() => {
+    if (!open) return
+    hydrate()
+  }, [hydrate, open])
+
+  useEffect(() => {
+    if (!open) return
+    setLoadingProviders(true)
+    listModelProviders()
+      .then((items) => setProviders(items))
+      .catch((error) => {
+        console.error("[WorkspacePresetDialog] load model providers failed:", error)
+      })
+      .finally(() => setLoadingProviders(false))
+  }, [open])
+
+  const title = useMemo(() => {
+    if (!folder) return "Workspace preset"
+    return `Workspace preset · ${folder.name}`
+  }, [folder])
+
+  const handleSave = useCallback(async () => {
+    if (!folder) return
+
+    const preset: WorkspacePreset = {
+      default_agent_type:
+        defaultAgent === "none"
+          ? null
+          : (defaultAgent as WorkspacePreset["default_agent_type"]),
+      model_provider_id:
+        modelProviderId === "none" ? null : Number(modelProviderId),
+      approval_policy: approvalPolicy.trim() || null,
+      skill_ids: parseListInput(skillIds),
+      mcp_server_ids: parseListInput(mcpServerIds),
+      env_overrides: parseEnvOverrides(envOverrides),
+    }
+
+    setSaving(true)
+    try {
+      await updateFolderWorkspacePreset(folder.id, isPresetEmpty(preset) ? null : preset)
+      await refreshFolder(folder.id)
+      toast.success("Workspace preset saved")
+      onOpenChange(false)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      toast.error(`Failed to save preset: ${message}`)
+    } finally {
+      setSaving(false)
+    }
+  }, [
+    approvalPolicy,
+    defaultAgent,
+    envOverrides,
+    folder,
+    mcpServerIds,
+    modelProviderId,
+    onOpenChange,
+    refreshFolder,
+    skillIds,
+  ])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <SlidersHorizontal className="h-4 w-4" />
+            {title}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Default agent</Label>
+              <Select value={defaultAgent} onValueChange={setDefaultAgent}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Inherit</SelectItem>
+                  {ALL_AGENT_TYPES.map((agentType) => (
+                    <SelectItem key={agentType} value={agentType}>
+                      {AGENT_LABELS[agentType]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Model provider</Label>
+              <Select value={modelProviderId} onValueChange={setModelProviderId}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Inherit</SelectItem>
+                  {providers.map((provider) => (
+                    <SelectItem key={provider.id} value={String(provider.id)}>
+                      {provider.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {loadingProviders && (
+                <div className="text-xs text-muted-foreground">Loading providers…</div>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Approval policy</Label>
+            <Input
+              value={approvalPolicy}
+              onChange={(event) => setApprovalPolicy(event.target.value)}
+              placeholder="Optional free-form policy label"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Skills</Label>
+              <Textarea
+                rows={5}
+                value={skillIds}
+                onChange={(event) => setSkillIds(event.target.value)}
+                placeholder="One skill id per line"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>MCP servers</Label>
+              <Textarea
+                rows={5}
+                value={mcpServerIds}
+                onChange={(event) => setMcpServerIds(event.target.value)}
+                placeholder="One server id per line"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Environment overrides</Label>
+            <Textarea
+              rows={6}
+              value={envOverrides}
+              onChange={(event) => setEnvOverrides(event.target.value)}
+              placeholder={"OPENAI_API_BASE=https://...\nOPENAI_API_KEY=..."}
+            />
+            <p className="text-xs text-muted-foreground">
+              Applied to ACP sessions started in this workspace.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !folder}>
+            {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+            Save preset
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/layout/workspace-preset-dialog.tsx
+++ b/src/components/layout/workspace-preset-dialog.tsx
@@ -96,7 +96,9 @@ export function WorkspacePresetDialog({
     const preset = folder?.workspace_preset
     setDefaultAgent(preset?.default_agent_type ?? "none")
     setModelProviderId(
-      preset?.model_provider_id != null ? String(preset.model_provider_id) : "none"
+      preset?.model_provider_id != null
+        ? String(preset.model_provider_id)
+        : "none"
     )
     setApprovalPolicy(preset?.approval_policy ?? "")
     setSkillIds((preset?.skill_ids ?? []).join("\n"))
@@ -115,7 +117,10 @@ export function WorkspacePresetDialog({
     listModelProviders()
       .then((items) => setProviders(items))
       .catch((error) => {
-        console.error("[WorkspacePresetDialog] load model providers failed:", error)
+        console.error(
+          "[WorkspacePresetDialog] load model providers failed:",
+          error
+        )
       })
       .finally(() => setLoadingProviders(false))
   }, [open])
@@ -143,7 +148,10 @@ export function WorkspacePresetDialog({
 
     setSaving(true)
     try {
-      await updateFolderWorkspacePreset(folder.id, isPresetEmpty(preset) ? null : preset)
+      await updateFolderWorkspacePreset(
+        folder.id,
+        isPresetEmpty(preset) ? null : preset
+      )
       await refreshFolder(folder.id)
       toast.success("Workspace preset saved")
       onOpenChange(false)
@@ -196,7 +204,10 @@ export function WorkspacePresetDialog({
 
             <div className="space-y-2">
               <Label>Model provider</Label>
-              <Select value={modelProviderId} onValueChange={setModelProviderId}>
+              <Select
+                value={modelProviderId}
+                onValueChange={setModelProviderId}
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
@@ -210,7 +221,9 @@ export function WorkspacePresetDialog({
                 </SelectContent>
               </Select>
               {loadingProviders && (
-                <div className="text-xs text-muted-foreground">Loading providers…</div>
+                <div className="text-xs text-muted-foreground">
+                  Loading providers…
+                </div>
               )}
             </div>
           </div>

--- a/src/components/settings/acp-agent-settings.tsx
+++ b/src/components/settings/acp-agent-settings.tsx
@@ -2310,10 +2310,7 @@ function buildAgentDraft(agent: AcpAgentInfo): AgentDraft {
     configText
   )
   const geminiImportant = extractGeminiImportantValues(agent.env, configText)
-  const genericImportant = extractGenericImportantValues(
-    agent.env,
-    configText
-  )
+  const genericImportant = extractGenericImportantValues(agent.env, configText)
   const codexImportant = extractCodexImportantValues(
     codexAuthJsonText,
     codexConfigTomlText

--- a/src/components/settings/acp-agent-settings.tsx
+++ b/src/components/settings/acp-agent-settings.tsx
@@ -134,9 +134,9 @@ interface AgentDraft {
   codexAuthJsonText: string
   codexConfigTomlText: string
   openCodeAuthJsonText: string
-  openClawGatewayUrl: string
-  openClawGatewayToken: string
-  openClawSessionKey: string
+  genericGatewayUrl: string
+  genericGatewayToken: string
+  genericSessionKey: string
   clineProvider: ClineProvider
   clineApiKey: string
   clineModel: string
@@ -302,10 +302,10 @@ const GEMINI_ENV_KEYS = {
   model: "GEMINI_MODEL",
 } as const
 
-const OPENCLAW_ENV_KEYS = {
-  gatewayUrl: "OPENCLAW_GATEWAY_URL",
-  gatewayToken: "OPENCLAW_GATEWAY_TOKEN",
-  sessionKey: "OPENCLAW_SESSION_KEY",
+const GENERIC_ENV_KEYS = {
+  gatewayUrl: "GENERIC_GATEWAY_URL",
+  gatewayToken: "GENERIC_GATEWAY_TOKEN",
+  sessionKey: "GENERIC_SESSION_KEY",
 } as const
 
 const CLINE_PROVIDERS = [
@@ -637,7 +637,7 @@ function extractGeminiImportantValues(
   }
 }
 
-interface OpenClawImportantValues {
+interface GenericImportantValues {
   gatewayUrl: string
   gatewayToken: string
   sessionKey: string
@@ -663,19 +663,19 @@ function extractClineImportantValues(configText: string): ClineImportantValues {
   }
 }
 
-function extractOpenClawImportantValues(
+function extractGenericImportantValues(
   env: Record<string, string>,
   configText: string
-): OpenClawImportantValues {
+): GenericImportantValues {
   const parseResult = parseConfigJsonText(configText)
   const config = parseResult.config
   const configEnv = envFromConfig(config)
   const mergedEnv = { ...env, ...configEnv }
 
   return {
-    gatewayUrl: findEnvValue(mergedEnv, [OPENCLAW_ENV_KEYS.gatewayUrl]),
-    gatewayToken: findEnvValue(mergedEnv, [OPENCLAW_ENV_KEYS.gatewayToken]),
-    sessionKey: findEnvValue(mergedEnv, [OPENCLAW_ENV_KEYS.sessionKey]),
+    gatewayUrl: findEnvValue(mergedEnv, [GENERIC_ENV_KEYS.gatewayUrl]),
+    gatewayToken: findEnvValue(mergedEnv, [GENERIC_ENV_KEYS.gatewayToken]),
+    sessionKey: findEnvValue(mergedEnv, [GENERIC_ENV_KEYS.sessionKey]),
   }
 }
 
@@ -2310,7 +2310,7 @@ function buildAgentDraft(agent: AcpAgentInfo): AgentDraft {
     configText
   )
   const geminiImportant = extractGeminiImportantValues(agent.env, configText)
-  const openClawImportant = extractOpenClawImportantValues(
+  const genericImportant = extractGenericImportantValues(
     agent.env,
     configText
   )
@@ -2395,9 +2395,9 @@ function buildAgentDraft(agent: AcpAgentInfo): AgentDraft {
     codexAuthJsonText,
     codexConfigTomlText,
     openCodeAuthJsonText,
-    openClawGatewayUrl: openClawImportant.gatewayUrl,
-    openClawGatewayToken: openClawImportant.gatewayToken,
-    openClawSessionKey: openClawImportant.sessionKey,
+    genericGatewayUrl: genericImportant.gatewayUrl,
+    genericGatewayToken: genericImportant.gatewayToken,
+    genericSessionKey: genericImportant.sessionKey,
     clineProvider: clineImportant.provider,
     clineApiKey: clineImportant.apiKey,
     clineModel: clineImportant.model,
@@ -3009,7 +3009,7 @@ export function AcpAgentSettings() {
       const usesMerge =
         agentType === "claude_code" ||
         agentType === "gemini" ||
-        agentType === "open_claw"
+        agentType === "generic"
       if (usesMerge && configForPersist) {
         const originalAgent = agents.find((a) => a.agent_type === agentType)
         const originalConfig = originalAgent?.config_json
@@ -4048,22 +4048,22 @@ export function AcpAgentSettings() {
     [selectedAgent, selectedDraft, t, updateSelectedDraft]
   )
 
-  const handleOpenClawFieldChange = useCallback(
+  const handleGenericFieldChange = useCallback(
     (
-      key: "openClawGatewayUrl" | "openClawGatewayToken" | "openClawSessionKey",
+      key: "genericGatewayUrl" | "genericGatewayToken" | "genericSessionKey",
       value: string
     ) => {
       if (
         !selectedAgent ||
         !selectedDraft ||
-        selectedAgent.agent_type !== "open_claw"
+        selectedAgent.agent_type !== "generic"
       )
         return
 
       const envKeyMap: Record<string, string> = {
-        openClawGatewayUrl: OPENCLAW_ENV_KEYS.gatewayUrl,
-        openClawGatewayToken: OPENCLAW_ENV_KEYS.gatewayToken,
-        openClawSessionKey: OPENCLAW_ENV_KEYS.sessionKey,
+        genericGatewayUrl: GENERIC_ENV_KEYS.gatewayUrl,
+        genericGatewayToken: GENERIC_ENV_KEYS.gatewayToken,
+        genericSessionKey: GENERIC_ENV_KEYS.sessionKey,
       }
 
       updateSelectedDraft((current) => ({
@@ -7013,14 +7013,14 @@ supports_websockets = true`}
                       </Button>
                     </div>
                   </div>
-                ) : selectedAgent.agent_type === "open_claw" ? (
+                ) : selectedAgent.agent_type === "generic" ? (
                   <div className="space-y-3 rounded-md border bg-muted/10 p-3">
                     <div>
                       <label className="text-xs font-medium">
-                        {t("openClaw.gatewayConfig")}
+                        {t("generic.gatewayConfig")}
                       </label>
                       <p className="mt-1 text-[11px] text-muted-foreground">
-                        {t("openClaw.gatewayDescription")}
+                        {t("generic.gatewayDescription")}
                       </p>
                     </div>
 
@@ -7029,17 +7029,17 @@ supports_websockets = true`}
                         Gateway URL
                       </label>
                       <Input
-                        value={selectedDraft.openClawGatewayUrl}
+                        value={selectedDraft.genericGatewayUrl}
                         onChange={(event) => {
-                          handleOpenClawFieldChange(
-                            "openClawGatewayUrl",
+                          handleGenericFieldChange(
+                            "genericGatewayUrl",
                             event.target.value
                           )
                         }}
                         placeholder="wss://gateway-host:18789"
                       />
                       <p className="text-[11px] text-muted-foreground">
-                        {t("openClaw.gatewayUrlHint")}
+                        {t("generic.gatewayUrlHint")}
                       </p>
                     </div>
 
@@ -7054,14 +7054,14 @@ supports_websockets = true`}
                               ? "text"
                               : "password"
                           }
-                          value={selectedDraft.openClawGatewayToken}
+                          value={selectedDraft.genericGatewayToken}
                           onChange={(event) => {
-                            handleOpenClawFieldChange(
-                              "openClawGatewayToken",
+                            handleGenericFieldChange(
+                              "genericGatewayToken",
                               event.target.value
                             )
                           }}
-                          placeholder={t("openClaw.gatewayTokenPlaceholder")}
+                          placeholder={t("generic.gatewayTokenPlaceholder")}
                         />
                         <Button
                           type="button"
@@ -7088,7 +7088,7 @@ supports_websockets = true`}
                         </Button>
                       </div>
                       <p className="text-[11px] text-muted-foreground">
-                        {t("openClaw.gatewayTokenHint")}
+                        {t("generic.gatewayTokenHint")}
                       </p>
                     </div>
 
@@ -7097,17 +7097,17 @@ supports_websockets = true`}
                         Session Key
                       </label>
                       <Input
-                        value={selectedDraft.openClawSessionKey}
+                        value={selectedDraft.genericSessionKey}
                         onChange={(event) => {
-                          handleOpenClawFieldChange(
-                            "openClawSessionKey",
+                          handleGenericFieldChange(
+                            "genericSessionKey",
                             event.target.value
                           )
                         }}
                         placeholder="agent:main:main"
                       />
                       <p className="text-[11px] text-muted-foreground">
-                        {t("openClaw.sessionKeyHint")}
+                        {t("generic.sessionKeyHint")}
                       </p>
                     </div>
 
@@ -7128,18 +7128,18 @@ supports_websockets = true`}
                             ),
                           ])
                             .then(() => {
-                              toast.success(t("toasts.openClawSaved"), {
+                              toast.success(t("toasts.genericSaved"), {
                                 description: t("toasts.configSavedHint"),
                               })
                             })
                             .catch((err) => {
                               console.error(
-                                "[Settings] save openclaw config failed:",
+                                "[Settings] save generic config failed:",
                                 err
                               )
                               const message =
                                 err instanceof Error ? err.message : String(err)
-                              toast.error(t("toasts.saveOpenClawFailed"), {
+                              toast.error(t("toasts.saveGenericFailed"), {
                                 description: message,
                               })
                             })
@@ -7154,7 +7154,7 @@ supports_websockets = true`}
                         ) : (
                           <>
                             <Save className="h-3.5 w-3.5" />
-                            {t("actions.saveOpenClawConfig")}
+                            {t("actions.saveGenericConfig")}
                           </>
                         )}
                       </Button>

--- a/src/components/settings/mcp-settings.tsx
+++ b/src/components/settings/mcp-settings.tsx
@@ -72,7 +72,7 @@ const APP_OPTIONS: { value: McpAppType; label: string }[] = [
   { value: "claude_code", label: "Claude Code" },
   { value: "codex", label: "Codex CLI" },
   { value: "gemini", label: "Gemini CLI" },
-  { value: "open_claw", label: "OpenClaw" },
+  { value: "generic", label: "Generic" },
   { value: "open_code", label: "OpenCode" },
   { value: "cline", label: "Cline" },
 ]
@@ -232,7 +232,7 @@ function appsToDraft(apps: McpAppType[]): Record<McpAppType, boolean> {
     claude_code: appSet.has("claude_code"),
     codex: appSet.has("codex"),
     gemini: appSet.has("gemini"),
-    open_claw: appSet.has("open_claw"),
+    generic: appSet.has("generic"),
     open_code: appSet.has("open_code"),
     cline: appSet.has("cline"),
   }

--- a/src/components/settings/skills-settings.tsx
+++ b/src/components/settings/skills-settings.tsx
@@ -85,8 +85,8 @@ function defaultSkillContent(
     return t("templates.openCode")
   }
 
-  if (agentType === "open_claw") {
-    return t("templates.openClaw")
+  if (agentType === "generic") {
+    return t("templates.generic")
   }
 
   return t("templates.default")
@@ -101,7 +101,7 @@ function defaultSkillLayoutForAgent(
   if (agentType === "open_code") return "skill_directory"
   if (agentType === "codex") return "skill_directory"
   if (agentType === "gemini") return "skill_directory"
-  if (agentType === "open_claw") return "skill_directory"
+  if (agentType === "generic") return "skill_directory"
   if (agentType === "cline") return "skill_directory"
   return null
 }

--- a/src/components/settings/system-network-settings.tsx
+++ b/src/components/settings/system-network-settings.tsx
@@ -99,10 +99,11 @@ export function SystemNetworkSettings() {
   const [appLanguage, setAppLanguage] = useState<LanguageSelectValue>(
     languageSettings.mode === "system" ? "system" : languageSettings.language
   )
-  const [diagnostics, setDiagnostics] = useState<RuntimeDiagnostics | null>(null)
-  const [cacheInventory, setCacheInventory] = useState<AcpCacheInventory | null>(
+  const [diagnostics, setDiagnostics] = useState<RuntimeDiagnostics | null>(
     null
   )
+  const [cacheInventory, setCacheInventory] =
+    useState<AcpCacheInventory | null>(null)
   const [loadingRuntime, setLoadingRuntime] = useState(false)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
   const [clearingCache, setClearingCache] = useState<AgentType | "all" | null>(
@@ -391,7 +392,9 @@ export function SystemNetworkSettings() {
       try {
         if (agentType === "all") {
           await Promise.all(
-            cacheInventory.entries.map((entry) => acpClearBinaryCache(entry.agent_type))
+            cacheInventory.entries.map((entry) =>
+              acpClearBinaryCache(entry.agent_type)
+            )
           )
         } else {
           await acpClearBinaryCache(agentType)
@@ -682,7 +685,10 @@ export function SystemNetworkSettings() {
                     {diagnostics.security?.allow_remote_access ? "yes" : "no"}
                   </div>
                   <div>
-                    Auth: {diagnostics.security?.auth_enabled ? "enabled" : "disabled"}
+                    Auth:{" "}
+                    {diagnostics.security?.auth_enabled
+                      ? "enabled"
+                      : "disabled"}
                   </div>
                   <div className="text-muted-foreground">
                     {diagnostics.security?.insecure
@@ -717,15 +723,21 @@ export function SystemNetworkSettings() {
               <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-2">
                 <div className="font-medium">Active ACP connections</div>
                 {diagnostics.connections.length === 0 ? (
-                  <div className="text-muted-foreground">No active ACP connections.</div>
+                  <div className="text-muted-foreground">
+                    No active ACP connections.
+                  </div>
                 ) : (
                   diagnostics.connections.map((connection) => (
                     <div
                       key={connection.id}
                       className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b last:border-b-0 pb-2 last:pb-0"
                     >
-                      <span className="font-medium">{AGENT_LABELS[connection.agent_type]}</span>
-                      <span className="text-muted-foreground">{connection.status}</span>
+                      <span className="font-medium">
+                        {AGENT_LABELS[connection.agent_type]}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {connection.status}
+                      </span>
                       <span className="text-muted-foreground">
                         owner {connection.owner_window_label}
                       </span>
@@ -740,7 +752,9 @@ export function SystemNetworkSettings() {
               <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-2">
                 <div className="font-medium">Recent runtime logs</div>
                 {diagnostics.recent_logs.length === 0 ? (
-                  <div className="text-muted-foreground">No recent runtime logs.</div>
+                  <div className="text-muted-foreground">
+                    No recent runtime logs.
+                  </div>
                 ) : (
                   diagnostics.recent_logs.slice(-12).map((entry, index) => (
                     <div
@@ -748,8 +762,12 @@ export function SystemNetworkSettings() {
                       className="grid gap-1 border-b last:border-b-0 pb-2 last:pb-0"
                     >
                       <div className="flex flex-wrap items-center gap-2">
-                        <span className="font-medium uppercase">{entry.level}</span>
-                        <span className="text-muted-foreground">{entry.scope}</span>
+                        <span className="font-medium uppercase">
+                          {entry.level}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {entry.scope}
+                        </span>
                         <span className="text-muted-foreground">
                           {formatTimestamp(entry.timestamp)}
                         </span>
@@ -787,9 +805,13 @@ export function SystemNetworkSettings() {
           {cacheInventory && (
             <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-3">
               <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
-                <span>Total size: {formatBytes(cacheInventory.total_size_bytes)}</span>
+                <span>
+                  Total size: {formatBytes(cacheInventory.total_size_bytes)}
+                </span>
                 <span>Root: {cacheInventory.root_path}</span>
-                <span>Generated: {formatTimestamp(cacheInventory.generated_at)}</span>
+                <span>
+                  Generated: {formatTimestamp(cacheInventory.generated_at)}
+                </span>
               </div>
 
               {cacheInventory.entries.map((entry) => (
@@ -801,7 +823,8 @@ export function SystemNetworkSettings() {
                     <div className="space-y-1">
                       <div className="font-medium">{entry.label}</div>
                       <div className="text-muted-foreground">
-                        {formatBytes(entry.size_bytes)} · {entry.file_count} files
+                        {formatBytes(entry.size_bytes)} · {entry.file_count}{" "}
+                        files
                       </div>
                       <div className="text-muted-foreground truncate">
                         {entry.path}

--- a/src/components/settings/system-network-settings.tsx
+++ b/src/components/settings/system-network-settings.tsx
@@ -28,12 +28,21 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import {
+  acpClearBinaryCache,
+  getAcpCacheInventory,
+  getRuntimeDiagnostics,
   getSystemProxySettings,
   updateSystemLanguageSettings,
   updateSystemProxySettings,
 } from "@/lib/api"
 import { openUrl } from "@/lib/platform"
-import type { AppLocale } from "@/lib/types"
+import { AGENT_LABELS } from "@/lib/types"
+import type {
+  AcpCacheInventory,
+  AgentType,
+  AppLocale,
+  RuntimeDiagnostics,
+} from "@/lib/types"
 import {
   checkAppUpdate,
   closeAppUpdate,
@@ -89,6 +98,15 @@ export function SystemNetworkSettings() {
 
   const [appLanguage, setAppLanguage] = useState<LanguageSelectValue>(
     languageSettings.mode === "system" ? "system" : languageSettings.language
+  )
+  const [diagnostics, setDiagnostics] = useState<RuntimeDiagnostics | null>(null)
+  const [cacheInventory, setCacheInventory] = useState<AcpCacheInventory | null>(
+    null
+  )
+  const [loadingRuntime, setLoadingRuntime] = useState(false)
+  const [runtimeError, setRuntimeError] = useState<string | null>(null)
+  const [clearingCache, setClearingCache] = useState<AgentType | "all" | null>(
+    null
   )
 
   useEffect(() => {
@@ -167,9 +185,30 @@ export function SystemNetworkSettings() {
     }
   }, [])
 
+  const loadRuntimeData = useCallback(async () => {
+    setLoadingRuntime(true)
+    setRuntimeError(null)
+    try {
+      const [runtimeSnapshot, cacheSnapshot] = await Promise.all([
+        getRuntimeDiagnostics(),
+        getAcpCacheInventory(),
+      ])
+      setDiagnostics(runtimeSnapshot)
+      setCacheInventory(cacheSnapshot)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setRuntimeError(message)
+    } finally {
+      setLoadingRuntime(false)
+    }
+  }, [])
+
   useEffect(() => {
     loadSettings().catch((err) => {
       console.error("[Settings] load system settings failed:", err)
+    })
+    loadRuntimeData().catch((err) => {
+      console.error("[Settings] load runtime diagnostics failed:", err)
     })
     checkForUpdates().catch((err) => {
       console.error("[Settings] auto check update failed:", err)
@@ -331,6 +370,43 @@ export function SystemNetworkSettings() {
       setDownloadProgress(null)
     }
   }, [availableUpdate, formatUpdateError, t])
+
+  const formatTimestamp = useCallback(
+    (value?: string | null) => {
+      if (!value) return "-"
+      const parsed = new Date(value)
+      if (Number.isNaN(parsed.getTime())) return value
+      return new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(parsed)
+    },
+    [locale]
+  )
+
+  const clearCache = useCallback(
+    async (agentType: AgentType | "all") => {
+      if (!cacheInventory) return
+      setClearingCache(agentType)
+      try {
+        if (agentType === "all") {
+          await Promise.all(
+            cacheInventory.entries.map((entry) => acpClearBinaryCache(entry.agent_type))
+          )
+        } else {
+          await acpClearBinaryCache(agentType)
+        }
+        await loadRuntimeData()
+        toast.success("ACP binary cache cleared")
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        toast.error(`Failed to clear cache: ${message}`)
+      } finally {
+        setClearingCache(null)
+      }
+    },
+    [cacheInventory, loadRuntimeData]
+  )
 
   if (loading) {
     return (
@@ -557,6 +633,205 @@ export function SystemNetworkSettings() {
               {t("proxyHint", { example: PROXY_EXAMPLE })}
             </p>
           </div>
+        </section>
+
+        <section className="rounded-xl border bg-card p-4 space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold">Runtime Diagnostics</h2>
+              <p className="text-xs text-muted-foreground leading-5">
+                ACP connections, web clients, build consistency and recent
+                runtime events.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => loadRuntimeData()}
+              disabled={loadingRuntime}
+            >
+              {loadingRuntime ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              Refresh
+            </Button>
+          </div>
+
+          {runtimeError && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+              {runtimeError}
+            </div>
+          )}
+
+          {diagnostics && (
+            <>
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-1">
+                  <div className="font-medium">Build</div>
+                  <div>Status: {diagnostics.build?.status ?? "-"}</div>
+                  <div className="text-muted-foreground">
+                    {diagnostics.build?.message ?? "Unavailable"}
+                  </div>
+                </div>
+                <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-1">
+                  <div className="font-medium">Security</div>
+                  <div>
+                    Remote access:{" "}
+                    {diagnostics.security?.allow_remote_access ? "yes" : "no"}
+                  </div>
+                  <div>
+                    Auth: {diagnostics.security?.auth_enabled ? "enabled" : "disabled"}
+                  </div>
+                  <div className="text-muted-foreground">
+                    {diagnostics.security?.insecure
+                      ? "Insecure remote exposure detected"
+                      : "No insecure startup warning"}
+                  </div>
+                </div>
+                <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-1">
+                  <div className="font-medium">Sessions</div>
+                  <div>ACP: {diagnostics.connections.length}</div>
+                  <div>Terminals: {diagnostics.terminals.length}</div>
+                  <div>Web clients: {diagnostics.web_clients.length}</div>
+                </div>
+                <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-1">
+                  <div className="font-medium">Circuit Breaker</div>
+                  <div>
+                    {diagnostics.connection_limits.breaker_open
+                      ? "Open"
+                      : "Closed"}
+                  </div>
+                  <div>
+                    Failures: {diagnostics.connection_limits.recent_failures}/
+                    {diagnostics.connection_limits.breaker_threshold}
+                  </div>
+                  <div className="text-muted-foreground">
+                    Global limit: {diagnostics.connection_limits.current_total}/
+                    {diagnostics.connection_limits.global_limit}
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-2">
+                <div className="font-medium">Active ACP connections</div>
+                {diagnostics.connections.length === 0 ? (
+                  <div className="text-muted-foreground">No active ACP connections.</div>
+                ) : (
+                  diagnostics.connections.map((connection) => (
+                    <div
+                      key={connection.id}
+                      className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b last:border-b-0 pb-2 last:pb-0"
+                    >
+                      <span className="font-medium">{AGENT_LABELS[connection.agent_type]}</span>
+                      <span className="text-muted-foreground">{connection.status}</span>
+                      <span className="text-muted-foreground">
+                        owner {connection.owner_window_label}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {connection.working_dir ?? "-"}
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-2">
+                <div className="font-medium">Recent runtime logs</div>
+                {diagnostics.recent_logs.length === 0 ? (
+                  <div className="text-muted-foreground">No recent runtime logs.</div>
+                ) : (
+                  diagnostics.recent_logs.slice(-12).map((entry, index) => (
+                    <div
+                      key={`${entry.timestamp}-${index}`}
+                      className="grid gap-1 border-b last:border-b-0 pb-2 last:pb-0"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium uppercase">{entry.level}</span>
+                        <span className="text-muted-foreground">{entry.scope}</span>
+                        <span className="text-muted-foreground">
+                          {formatTimestamp(entry.timestamp)}
+                        </span>
+                      </div>
+                      <div>{entry.message}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </section>
+
+        <section className="rounded-xl border bg-card p-4 space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold">Cache Governance</h2>
+              <p className="text-xs text-muted-foreground leading-5">
+                Inspect and clear ACP binary caches without leaving Settings.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={!cacheInventory || clearingCache !== null}
+              onClick={() => clearCache("all")}
+            >
+              {clearingCache === "all" && (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              )}
+              Clear all
+            </Button>
+          </div>
+
+          {cacheInventory && (
+            <div className="rounded-md border bg-muted/20 px-3 py-3 text-xs space-y-3">
+              <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
+                <span>Total size: {formatBytes(cacheInventory.total_size_bytes)}</span>
+                <span>Root: {cacheInventory.root_path}</span>
+                <span>Generated: {formatTimestamp(cacheInventory.generated_at)}</span>
+              </div>
+
+              {cacheInventory.entries.map((entry) => (
+                <div
+                  key={entry.agent_type}
+                  className="flex flex-col gap-2 rounded-md border bg-background/70 px-3 py-3"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="font-medium">{entry.label}</div>
+                      <div className="text-muted-foreground">
+                        {formatBytes(entry.size_bytes)} · {entry.file_count} files
+                      </div>
+                      <div className="text-muted-foreground truncate">
+                        {entry.path}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={clearingCache !== null}
+                      onClick={() => clearCache(entry.agent_type)}
+                    >
+                      {clearingCache === entry.agent_type && (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      )}
+                      Clear
+                    </Button>
+                  </div>
+                  <div className="text-muted-foreground">
+                    Installed: {entry.installed_version ?? "-"} · Recommended:{" "}
+                    {entry.recommended_version ?? "-"}
+                  </div>
+                  {entry.versions.length > 0 && (
+                    <div className="text-muted-foreground">
+                      Versions: {entry.versions.join(", ")}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </section>
 
         <section className="rounded-xl border bg-card p-4 space-y-4">

--- a/src/contexts/acp-connections-context.tsx
+++ b/src/contexts/acp-connections-context.tsx
@@ -124,6 +124,13 @@ export interface ConnectionState {
   pendingPermission: PendingPermission | null
   pendingQuestion: PendingQuestion | null
   claudeApiRetry: ClaudeApiRetryState | null
+  /** True while the agent is performing mid-turn context compaction.
+   * Used to render a "Compacting context…" hint without leaving the
+   * spinner unexplained. */
+  compacting: boolean
+  /** Most recent non-fatal stream parse warning. Cleared on next turn
+   * start. Helps surface silently swallowed errors. */
+  streamWarning: string | null
   error: string | null
 }
 
@@ -252,6 +259,10 @@ type Action =
       retry: ClaudeApiRetryState | null
     }
   | { type: "ERROR"; contextKey: string; message: string }
+  | { type: "COMPACTION_STARTED"; contextKey: string }
+  | { type: "COMPACTION_FINISHED"; contextKey: string }
+  | { type: "STREAM_WARNING"; contextKey: string; message: string }
+  | { type: "TURN_IDLE_TIMEOUT"; contextKey: string; idleMs: number }
   | {
       type: "AVAILABLE_COMMANDS"
       contextKey: string
@@ -621,6 +632,8 @@ function connectionsReducer(
         pendingPermission: null,
         pendingQuestion: null,
         claudeApiRetry: null,
+        compacting: false,
+        streamWarning: null,
         error: null,
       })
       return next
@@ -649,10 +662,14 @@ function connectionsReducer(
         }
         updated.pendingQuestion = null
         updated.claudeApiRetry = null
+        updated.compacting = false
+        updated.streamWarning = null
         updated.error = null
       } else if (conn.status === "prompting") {
-        // Prompt cycle ended: clear in-flight Claude API retry banner.
+        // Prompt cycle ended: clear in-flight Claude API retry banner
+        // and any lingering compaction hint.
         updated.claudeApiRetry = null
+        updated.compacting = false
       }
       next.set(action.contextKey, updated)
       return next
@@ -1183,10 +1200,63 @@ function connectionsReducer(
       const conn = state.get(action.contextKey)
       if (!conn) return state
       const next = new Map(state)
+      // If the error arrived while a turn was in flight, the turn is
+      // effectively dead — bring the UI back to a usable "connected"
+      // state so the user can retry. Without this the spinner would
+      // run forever and the send box stay disabled even though we
+      // already showed an error banner.
+      const wasPrompting = conn.status === "prompting"
       next.set(action.contextKey, {
         ...conn,
+        status: wasPrompting ? "connected" : conn.status,
+        liveMessage: wasPrompting ? null : conn.liveMessage,
         claudeApiRetry: null,
+        compacting: false,
         error: action.message,
+      })
+      return next
+    }
+
+    case "COMPACTION_STARTED": {
+      const conn = state.get(action.contextKey)
+      if (!conn) return state
+      if (conn.compacting) return state
+      const next = new Map(state)
+      next.set(action.contextKey, { ...conn, compacting: true })
+      return next
+    }
+
+    case "COMPACTION_FINISHED": {
+      const conn = state.get(action.contextKey)
+      if (!conn) return state
+      if (!conn.compacting) return state
+      const next = new Map(state)
+      next.set(action.contextKey, { ...conn, compacting: false })
+      return next
+    }
+
+    case "STREAM_WARNING": {
+      const conn = state.get(action.contextKey)
+      if (!conn) return state
+      if (conn.streamWarning === action.message) return state
+      const next = new Map(state)
+      next.set(action.contextKey, { ...conn, streamWarning: action.message })
+      return next
+    }
+
+    case "TURN_IDLE_TIMEOUT": {
+      // Treated like a forced TurnComplete: clear in-flight state and
+      // surface a recoverable error so the user knows what happened.
+      const conn = state.get(action.contextKey)
+      if (!conn) return state
+      const next = new Map(state)
+      next.set(action.contextKey, {
+        ...conn,
+        status: "connected",
+        liveMessage: null,
+        pendingPermission: null,
+        claudeApiRetry: null,
+        compacting: false,
       })
       return next
     }
@@ -2012,6 +2082,46 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
             },
           })
           break
+        case "compaction_started":
+          // Don't flush streaming queue — text deltas can resume
+          // immediately after compaction; we just want to surface the
+          // hint and keep ordering intact.
+          dispatch({ type: "COMPACTION_STARTED", contextKey })
+          break
+        case "compaction_finished":
+          dispatch({ type: "COMPACTION_FINISHED", contextKey })
+          break
+        case "stream_warning":
+          // Non-fatal: stash the message so debugging is possible, but
+          // don't break the spinner. The watchdog will catch a true hang.
+          dispatch({
+            type: "STREAM_WARNING",
+            contextKey,
+            message: e.message,
+          })
+          break
+        case "turn_idle_timeout": {
+          flushStreamingQueue()
+          flushPendingToolCallUpdates()
+          dispatch({
+            type: "TURN_IDLE_TIMEOUT",
+            contextKey,
+            idleMs: e.idle_ms,
+          })
+          // Surface a localized banner so the user understands why the
+          // turn ended without a normal completion.
+          const idleConn = storeRef.current.connections.get(contextKey)
+          const agentLabel = idleConn
+            ? AGENT_LABELS[idleConn.agentType]
+            : (e.agent_type as string)
+          const seconds = Math.round(e.idle_ms / 1000)
+          const message = t("backendErrors.turnIdleTimeout", {
+            agent: agentLabel,
+            seconds,
+          })
+          pushAlertRef.current("warning", t("eventErrorTitle"), message)
+          break
+        }
       }
     },
     [
@@ -2171,11 +2281,17 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
         }
 
         const nextWorkingDir = workingDir ?? null
+        const requestedSessionId =
+          typeof sessionId === "string" && sessionId.trim().length > 0
+            ? sessionId
+            : null
         const existing = storeRef.current.connections.get(contextKey)
         if (existing) {
           if (
             existing.agentType === agentType &&
             existing.workingDir === nextWorkingDir &&
+            (requestedSessionId === null ||
+              existing.sessionId === requestedSessionId) &&
             existing.status !== "disconnected" &&
             existing.status !== "error"
           ) {

--- a/src/contexts/acp-connections-context.tsx
+++ b/src/contexts/acp-connections-context.tsx
@@ -282,6 +282,13 @@ type ConnectionsMap = Map<string, ConnectionState>
 const MAX_LIVE_TOOL_RAW_OUTPUT_CHARS = 200_000
 const MAX_BUFFERED_UNMAPPED_EVENTS_PER_CONNECTION = 64
 const MAX_BUFFERED_UNMAPPED_CONNECTIONS = 128
+/** Buffered unmapped events older than this are evicted on access. */
+const UNMAPPED_EVENT_TTL_MS = 60_000
+
+interface BufferedEntry {
+  events: AcpEvent[]
+  lastSeenAt: number
+}
 
 // Per-agentType cache for selectors (modes / configOptions).
 // Populated when real data arrives from the backend.
@@ -1494,7 +1501,7 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
   const lastActivityRef = useRef(new Map<string, number>())
   const streamingQueueRef = useRef<StreamingAction[]>([])
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pendingUnmappedEventsRef = useRef(new Map<string, AcpEvent[]>())
+  const pendingUnmappedEventsRef = useRef(new Map<string, BufferedEntry>())
   const listenerReadyRef = useRef(false)
   const listenerReadyWaitersRef = useRef<Array<() => void>>([])
 
@@ -1659,29 +1666,43 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
 
   const bufferUnmappedEvent = useCallback((event: AcpEvent) => {
     const connectionId = event.connection_id
-    const buffered = pendingUnmappedEventsRef.current.get(connectionId) ?? []
-    if (buffered.length >= MAX_BUFFERED_UNMAPPED_EVENTS_PER_CONNECTION) {
-      buffered.shift()
-    }
-    buffered.push(event)
-    pendingUnmappedEventsRef.current.set(connectionId, buffered)
+    const now = Date.now()
+    const map = pendingUnmappedEventsRef.current
 
-    if (
-      pendingUnmappedEventsRef.current.size > MAX_BUFFERED_UNMAPPED_CONNECTIONS
-    ) {
-      const oldest = pendingUnmappedEventsRef.current.keys().next().value
-      if (oldest) {
-        pendingUnmappedEventsRef.current.delete(oldest)
+    // TTL eviction: drop entries whose lastSeenAt is older than TTL.
+    // Iterating a Map in insertion order makes this cheap — once we hit
+    // a non-stale entry the rest are guaranteed newer (we re-set on touch).
+    if (map.size > 0) {
+      for (const [key, entry] of map) {
+        if (now - entry.lastSeenAt < UNMAPPED_EVENT_TTL_MS) break
+        map.delete(key)
       }
+    }
+
+    const existing = map.get(connectionId)
+    const events = existing?.events ?? []
+    if (events.length >= MAX_BUFFERED_UNMAPPED_EVENTS_PER_CONNECTION) {
+      events.shift()
+    }
+    events.push(event)
+
+    // Re-insert (delete + set) so the entry moves to the tail, keeping the
+    // Map in approximate LRU order for the iterator-based eviction above.
+    map.delete(connectionId)
+    map.set(connectionId, { events, lastSeenAt: now })
+
+    if (map.size > MAX_BUFFERED_UNMAPPED_CONNECTIONS) {
+      const oldest = map.keys().next().value
+      if (oldest) map.delete(oldest)
     }
   }, [])
 
   const consumeBufferedEvents = useCallback(
     (connectionId: string): AcpEvent[] => {
-      const buffered = pendingUnmappedEventsRef.current.get(connectionId)
-      if (!buffered || buffered.length === 0) return []
+      const entry = pendingUnmappedEventsRef.current.get(connectionId)
+      if (!entry || entry.events.length === 0) return []
       pendingUnmappedEventsRef.current.delete(connectionId)
-      return buffered
+      return entry.events
     },
     []
   )

--- a/src/contexts/aux-panel-context.tsx
+++ b/src/contexts/aux-panel-context.tsx
@@ -15,7 +15,12 @@ import {
 } from "@/lib/panel-state-storage"
 import { useActiveFolder } from "@/contexts/active-folder-context"
 
-export type AuxPanelTab = "file_tree" | "changes" | "git_log" | "session_files"
+export type AuxPanelTab =
+  | "file_tree"
+  | "changes"
+  | "git_log"
+  | "session_files"
+  | "squad"
 
 const STORAGE_KEY = "workspace:right-sidebar"
 

--- a/src/contexts/squad-context.tsx
+++ b/src/contexts/squad-context.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react"
@@ -22,6 +23,7 @@ import {
   squadUpdateTaskStatus,
 } from "@/lib/api"
 import { subscribe } from "@/lib/platform"
+import { applySquadEvent } from "@/lib/squad-events"
 import type {
   SquadEvent,
   SquadRoleKind,
@@ -197,13 +199,66 @@ export function SquadProvider({ children }: { children: ReactNode }) {
     []
   )
 
+  // Track the active run id in a ref so the event subscription doesn't have
+  // to re-bind when the snapshot reference changes.
+  const activeRunRef = useRef<SquadRunSnapshot | null>(null)
   useEffect(() => {
+    activeRunRef.current = activeRun
+  }, [activeRun])
+
+  useEffect(() => {
+    // Coalesce reload requests so a burst of unknown-entity events triggers
+    // at most one refetch per run id.
+    const pendingReload = new Map<number, ReturnType<typeof setTimeout>>()
+    const scheduleReload = (squadRunId: number) => {
+      if (pendingReload.has(squadRunId)) return
+      const handle = setTimeout(() => {
+        pendingReload.delete(squadRunId)
+        void squadGetRun(squadRunId)
+          .then((snap) => {
+            // Only commit if we're still looking at this run.
+            if (activeRunRef.current?.run.id === snap.run.id) {
+              setActiveRun(snap)
+            }
+            setError(null)
+          })
+          .catch((err) => setError(errorMessage(err)))
+      }, 50)
+      pendingReload.set(squadRunId, handle)
+    }
+
     const unlisten = subscribe<SquadEvent>("squad://event", (event) => {
-      void squadGetRun(event.squadRunId)
-        .then(setActiveRun)
-        .catch((err) => setError(errorMessage(err)))
+      // Keep the runs list summary in sync for run-level transitions even
+      // when the user isn't focused on that specific run.
+      if (event.type === "squad_run_status_changed") {
+        const payload = event.payload as Partial<SquadRunInfo> | undefined
+        if (
+          payload &&
+          typeof payload.id === "number" &&
+          typeof payload.status === "string"
+        ) {
+          const next = payload as SquadRunInfo
+          setRuns((prev) => prev.map((r) => (r.id === next.id ? next : r)))
+        }
+      }
+      const current = activeRunRef.current
+      if (!current || current.run.id !== event.squadRunId) {
+        // Event is for a different run: nothing to patch locally.
+        return
+      }
+      const result = applySquadEvent(current, event)
+      if (result.changed && result.snapshot) {
+        setActiveRun(result.snapshot)
+      }
+      if (result.needsReload) {
+        scheduleReload(event.squadRunId)
+      }
     })
     return () => {
+      for (const handle of pendingReload.values()) {
+        clearTimeout(handle)
+      }
+      pendingReload.clear()
       void unlisten.then((fn) => fn())
     }
   }, [])

--- a/src/contexts/squad-context.tsx
+++ b/src/contexts/squad-context.tsx
@@ -93,6 +93,14 @@ export function SquadProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Track the active run snapshot in a ref so callbacks can read the
+  // latest value without re-binding when state changes. Declared up
+  // front so any callback below can rely on it.
+  const activeRunRef = useRef<SquadRunSnapshot | null>(null)
+  useEffect(() => {
+    activeRunRef.current = activeRun
+  }, [activeRun])
+
   const loadForFolder = useCallback(async (folderId: number) => {
     setLoading(true)
     try {
@@ -102,8 +110,16 @@ export function SquadProvider({ children }: { children: ReactNode }) {
       ])
       setProfiles(nextProfiles)
       setRuns(nextRuns)
-      if (nextRuns[0]) {
-        setActiveRun(await squadGetRun(nextRuns[0].id))
+      // Prefer keeping the currently-selected run if it still exists in
+      // the folder; otherwise pick the most recent. This avoids clobbering
+      // a user's selection on a routine refresh.
+      const previousId = activeRunRef.current?.run.id
+      const stillSelected = previousId
+        ? nextRuns.find((r) => r.id === previousId)
+        : null
+      const target = stillSelected ?? nextRuns[0]
+      if (target) {
+        setActiveRun(await squadGetRun(target.id))
       } else {
         setActiveRun(null)
       }
@@ -127,6 +143,7 @@ export function SquadProvider({ children }: { children: ReactNode }) {
         snapshot.run,
         ...prev.filter((r) => r.id !== snapshot.run.id),
       ])
+      setError(null)
       return snapshot
     },
     []
@@ -168,8 +185,11 @@ export function SquadProvider({ children }: { children: ReactNode }) {
       title: string
       description: string
     }) => {
+      // Backend emits `squad_task_created` which the event reducer in
+      // useEffect below patches into activeRun.tasks; we don't need a
+      // follow-up squadGetRun here. The optimistic returned task lets
+      // callers chain on the new id immediately.
       const task = await squadCreateTask(params)
-      setActiveRun(await squadGetRun(params.squadRunId))
       setError(null)
       return task
     },
@@ -178,8 +198,9 @@ export function SquadProvider({ children }: { children: ReactNode }) {
 
   const updateTaskStatus = useCallback(
     async (params: { taskId: number; status: SquadTaskStatus }) => {
+      // `squad_task_status_changed` event will patch activeRun.tasks via
+      // the reducer.
       const task = await squadUpdateTaskStatus(params)
-      setActiveRun(await squadGetRun(task.squadRunId))
       setError(null)
       return task
     },
@@ -192,19 +213,13 @@ export function SquadProvider({ children }: { children: ReactNode }) {
       roleKind: SquadRoleKind
       taskId?: number | null
     }) => {
+      // Role status flips are emitted via `squad_role_status_changed`;
+      // the reducer keeps activeRun.roles in sync without a refetch.
       await squadPromptRole(params)
-      setActiveRun(await squadGetRun(params.squadRunId))
       setError(null)
     },
     []
   )
-
-  // Track the active run id in a ref so the event subscription doesn't have
-  // to re-bind when the snapshot reference changes.
-  const activeRunRef = useRef<SquadRunSnapshot | null>(null)
-  useEffect(() => {
-    activeRunRef.current = activeRun
-  }, [activeRun])
 
   useEffect(() => {
     // Coalesce reload requests so a burst of unknown-entity events triggers

--- a/src/contexts/squad-context.tsx
+++ b/src/contexts/squad-context.tsx
@@ -1,0 +1,245 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import {
+  squadCreateRun,
+  squadCreateTask,
+  squadGetRun,
+  squadListRuns,
+  squadPromptRole,
+  squadSeedRoleProfiles,
+  squadStartRun,
+  squadStopRun,
+  squadUpdateRoleProfile,
+  squadUpdateTaskStatus,
+} from "@/lib/api"
+import { subscribe } from "@/lib/platform"
+import type {
+  SquadEvent,
+  SquadRoleKind,
+  SquadRoleProfileInfo,
+  SquadRoleProfilePatch,
+  SquadRunInfo,
+  SquadRunMode,
+  SquadRunSnapshot,
+  SquadTaskInfo,
+  SquadTaskStatus,
+} from "@/lib/types"
+
+interface SquadContextValue {
+  profiles: SquadRoleProfileInfo[]
+  runs: SquadRunInfo[]
+  activeRun: SquadRunSnapshot | null
+  loading: boolean
+  error: string | null
+  loadForFolder: (folderId: number) => Promise<void>
+  createRun: (params: {
+    folderId: number
+    mode: SquadRunMode
+    goalSummary: string
+  }) => Promise<SquadRunSnapshot>
+  startRun: (squadRunId: number, workingDir?: string | null) => Promise<void>
+  stopRun: (squadRunId: number) => Promise<void>
+  updateRoleProfile: (params: {
+    folderId: number
+    roleKind: SquadRoleKind
+    patch: SquadRoleProfilePatch
+  }) => Promise<SquadRoleProfileInfo>
+  createTask: (params: {
+    squadRunId: number
+    assignedRoleKind: SquadRoleKind
+    title: string
+    description: string
+  }) => Promise<SquadTaskInfo>
+  updateTaskStatus: (params: {
+    taskId: number
+    status: SquadTaskStatus
+  }) => Promise<SquadTaskInfo>
+  promptRole: (params: {
+    squadRunId: number
+    roleKind: SquadRoleKind
+    taskId?: number | null
+  }) => Promise<void>
+}
+
+const SquadContext = createContext<SquadContextValue | null>(null)
+
+export function useSquadContext() {
+  const ctx = useContext(SquadContext)
+  if (!ctx) {
+    throw new Error("useSquadContext must be used within SquadProvider")
+  }
+  return ctx
+}
+
+function errorMessage(err: unknown) {
+  return err instanceof Error ? err.message : String(err)
+}
+
+export function SquadProvider({ children }: { children: ReactNode }) {
+  const [profiles, setProfiles] = useState<SquadRoleProfileInfo[]>([])
+  const [runs, setRuns] = useState<SquadRunInfo[]>([])
+  const [activeRun, setActiveRun] = useState<SquadRunSnapshot | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadForFolder = useCallback(async (folderId: number) => {
+    setLoading(true)
+    try {
+      const [nextProfiles, nextRuns] = await Promise.all([
+        squadSeedRoleProfiles(folderId),
+        squadListRuns(folderId),
+      ])
+      setProfiles(nextProfiles)
+      setRuns(nextRuns)
+      if (nextRuns[0]) {
+        setActiveRun(await squadGetRun(nextRuns[0].id))
+      } else {
+        setActiveRun(null)
+      }
+      setError(null)
+    } catch (err) {
+      setError(errorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const createRun = useCallback(
+    async (params: {
+      folderId: number
+      mode: SquadRunMode
+      goalSummary: string
+    }) => {
+      const snapshot = await squadCreateRun(params)
+      setActiveRun(snapshot)
+      setRuns((prev) => [
+        snapshot.run,
+        ...prev.filter((r) => r.id !== snapshot.run.id),
+      ])
+      return snapshot
+    },
+    []
+  )
+
+  const startRun = useCallback(
+    async (squadRunId: number, workingDir?: string | null) => {
+      await squadStartRun({ squadRunId, workingDir })
+      setActiveRun(await squadGetRun(squadRunId))
+    },
+    []
+  )
+
+  const stopRun = useCallback(async (squadRunId: number) => {
+    await squadStopRun(squadRunId)
+    setActiveRun(await squadGetRun(squadRunId))
+  }, [])
+
+  const updateRoleProfile = useCallback(
+    async (params: {
+      folderId: number
+      roleKind: SquadRoleKind
+      patch: SquadRoleProfilePatch
+    }) => {
+      const profile = await squadUpdateRoleProfile(params)
+      setProfiles((prev) =>
+        prev.map((item) => (item.id === profile.id ? profile : item))
+      )
+      setError(null)
+      return profile
+    },
+    []
+  )
+
+  const createTask = useCallback(
+    async (params: {
+      squadRunId: number
+      assignedRoleKind: SquadRoleKind
+      title: string
+      description: string
+    }) => {
+      const task = await squadCreateTask(params)
+      setActiveRun(await squadGetRun(params.squadRunId))
+      setError(null)
+      return task
+    },
+    []
+  )
+
+  const updateTaskStatus = useCallback(
+    async (params: { taskId: number; status: SquadTaskStatus }) => {
+      const task = await squadUpdateTaskStatus(params)
+      setActiveRun(await squadGetRun(task.squadRunId))
+      setError(null)
+      return task
+    },
+    []
+  )
+
+  const promptRole = useCallback(
+    async (params: {
+      squadRunId: number
+      roleKind: SquadRoleKind
+      taskId?: number | null
+    }) => {
+      await squadPromptRole(params)
+      setActiveRun(await squadGetRun(params.squadRunId))
+      setError(null)
+    },
+    []
+  )
+
+  useEffect(() => {
+    const unlisten = subscribe<SquadEvent>("squad://event", (event) => {
+      void squadGetRun(event.squadRunId)
+        .then(setActiveRun)
+        .catch((err) => setError(errorMessage(err)))
+    })
+    return () => {
+      void unlisten.then((fn) => fn())
+    }
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      profiles,
+      runs,
+      activeRun,
+      loading,
+      error,
+      loadForFolder,
+      createRun,
+      startRun,
+      stopRun,
+      updateRoleProfile,
+      createTask,
+      updateTaskStatus,
+      promptRole,
+    }),
+    [
+      profiles,
+      runs,
+      activeRun,
+      loading,
+      error,
+      loadForFolder,
+      createRun,
+      startRun,
+      stopRun,
+      updateRoleProfile,
+      createTask,
+      updateTaskStatus,
+      promptRole,
+    ]
+  )
+
+  return <SquadContext.Provider value={value}>{children}</SquadContext.Provider>
+}

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useMemo, useSyncExternalStore } from "react"
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
 import {
   useAcpActions,
   useConnectionStore,
@@ -61,6 +61,101 @@ export interface UseConnectionReturn {
 function derive(conn: ConnectionState | undefined) {
   if (!conn) return null
   return conn
+}
+
+/**
+ * Subscribe to a single derived slice of a connection. Returns a stable
+ * reference whenever the slice value compares equal (Object.is) to the
+ * previous one, so consumers re-render only when their slice actually
+ * changes — instead of on every connection-state mutation.
+ *
+ * This is the field-scoped primitive that backs the granular hooks below.
+ * Use it directly when you need a custom slice not covered by them.
+ */
+function useConnectionSlice<T>(
+  contextKey: string,
+  selector: (conn: ConnectionState | undefined) => T
+): T {
+  const store = useConnectionStore()
+  const subscribe = useCallback(
+    (cb: () => void) => store.subscribeKey(contextKey, cb),
+    [store, contextKey]
+  )
+
+  // Cache the last selected value to keep the snapshot identity stable
+  // when the underlying connection mutates but the slice is equal.
+  const lastValueRef = useRef<{ value: T; computed: boolean }>({
+    value: undefined as unknown as T,
+    computed: false,
+  })
+
+  const getSnapshot = useCallback(() => {
+    const next = selector(store.getConnection(contextKey))
+    if (
+      lastValueRef.current.computed &&
+      Object.is(lastValueRef.current.value, next)
+    ) {
+      return lastValueRef.current.value
+    }
+    lastValueRef.current = { value: next, computed: true }
+    return next
+  }, [store, contextKey, selector])
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+const selectStatus = (c: ConnectionState | undefined) => c?.status ?? null
+const selectLiveMessage = (c: ConnectionState | undefined) =>
+  c?.liveMessage ?? null
+const selectPendingPermission = (c: ConnectionState | undefined) =>
+  c?.pendingPermission ?? null
+const selectPendingQuestion = (c: ConnectionState | undefined) =>
+  c?.pendingQuestion ?? null
+const selectError = (c: ConnectionState | undefined) => c?.error ?? null
+const selectCompacting = (c: ConnectionState | undefined) =>
+  c?.compacting ?? false
+const selectClaudeApiRetry = (c: ConnectionState | undefined) =>
+  c?.claudeApiRetry ?? null
+const selectConnectionId = (c: ConnectionState | undefined) =>
+  c?.connectionId ?? null
+const selectSessionId = (c: ConnectionState | undefined) => c?.sessionId ?? null
+
+/** Subscribe only to connection status. */
+export function useConnectionStatus(contextKey: string) {
+  return useConnectionSlice(contextKey, selectStatus)
+}
+
+/** Subscribe only to the live (streaming) message. High-frequency: prefer
+ * this over `useConnection` in components that render the streaming bubble. */
+export function useConnectionLiveMessage(contextKey: string) {
+  return useConnectionSlice(contextKey, selectLiveMessage)
+}
+
+/** Subscribe only to pending permission/question prompts. */
+export function useConnectionPendingPermission(contextKey: string) {
+  return useConnectionSlice(contextKey, selectPendingPermission)
+}
+export function useConnectionPendingQuestion(contextKey: string) {
+  return useConnectionSlice(contextKey, selectPendingQuestion)
+}
+
+/** Subscribe only to error / retry / compacting indicators. */
+export function useConnectionError(contextKey: string) {
+  return useConnectionSlice(contextKey, selectError)
+}
+export function useConnectionCompacting(contextKey: string) {
+  return useConnectionSlice(contextKey, selectCompacting)
+}
+export function useConnectionClaudeApiRetry(contextKey: string) {
+  return useConnectionSlice(contextKey, selectClaudeApiRetry)
+}
+
+/** Subscribe only to identifiers. */
+export function useConnectionId(contextKey: string) {
+  return useConnectionSlice(contextKey, selectConnectionId)
+}
+export function useConnectionSessionId(contextKey: string) {
+  return useConnectionSlice(contextKey, selectSessionId)
 }
 
 export function useConnection(contextKey: string): UseConnectionReturn {

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -42,6 +42,8 @@ export interface UseConnectionReturn {
   pendingPermission: PendingPermission | null
   pendingQuestion: PendingQuestion | null
   claudeApiRetry: ClaudeApiRetryState | null
+  /** True while the agent is compacting context history mid-turn. */
+  compacting: boolean
   error: string | null
   connect: (
     agentType: AgentType,
@@ -94,6 +96,7 @@ export function useConnection(contextKey: string): UseConnectionReturn {
   const pendingPermission = connection?.pendingPermission ?? null
   const pendingQuestion = connection?.pendingQuestion ?? null
   const claudeApiRetry = connection?.claudeApiRetry ?? null
+  const compacting = connection?.compacting ?? false
   const error = connection?.error ?? null
 
   const connect = useCallback(
@@ -150,6 +153,7 @@ export function useConnection(contextKey: string): UseConnectionReturn {
       pendingPermission,
       pendingQuestion,
       claudeApiRetry,
+      compacting,
       error,
       connect,
       disconnect,
@@ -174,6 +178,7 @@ export function useConnection(contextKey: string): UseConnectionReturn {
       pendingPermission,
       pendingQuestion,
       claudeApiRetry,
+      compacting,
       error,
       connect,
       disconnect,

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "حفظ إعداد Codex",
       "saveGeminiConfig": "حفظ إعداد Gemini",
       "saveOpenCodeConfig": "حفظ إعداد OpenCode",
-      "saveOpenClawConfig": "حفظ إعداد OpenClaw",
+      "saveGenericConfig": "حفظ إعداد Generic",
       "saveConfigManagement": "حفظ إدارة الإعدادات",
       "saveCurrentProvider": "حفظ المزود الحالي",
       "showApiKey": "إظهار مفتاح API",
@@ -568,12 +568,12 @@
       "smallModel": "النموذج الصغير",
       "noMatchingModels": "لا توجد نماذج مطابقة"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "إعداد Gateway",
-      "gatewayDescription": "قم بإعداد اتصال OpenClaw Gateway. يدعم gateway محليًا أو بعيدًا.",
-      "gatewayUrlHint": "اتركه فارغًا لاستخدام gateway.remote.url من إعداد openclaw المحلي.",
+      "gatewayDescription": "قم بإعداد اتصال Generic Gateway. يدعم gateway محليًا أو بعيدًا.",
+      "gatewayUrlHint": "اتركه فارغًا لاستخدام gateway.remote.url من إعداد generic المحلي.",
       "gatewayTokenPlaceholder": "رمز مصادقة Gateway",
-      "gatewayTokenHint": "يُفضّل استخدام token-file بدل الرمز النصي متى أمكن؛ قم بالإعداد عبر openclaw CLI.",
+      "gatewayTokenHint": "يُفضّل استخدام token-file بدل الرمز النصي متى أمكن؛ قم بالإعداد عبر generic CLI.",
       "sessionKeyHint": "اختياري. حدّد مفتاح جلسة gateway؛ واتركه فارغًا للتعيين التلقائي لجلسة معزولة."
     },
     "authModeOfficialSubscription": "الاشتراك الرسمي",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "تمت مزامنة إعداد OpenCode وauth JSON.",
       "openCodeSaved": "تم حفظ إعداد OpenCode",
       "saveOpenCodeFailed": "فشل حفظ إعداد OpenCode",
-      "openClawSaved": "تم حفظ إعداد OpenClaw",
-      "saveOpenClawFailed": "فشل حفظ إعداد OpenClaw",
+      "genericSaved": "تم حفظ إعداد Generic",
+      "saveGenericFailed": "فشل حفظ إعداد Generic",
       "configSaved": "تم حفظ الإعداد",
       "configSavedHint": "يجب إعادة فتح الجلسات الحالية لتطبيق التغييرات",
       "saveConfigManagementFailed": "فشل حفظ إدارة الإعدادات",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "انتهت مهلة مصافحة اتصال {agent} (لا استجابة بعد 60 ثانية). افتح الإعدادات للتحقق من إعدادات الوكيل والشبكة.",
           "processExited": "انتهت عملية {agent} بشكل غير متوقع.",
           "spawnFailed": "تعذر بدء تشغيل {agent}: {message}",
-          "downloadFailed": "فشل تنزيل {agent}: {message}"
+          "downloadFailed": "فشل تنزيل {agent}: {message}",
+          "turnIdleTimeout": "توقف {agent} عن الاستجابة لمدة {seconds} ثانية — تم إنهاء الجولة تلقائيًا. يمكنك المحاولة مجددًا."
         },
         "unableReadAgentConfig": "تعذر قراءة إعدادات الوكيل: {message}",
         "connectFailedTitle": "فشل اتصال {agent}",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}، {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "جارٍ ضغط السياق…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Codex-Konfiguration speichern",
       "saveGeminiConfig": "Gemini-Konfiguration speichern",
       "saveOpenCodeConfig": "OpenCode-Konfiguration speichern",
-      "saveOpenClawConfig": "OpenClaw-Konfiguration speichern",
+      "saveGenericConfig": "Generic-Konfiguration speichern",
       "saveConfigManagement": "Konfigurationsverwaltung speichern",
       "saveCurrentProvider": "Aktuellen Provider speichern",
       "showApiKey": "API-Key anzeigen",
@@ -568,12 +568,12 @@
       "smallModel": "Kleines Modell",
       "noMatchingModels": "Keine passenden Modelle"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Gateway-Konfiguration",
-      "gatewayDescription": "OpenClaw-Gateway-Verbindung konfigurieren. Unterstützt lokales oder entferntes Gateway.",
-      "gatewayUrlHint": "Leer lassen, um gateway.remote.url aus der lokalen openclaw-Konfiguration zu verwenden.",
+      "gatewayDescription": "Generic-Gateway-Verbindung konfigurieren. Unterstützt lokales oder entferntes Gateway.",
+      "gatewayUrlHint": "Leer lassen, um gateway.remote.url aus der lokalen generic-Konfiguration zu verwenden.",
       "gatewayTokenPlaceholder": "Gateway-Auth-Token",
-      "gatewayTokenHint": "Wenn möglich token-file statt Klartext-Token verwenden; über openclaw CLI konfigurieren.",
+      "gatewayTokenHint": "Wenn möglich token-file statt Klartext-Token verwenden; über generic CLI konfigurieren.",
       "sessionKeyHint": "Optional. Gateway-Session-Key angeben; leer lassen für automatische Zuweisung einer isolierten Session."
     },
     "authModeOfficialSubscription": "Offizielles Abonnement",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "OpenCode-Konfiguration und auth JSON wurden synchronisiert.",
       "openCodeSaved": "OpenCode-Konfiguration gespeichert",
       "saveOpenCodeFailed": "Speichern der OpenCode-Konfiguration fehlgeschlagen",
-      "openClawSaved": "OpenClaw-Konfiguration gespeichert",
-      "saveOpenClawFailed": "Speichern der OpenClaw-Konfiguration fehlgeschlagen",
+      "genericSaved": "Generic-Konfiguration gespeichert",
+      "saveGenericFailed": "Speichern der Generic-Konfiguration fehlgeschlagen",
       "configSaved": "Konfiguration gespeichert",
       "configSavedHint": "Bestehende Sitzungen müssen neu geöffnet werden, damit die Änderungen wirksam werden",
       "saveConfigManagementFailed": "Speichern der Konfigurationsverwaltung fehlgeschlagen",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "Der Verbindungs-Handshake von {agent} hat nach 60 Sekunden das Zeitlimit überschritten. Öffnen Sie die Einstellungen, um Agenten- und Netzwerkkonfiguration zu prüfen.",
           "processExited": "{agent}-Prozess wurde unerwartet beendet.",
           "spawnFailed": "{agent} konnte nicht gestartet werden: {message}",
-          "downloadFailed": "{agent}-Download fehlgeschlagen: {message}"
+          "downloadFailed": "{agent}-Download fehlgeschlagen: {message}",
+          "turnIdleTimeout": "{agent} hat {seconds} s lang nicht reagiert – die Anfrage wurde automatisch abgebrochen. Du kannst es erneut versuchen."
         },
         "unableReadAgentConfig": "Agenten-Konfiguration kann nicht gelesen werden: {message}",
         "connectFailedTitle": "{agent} Verbindung fehlgeschlagen",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}, {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "Kontext wird komprimiert …"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Save Codex Config",
       "saveGeminiConfig": "Save Gemini Config",
       "saveOpenCodeConfig": "Save OpenCode Config",
-      "saveOpenClawConfig": "Save OpenClaw Config",
+      "saveGenericConfig": "Save Generic Config",
       "saveConfigManagement": "Save Config Management",
       "saveCurrentProvider": "Save Current Provider",
       "showApiKey": "Show API Key",
@@ -568,12 +568,12 @@
       "smallModel": "Small Model",
       "noMatchingModels": "No matching models"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Gateway Config",
-      "gatewayDescription": "Configure OpenClaw Gateway connection. Supports local or remote gateway.",
-      "gatewayUrlHint": "Leave empty to use gateway.remote.url from local openclaw config.",
+      "gatewayDescription": "Configure Generic Gateway connection. Supports local or remote gateway.",
+      "gatewayUrlHint": "Leave empty to use gateway.remote.url from local generic config.",
       "gatewayTokenPlaceholder": "Gateway auth token",
-      "gatewayTokenHint": "Use token-file instead of plain token when possible; configure via openclaw CLI.",
+      "gatewayTokenHint": "Use token-file instead of plain token when possible; configure via generic CLI.",
       "sessionKeyHint": "Optional. Specify gateway session key; leave empty to auto-assign isolated session."
     },
     "authModeOfficialSubscription": "Official Subscription",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "OpenCode config and auth JSON have been synced.",
       "openCodeSaved": "OpenCode config saved",
       "saveOpenCodeFailed": "Failed to save OpenCode config",
-      "openClawSaved": "OpenClaw config saved",
-      "saveOpenClawFailed": "Failed to save OpenClaw config",
+      "genericSaved": "Generic config saved",
+      "saveGenericFailed": "Failed to save Generic config",
       "configSaved": "Config saved",
       "configSavedHint": "Existing sessions need to be reopened to take effect",
       "saveConfigManagementFailed": "Failed to save config management",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "{agent} connection handshake timed out after 60 seconds. Please open Settings to check Agent configuration and network settings.",
           "processExited": "{agent} process exited unexpectedly.",
           "spawnFailed": "Failed to start {agent}: {message}",
-          "downloadFailed": "{agent} download failed: {message}"
+          "downloadFailed": "{agent} download failed: {message}",
+          "turnIdleTimeout": "{agent} stopped responding after {seconds}s — the turn was aborted automatically. You can retry now."
         },
         "unableReadAgentConfig": "Unable to read Agent config: {message}",
         "connectFailedTitle": "{agent} connection failed",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}, {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "Compacting context…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Guardar configuración de Codex",
       "saveGeminiConfig": "Guardar configuración de Gemini",
       "saveOpenCodeConfig": "Guardar configuración de OpenCode",
-      "saveOpenClawConfig": "Guardar configuración de OpenClaw",
+      "saveGenericConfig": "Guardar configuración de Generic",
       "saveConfigManagement": "Guardar gestión de configuración",
       "saveCurrentProvider": "Guardar proveedor actual",
       "showApiKey": "Mostrar API Key",
@@ -568,12 +568,12 @@
       "smallModel": "Modelo pequeño",
       "noMatchingModels": "No hay modelos coincidentes"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Configuración de Gateway",
-      "gatewayDescription": "Configura la conexión de OpenClaw Gateway. Admite gateway local o remoto.",
-      "gatewayUrlHint": "Déjalo vacío para usar gateway.remote.url desde la configuración local de openclaw.",
+      "gatewayDescription": "Configura la conexión de Generic Gateway. Admite gateway local o remoto.",
+      "gatewayUrlHint": "Déjalo vacío para usar gateway.remote.url desde la configuración local de generic.",
       "gatewayTokenPlaceholder": "Token de autenticación de Gateway",
-      "gatewayTokenHint": "Usa token-file en lugar de token en texto plano cuando sea posible; configúralo con el CLI de openclaw.",
+      "gatewayTokenHint": "Usa token-file en lugar de token en texto plano cuando sea posible; configúralo con el CLI de generic.",
       "sessionKeyHint": "Opcional. Especifica la session key del gateway; si se deja vacío se asigna automáticamente una sesión aislada."
     },
     "authModeOfficialSubscription": "Suscripción oficial",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "La configuración de OpenCode y auth JSON se sincronizaron.",
       "openCodeSaved": "Configuración de OpenCode guardada",
       "saveOpenCodeFailed": "No se pudo guardar la configuración de OpenCode",
-      "openClawSaved": "Configuración de OpenClaw guardada",
-      "saveOpenClawFailed": "No se pudo guardar la configuración de OpenClaw",
+      "genericSaved": "Configuración de Generic guardada",
+      "saveGenericFailed": "No se pudo guardar la configuración de Generic",
       "configSaved": "Configuración guardada",
       "configSavedHint": "Las sesiones existentes deben reabrirse para que surta efecto",
       "saveConfigManagementFailed": "No se pudo guardar la gestión de configuración",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "Se agotó el tiempo del handshake de conexión de {agent} (sin respuesta tras 60 segundos). Abre Ajustes para revisar la configuración del agente y de la red.",
           "processExited": "El proceso de {agent} terminó inesperadamente.",
           "spawnFailed": "No se pudo iniciar {agent}: {message}",
-          "downloadFailed": "La descarga de {agent} falló: {message}"
+          "downloadFailed": "La descarga de {agent} falló: {message}",
+          "turnIdleTimeout": "{agent} dejó de responder durante {seconds} s; el turno se canceló automáticamente. Puedes volver a intentarlo."
         },
         "unableReadAgentConfig": "No se puede leer la configuración del agente: {message}",
         "connectFailedTitle": "Falló la conexión de {agent}",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}, {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "Compactando contexto…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Enregistrer la config Codex",
       "saveGeminiConfig": "Enregistrer la config Gemini",
       "saveOpenCodeConfig": "Enregistrer la config OpenCode",
-      "saveOpenClawConfig": "Enregistrer la config OpenClaw",
+      "saveGenericConfig": "Enregistrer la config Generic",
       "saveConfigManagement": "Enregistrer la gestion de config",
       "saveCurrentProvider": "Enregistrer le provider actuel",
       "showApiKey": "Afficher la clé API",
@@ -568,12 +568,12 @@
       "smallModel": "Petit modèle",
       "noMatchingModels": "Aucun modèle correspondant"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Configuration Gateway",
-      "gatewayDescription": "Configure la connexion OpenClaw Gateway. Prend en charge une gateway locale ou distante.",
-      "gatewayUrlHint": "Laisser vide pour utiliser gateway.remote.url depuis la configuration locale openclaw.",
+      "gatewayDescription": "Configure la connexion Generic Gateway. Prend en charge une gateway locale ou distante.",
+      "gatewayUrlHint": "Laisser vide pour utiliser gateway.remote.url depuis la configuration locale generic.",
       "gatewayTokenPlaceholder": "Token d’authentification Gateway",
-      "gatewayTokenHint": "Utilisez token-file plutôt qu’un token en clair si possible ; configurez-le via le CLI openclaw.",
+      "gatewayTokenHint": "Utilisez token-file plutôt qu’un token en clair si possible ; configurez-le via le CLI generic.",
       "sessionKeyHint": "Optionnel. Spécifie la session key de la gateway ; laisser vide pour auto-attribuer une session isolée."
     },
     "authModeOfficialSubscription": "Abonnement officiel",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "La configuration OpenCode et auth JSON ont été synchronisés.",
       "openCodeSaved": "Configuration OpenCode enregistrée",
       "saveOpenCodeFailed": "Échec de l’enregistrement de la configuration OpenCode",
-      "openClawSaved": "Configuration OpenClaw enregistrée",
-      "saveOpenClawFailed": "Échec de l’enregistrement de la configuration OpenClaw",
+      "genericSaved": "Configuration Generic enregistrée",
+      "saveGenericFailed": "Échec de l’enregistrement de la configuration Generic",
       "configSaved": "Configuration enregistrée",
       "configSavedHint": "Les sessions existantes doivent être rouvertes pour prendre effet",
       "saveConfigManagementFailed": "Échec de l’enregistrement de la gestion de configuration",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "Le handshake de connexion de {agent} a expiré (aucune réponse après 60 secondes). Ouvrez Paramètres pour vérifier la configuration de l'agent et du réseau.",
           "processExited": "Le processus {agent} s'est arrêté de manière inattendue.",
           "spawnFailed": "Impossible de démarrer {agent} : {message}",
-          "downloadFailed": "Échec du téléchargement de {agent} : {message}"
+          "downloadFailed": "Échec du téléchargement de {agent} : {message}",
+          "turnIdleTimeout": "{agent} n'a pas répondu pendant {seconds} s — le tour a été interrompu automatiquement. Vous pouvez réessayer."
         },
         "unableReadAgentConfig": "Impossible de lire la configuration de l'agent : {message}",
         "connectFailedTitle": "Échec de la connexion de {agent}",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}, {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "Compactage du contexte…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Codex設定を保存",
       "saveGeminiConfig": "Gemini設定を保存",
       "saveOpenCodeConfig": "OpenCode設定を保存",
-      "saveOpenClawConfig": "OpenClaw設定を保存",
+      "saveGenericConfig": "Generic設定を保存",
       "saveConfigManagement": "設定管理を保存",
       "saveCurrentProvider": "現在のプロバイダーを保存",
       "showApiKey": "APIキーを表示",
@@ -568,12 +568,12 @@
       "smallModel": "スモールモデル",
       "noMatchingModels": "一致するモデルがありません"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Gateway 設定",
-      "gatewayDescription": "OpenClaw Gateway 接続を設定します。ローカルまたはリモートの gateway をサポートします。",
-      "gatewayUrlHint": "空欄の場合はローカル openclaw 設定の gateway.remote.url を使用します。",
+      "gatewayDescription": "Generic Gateway 接続を設定します。ローカルまたはリモートの gateway をサポートします。",
+      "gatewayUrlHint": "空欄の場合はローカル generic 設定の gateway.remote.url を使用します。",
       "gatewayTokenPlaceholder": "Gateway 認証トークン",
-      "gatewayTokenHint": "可能な場合は平文トークンではなく token-file の使用を推奨します。openclaw CLI で設定してください。",
+      "gatewayTokenHint": "可能な場合は平文トークンではなく token-file の使用を推奨します。generic CLI で設定してください。",
       "sessionKeyHint": "任意。gateway の session key を指定します。空欄の場合は分離されたセッションが自動割り当てされます。"
     },
     "authModeOfficialSubscription": "公式サブスクリプション",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "OpenCode config と auth JSON が同期されました。",
       "openCodeSaved": "OpenCode設定を保存しました",
       "saveOpenCodeFailed": "OpenCode設定の保存に失敗しました",
-      "openClawSaved": "OpenClaw設定を保存しました",
-      "saveOpenClawFailed": "OpenClaw設定の保存に失敗しました",
+      "genericSaved": "Generic設定を保存しました",
+      "saveGenericFailed": "Generic設定の保存に失敗しました",
       "configSaved": "設定を保存しました",
       "configSavedHint": "既存のセッションは再度開く必要があります",
       "saveConfigManagementFailed": "設定管理の保存に失敗しました",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "{agent} の接続ハンドシェイクがタイムアウトしました（60 秒以内に応答なし）。設定を開いてエージェントとネットワーク設定を確認してください。",
           "processExited": "{agent} プロセスが予期せず終了しました。",
           "spawnFailed": "{agent} の起動に失敗しました: {message}",
-          "downloadFailed": "{agent} のダウンロードに失敗しました: {message}"
+          "downloadFailed": "{agent} のダウンロードに失敗しました: {message}",
+          "turnIdleTimeout": "{agent} が {seconds} 秒間応答しなかったため、ターンを自動中断しました。再送信できます。"
         },
         "unableReadAgentConfig": "エージェント設定を読み取れません: {message}",
         "connectFailedTitle": "{agent} の接続に失敗しました",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}、{delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "コンテキストを圧縮中…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Codex 설정 저장",
       "saveGeminiConfig": "Gemini 설정 저장",
       "saveOpenCodeConfig": "OpenCode 설정 저장",
-      "saveOpenClawConfig": "OpenClaw 설정 저장",
+      "saveGenericConfig": "Generic 설정 저장",
       "saveConfigManagement": "구성 관리 저장",
       "saveCurrentProvider": "현재 Provider 저장",
       "showApiKey": "API 키 보기",
@@ -568,12 +568,12 @@
       "smallModel": "스몰 모델",
       "noMatchingModels": "일치하는 모델 없음"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Gateway 구성",
-      "gatewayDescription": "OpenClaw Gateway 연결을 구성합니다. 로컬 또는 원격 gateway를 지원합니다.",
-      "gatewayUrlHint": "비워두면 로컬 openclaw 설정의 gateway.remote.url을 사용합니다.",
+      "gatewayDescription": "Generic Gateway 연결을 구성합니다. 로컬 또는 원격 gateway를 지원합니다.",
+      "gatewayUrlHint": "비워두면 로컬 generic 설정의 gateway.remote.url을 사용합니다.",
       "gatewayTokenPlaceholder": "Gateway 인증 토큰",
-      "gatewayTokenHint": "가능하면 평문 토큰 대신 token-file을 사용하세요. openclaw CLI로 설정하세요.",
+      "gatewayTokenHint": "가능하면 평문 토큰 대신 token-file을 사용하세요. generic CLI로 설정하세요.",
       "sessionKeyHint": "선택 사항입니다. gateway 세션 키를 지정합니다. 비워두면 격리된 세션이 자동 할당됩니다."
     },
     "authModeOfficialSubscription": "공식 구독",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "OpenCode config와 auth JSON이 동기화되었습니다.",
       "openCodeSaved": "OpenCode 설정 저장됨",
       "saveOpenCodeFailed": "OpenCode 설정 저장 실패",
-      "openClawSaved": "OpenClaw 설정 저장됨",
-      "saveOpenClawFailed": "OpenClaw 설정 저장 실패",
+      "genericSaved": "Generic 설정 저장됨",
+      "saveGenericFailed": "Generic 설정 저장 실패",
       "configSaved": "구성이 저장되었습니다",
       "configSavedHint": "기존 세션은 다시 열어야 적용됩니다",
       "saveConfigManagementFailed": "구성 관리 저장 실패",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "{agent} 연결 핸드셰이크가 시간 초과되었습니다(60초 동안 응답 없음). 설정을 열어 에이전트 및 네트워크 구성을 확인하세요.",
           "processExited": "{agent} 프로세스가 예기치 않게 종료되었습니다.",
           "spawnFailed": "{agent} 시작 실패: {message}",
-          "downloadFailed": "{agent} 다운로드 실패: {message}"
+          "downloadFailed": "{agent} 다운로드 실패: {message}",
+          "turnIdleTimeout": "{agent}이(가) {seconds}초 동안 응답하지 않아 턴이 자동으로 중단되었습니다. 다시 보낼 수 있습니다."
         },
         "unableReadAgentConfig": "에이전트 구성을 읽을 수 없습니다: {message}",
         "connectFailedTitle": "{agent} 연결 실패",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}, {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "컨텍스트 압축 중…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "Salvar configuração do Codex",
       "saveGeminiConfig": "Salvar configuração do Gemini",
       "saveOpenCodeConfig": "Salvar configuração do OpenCode",
-      "saveOpenClawConfig": "Salvar configuração do OpenClaw",
+      "saveGenericConfig": "Salvar configuração do Generic",
       "saveConfigManagement": "Salvar gerenciamento de configuração",
       "saveCurrentProvider": "Salvar provedor atual",
       "showApiKey": "Mostrar API Key",
@@ -568,12 +568,12 @@
       "smallModel": "Modelo pequeno",
       "noMatchingModels": "Nenhum modelo correspondente"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Configuração de Gateway",
-      "gatewayDescription": "Configure a conexão do OpenClaw Gateway. Suporta gateway local ou remoto.",
-      "gatewayUrlHint": "Deixe vazio para usar gateway.remote.url da configuração local do openclaw.",
+      "gatewayDescription": "Configure a conexão do Generic Gateway. Suporta gateway local ou remoto.",
+      "gatewayUrlHint": "Deixe vazio para usar gateway.remote.url da configuração local do generic.",
       "gatewayTokenPlaceholder": "Token de autenticação do Gateway",
-      "gatewayTokenHint": "Use token-file em vez de token em texto puro quando possível; configure via CLI do openclaw.",
+      "gatewayTokenHint": "Use token-file em vez de token em texto puro quando possível; configure via CLI do generic.",
       "sessionKeyHint": "Opcional. Especifique a session key do gateway; deixe vazio para atribuição automática de sessão isolada."
     },
     "authModeOfficialSubscription": "Assinatura oficial",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "A configuração do OpenCode e o auth JSON foram sincronizados.",
       "openCodeSaved": "Configuração do OpenCode salva",
       "saveOpenCodeFailed": "Falha ao salvar configuração do OpenCode",
-      "openClawSaved": "Configuração do OpenClaw salva",
-      "saveOpenClawFailed": "Falha ao salvar configuração do OpenClaw",
+      "genericSaved": "Configuração do Generic salva",
+      "saveGenericFailed": "Falha ao salvar configuração do Generic",
       "configSaved": "Configuração salva",
       "configSavedHint": "Sessões existentes precisam ser reabertas para que as alterações tenham efeito",
       "saveConfigManagementFailed": "Falha ao salvar o gerenciamento de configuração",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "O handshake de conexão de {agent} expirou (sem resposta após 60 segundos). Abra Configurações para verificar a configuração do agente e da rede.",
           "processExited": "O processo de {agent} encerrou inesperadamente.",
           "spawnFailed": "Falha ao iniciar {agent}: {message}",
-          "downloadFailed": "Falha no download de {agent}: {message}"
+          "downloadFailed": "Falha no download de {agent}: {message}",
+          "turnIdleTimeout": "{agent} parou de responder por {seconds}s — a interação foi cancelada automaticamente. Você pode tentar de novo."
         },
         "unableReadAgentConfig": "Não foi possível ler a configuração do agente: {message}",
         "connectFailedTitle": "Falha na conexão de {agent}",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}, {delay}",
           "httpStatus": " (HTTP {status})"
-        }
+        },
+        "compacting": "Compactando contexto…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "保存 Codex 配置",
       "saveGeminiConfig": "保存 Gemini 配置",
       "saveOpenCodeConfig": "保存 OpenCode 配置",
-      "saveOpenClawConfig": "保存 OpenClaw 配置",
+      "saveGenericConfig": "保存 Generic 配置",
       "saveConfigManagement": "保存配置管理",
       "saveCurrentProvider": "保存当前 Provider",
       "showApiKey": "显示 API Key",
@@ -568,12 +568,12 @@
       "smallModel": "小模型",
       "noMatchingModels": "没有匹配的模型"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Gateway 配置",
-      "gatewayDescription": "配置 OpenClaw Gateway 连接信息。支持本地或远程 Gateway。",
-      "gatewayUrlHint": "留空则使用 openclaw 本地配置的 gateway.remote.url。",
+      "gatewayDescription": "配置 Generic Gateway 连接信息。支持本地或远程 Gateway。",
+      "gatewayUrlHint": "留空则使用 generic 本地配置的 gateway.remote.url。",
       "gatewayTokenPlaceholder": "Gateway 认证 Token",
-      "gatewayTokenHint": "建议使用 token-file 替代明文 Token，可通过 openclaw 命令行配置。",
+      "gatewayTokenHint": "建议使用 token-file 替代明文 Token，可通过 generic 命令行配置。",
       "sessionKeyHint": "可选。指定 Gateway Session Key，留空则自动分配隔离会话。"
     },
     "authModeOfficialSubscription": "官网订阅",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "OpenCode 配置与认证 JSON 已同步保存。",
       "openCodeSaved": "OpenCode 配置已保存",
       "saveOpenCodeFailed": "保存 OpenCode 配置失败",
-      "openClawSaved": "OpenClaw 配置已保存",
-      "saveOpenClawFailed": "保存 OpenClaw 配置失败",
+      "genericSaved": "Generic 配置已保存",
+      "saveGenericFailed": "保存 Generic 配置失败",
       "configSaved": "配置已保存",
       "configSavedHint": "已有会话需要重新打开才能生效",
       "saveConfigManagementFailed": "保存配置管理失败",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "{agent} 连接握手超时（60 秒未响应），请前往设置页面检查智能体和网络配置。",
           "processExited": "{agent} 进程意外退出。",
           "spawnFailed": "启动 {agent} 失败：{message}",
-          "downloadFailed": "{agent} 下载失败：{message}"
+          "downloadFailed": "{agent} 下载失败：{message}",
+          "turnIdleTimeout": "{agent} 在 {seconds} 秒内无任何响应，本轮对话已被自动中断，可重新发送。"
         },
         "unableReadAgentConfig": "无法读取 Agent 配置：{message}",
         "connectFailedTitle": "{agent} 连接失败",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}，{delay}",
           "httpStatus": "（HTTP {status}）"
-        }
+        },
+        "compacting": "正在压缩上下文…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -341,7 +341,7 @@
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
       "openCode": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Steps\n\n1. Add actionable step one.\n2. Add actionable step two.\n",
-      "openClaw": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
+      "generic": "---\nname: example-skill\ndescription: Describe when this skill should be used.\nuser-invocable: true\ndisable-model-invocation: false\n---\n\n# Purpose\n\nDescribe what this skill helps with.\n\n# Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n",
       "default": "# Skill: example-skill\n\n## When to use\n\n- Describe trigger conditions.\n\n## Instructions\n\n1. Add actionable instruction one.\n2. Add actionable instruction two.\n"
     }
   },
@@ -466,7 +466,7 @@
       "saveCodexConfig": "儲存 Codex 配置",
       "saveGeminiConfig": "儲存 Gemini 配置",
       "saveOpenCodeConfig": "儲存 OpenCode 配置",
-      "saveOpenClawConfig": "儲存 OpenClaw 配置",
+      "saveGenericConfig": "儲存 Generic 配置",
       "saveConfigManagement": "儲存配置管理",
       "saveCurrentProvider": "儲存目前 Provider",
       "showApiKey": "顯示 API Key",
@@ -568,12 +568,12 @@
       "smallModel": "小模型",
       "noMatchingModels": "沒有匹配的模型"
     },
-    "openClaw": {
+    "generic": {
       "gatewayConfig": "Gateway 配置",
-      "gatewayDescription": "配置 OpenClaw Gateway 連線資訊。支援本地或遠端 Gateway。",
-      "gatewayUrlHint": "留空則使用 openclaw 本地配置的 gateway.remote.url。",
+      "gatewayDescription": "配置 Generic Gateway 連線資訊。支援本地或遠端 Gateway。",
+      "gatewayUrlHint": "留空則使用 generic 本地配置的 gateway.remote.url。",
       "gatewayTokenPlaceholder": "Gateway 認證 Token",
-      "gatewayTokenHint": "建議使用 token-file 取代明文 Token，可透過 openclaw 命令列配置。",
+      "gatewayTokenHint": "建議使用 token-file 取代明文 Token，可透過 generic 命令列配置。",
       "sessionKeyHint": "可選。指定 Gateway Session Key，留空則自動分配隔離會話。"
     },
     "authModeOfficialSubscription": "官網訂閱",
@@ -646,8 +646,8 @@
       "openCodeConfigSynced": "OpenCode 配置與認證 JSON 已同步儲存。",
       "openCodeSaved": "OpenCode 配置已儲存",
       "saveOpenCodeFailed": "儲存 OpenCode 配置失敗",
-      "openClawSaved": "OpenClaw 配置已儲存",
-      "saveOpenClawFailed": "儲存 OpenClaw 配置失敗",
+      "genericSaved": "Generic 配置已儲存",
+      "saveGenericFailed": "儲存 Generic 配置失敗",
       "configSaved": "配置已儲存",
       "configSavedHint": "已有會話需要重新打開才能生效",
       "saveConfigManagementFailed": "儲存配置管理失敗",
@@ -1517,7 +1517,8 @@
           "initializeTimeout": "{agent} 連線交握逾時（60 秒未回應），請前往設定頁面檢查智能體與網路設定。",
           "processExited": "{agent} 處理程序意外結束。",
           "spawnFailed": "啟動 {agent} 失敗：{message}",
-          "downloadFailed": "{agent} 下載失敗：{message}"
+          "downloadFailed": "{agent} 下載失敗：{message}",
+          "turnIdleTimeout": "{agent} 在 {seconds} 秒內無任何回應，本輪對話已自動中止，可重新發送。"
         },
         "unableReadAgentConfig": "無法讀取 Agent 設定：{message}",
         "connectFailedTitle": "{agent} 連線失敗",
@@ -1534,7 +1535,8 @@
           "line": "{error}{status} · {retry}",
           "lineWithDelay": "{error}{status} · {retry}，{delay}",
           "httpStatus": "（HTTP {status}）"
-        }
+        },
+        "compacting": "正在壓縮上下文…"
       },
       "connectionLifecycle": {
         "tasks": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -66,6 +66,17 @@ import type {
   ChatChannelMessageLog,
   ModelProviderInfo,
   PluginCheckSummary,
+  SquadArtifactInfo,
+  SquadArtifactType,
+  SquadRoleKind,
+  SquadRoleProfileInfo,
+  SquadRoleProfilePatch,
+  SquadRoleRunInfo,
+  SquadRunInfo,
+  SquadRunMode,
+  SquadRunSnapshot,
+  SquadTaskInfo,
+  SquadTaskStatus,
 } from "./types"
 
 export async function listConversations(params?: {
@@ -1676,4 +1687,141 @@ export async function updateModelProvider(params: {
 
 export async function deleteModelProvider(id: number): Promise<void> {
   return getTransport().call("delete_model_provider", { id })
+}
+
+// Squad orchestration
+
+export async function squadGetRoleProfiles(
+  folderId: number
+): Promise<SquadRoleProfileInfo[]> {
+  return getTransport().call("squad_get_role_profiles", { folderId })
+}
+
+export async function squadSeedRoleProfiles(
+  folderId: number
+): Promise<SquadRoleProfileInfo[]> {
+  return getTransport().call("squad_seed_role_profiles", { folderId })
+}
+
+export async function squadUpdateRoleProfile(params: {
+  folderId: number
+  roleKind: SquadRoleKind
+  patch: SquadRoleProfilePatch
+}): Promise<SquadRoleProfileInfo> {
+  return getTransport().call("squad_update_role_profile", params)
+}
+
+export async function squadResetRoleProfile(params: {
+  folderId: number
+  roleKind: SquadRoleKind
+}): Promise<SquadRoleProfileInfo> {
+  return getTransport().call("squad_reset_role_profile", params)
+}
+
+export async function squadCreateRun(params: {
+  folderId: number
+  originConversationId?: number | null
+  mode: SquadRunMode
+  goalSummary: string
+}): Promise<SquadRunSnapshot> {
+  return getTransport().call("squad_create_run", {
+    folderId: params.folderId,
+    originConversationId: params.originConversationId ?? null,
+    mode: params.mode,
+    goalSummary: params.goalSummary,
+  })
+}
+
+export async function squadGetRun(
+  squadRunId: number
+): Promise<SquadRunSnapshot> {
+  return getTransport().call("squad_get_run", { squadRunId })
+}
+
+export async function squadListRuns(folderId: number): Promise<SquadRunInfo[]> {
+  return getTransport().call("squad_list_runs", { folderId })
+}
+
+export async function squadStartRun(params: {
+  squadRunId: number
+  workingDir?: string | null
+}): Promise<void> {
+  return getTransport().call("squad_start_run", {
+    squadRunId: params.squadRunId,
+    workingDir: params.workingDir ?? null,
+  })
+}
+
+export async function squadStopRun(squadRunId: number): Promise<void> {
+  return getTransport().call("squad_stop_run", { squadRunId })
+}
+
+export async function squadConnectRole(params: {
+  squadRunId: number
+  roleKind: SquadRoleKind
+  workingDir?: string | null
+}): Promise<SquadRoleRunInfo> {
+  return getTransport().call("squad_connect_role", {
+    squadRunId: params.squadRunId,
+    roleKind: params.roleKind,
+    workingDir: params.workingDir ?? null,
+  })
+}
+
+export async function squadPromptRole(params: {
+  squadRunId: number
+  roleKind: SquadRoleKind
+  taskId?: number | null
+}): Promise<SquadRoleRunInfo> {
+  return getTransport().call("squad_prompt_role", {
+    squadRunId: params.squadRunId,
+    roleKind: params.roleKind,
+    taskId: params.taskId ?? null,
+  })
+}
+
+export async function squadCreateTask(params: {
+  squadRunId: number
+  assignedRoleKind: SquadRoleKind
+  title: string
+  description: string
+}): Promise<SquadTaskInfo> {
+  return getTransport().call("squad_create_task", params)
+}
+
+export async function squadUpdateTaskStatus(params: {
+  taskId: number
+  status: SquadTaskStatus
+}): Promise<SquadTaskInfo> {
+  return getTransport().call("squad_update_task_status", params)
+}
+
+export async function squadListTasks(
+  squadRunId: number
+): Promise<SquadTaskInfo[]> {
+  return getTransport().call("squad_list_tasks", { squadRunId })
+}
+
+export async function squadCreateArtifact(params: {
+  squadRunId: number
+  roleKind?: SquadRoleKind | null
+  taskId?: number | null
+  artifactType: SquadArtifactType
+  title: string
+  contentJson: string
+}): Promise<SquadArtifactInfo> {
+  return getTransport().call("squad_create_artifact", {
+    squadRunId: params.squadRunId,
+    roleKind: params.roleKind ?? null,
+    taskId: params.taskId ?? null,
+    artifactType: params.artifactType,
+    title: params.title,
+    contentJson: params.contentJson,
+  })
+}
+
+export async function squadListArtifacts(
+  squadRunId: number
+): Promise<SquadArtifactInfo[]> {
+  return getTransport().call("squad_list_artifacts", { squadRunId })
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   ExpertInstallStatus,
   FolderHistoryEntry,
   FolderDetail,
+  WorkspacePreset,
   DbConversationSummary,
   ImportResult,
   OpenedTab,
@@ -53,6 +54,8 @@ import type {
   GitSettings,
   GitHubAccountsSettings,
   GitHubTokenValidation,
+  RuntimeDiagnostics,
+  AcpCacheInventory,
   McpAppType,
   LocalMcpServer,
   McpMarketplaceProvider,
@@ -455,6 +458,14 @@ export async function updateSystemLanguageSettings(
   return getTransport().call("update_system_language_settings", { settings })
 }
 
+export async function getRuntimeDiagnostics(): Promise<RuntimeDiagnostics> {
+  return getTransport().call("get_runtime_diagnostics")
+}
+
+export async function getAcpCacheInventory(): Promise<AcpCacheInventory> {
+  return getTransport().call("get_acp_cache_inventory")
+}
+
 // --- Version Control ---
 
 export async function detectGit(): Promise<GitDetectResult> {
@@ -628,6 +639,16 @@ export async function listOpenFolderDetails(): Promise<FolderDetail[]> {
 
 export async function listAllFolderDetails(): Promise<FolderDetail[]> {
   return getTransport().call("list_all_folder_details")
+}
+
+export async function updateFolderWorkspacePreset(
+  folderId: number,
+  workspacePreset: WorkspacePreset | null
+): Promise<FolderDetail> {
+  return getTransport().call("update_folder_workspace_preset", {
+    folderId,
+    workspacePreset,
+  })
 }
 
 export async function openFolderById(folderId: number): Promise<FolderDetail> {

--- a/src/lib/squad-events.test.ts
+++ b/src/lib/squad-events.test.ts
@@ -16,7 +16,7 @@ function makeRun(overrides: Partial<SquadRunInfo> = {}): SquadRunInfo {
     id: 1,
     folderId: 10,
     originConversationId: null,
-    mode: "feature",
+    mode: "manual",
     status: "running",
     goalSummary: "ship it",
     baseBranch: "main",
@@ -43,7 +43,7 @@ function makeRole(overrides: Partial<SquadRoleRunInfo> = {}): SquadRoleRunInfo {
     conversationId: null,
     workspacePath: null,
     branchName: null,
-    status: "idle",
+    status: "pending",
     lastEventAt: null,
     budgetStateJson: null,
     errorMessage: null,
@@ -155,16 +155,16 @@ describe("applySquadEvent", () => {
   })
 
   it("upserts role on squad_role_status_changed", () => {
-    const existing = makeRole({ id: 100, status: "idle" })
+    const existing = makeRole({ id: 100, status: "pending" })
     const snapshot = makeSnapshot({ roles: [existing] })
-    const updated = makeRole({ id: 100, status: "working" })
+    const updated = makeRole({ id: 100, status: "connected" })
     const result = applySquadEvent(
       snapshot,
       makeEvent({ type: "squad_role_status_changed", payload: updated })
     )
     expect(result.changed).toBe(true)
     expect(result.snapshot?.roles).toHaveLength(1)
-    expect(result.snapshot?.roles[0].status).toBe("working")
+    expect(result.snapshot?.roles[0].status).toBe("connected")
   })
 
   it("appends a brand-new role on squad_role_status_changed", () => {
@@ -297,15 +297,15 @@ describe("applySquadEvent", () => {
   })
 
   it("does not mutate the input snapshot when applying changes", () => {
-    const role = makeRole({ id: 100, status: "idle" })
+    const role = makeRole({ id: 100, status: "pending" })
     const snapshot = makeSnapshot({ roles: [role] })
-    const updated = makeRole({ id: 100, status: "working" })
+    const updated = makeRole({ id: 100, status: "connected" })
     const result = applySquadEvent(
       snapshot,
       makeEvent({ type: "squad_role_status_changed", payload: updated })
     )
     expect(result.snapshot).not.toBe(snapshot)
-    expect(snapshot.roles[0].status).toBe("idle")
-    expect(result.snapshot?.roles[0].status).toBe("working")
+    expect(snapshot.roles[0].status).toBe("pending")
+    expect(result.snapshot?.roles[0].status).toBe("connected")
   })
 })

--- a/src/lib/squad-events.test.ts
+++ b/src/lib/squad-events.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "vitest"
+import { applySquadEvent } from "./squad-events"
+import type {
+  SquadArtifactInfo,
+  SquadEvent,
+  SquadRoleRunInfo,
+  SquadRunInfo,
+  SquadRunSnapshot,
+  SquadTaskInfo,
+} from "./types"
+
+// ---- fixture builders ------------------------------------------------------
+
+function makeRun(overrides: Partial<SquadRunInfo> = {}): SquadRunInfo {
+  return {
+    id: 1,
+    folderId: 10,
+    originConversationId: null,
+    mode: "feature",
+    status: "running",
+    goalSummary: "ship it",
+    baseBranch: "main",
+    isolationMode: "shared",
+    startedWithDirtyBase: false,
+    createdAt: "2026-04-26T00:00:00Z",
+    updatedAt: "2026-04-26T00:00:00Z",
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    errorMessage: null,
+    ...overrides,
+  }
+}
+
+function makeRole(overrides: Partial<SquadRoleRunInfo> = {}): SquadRoleRunInfo {
+  return {
+    id: 100,
+    squadRunId: 1,
+    roleKind: "frontend",
+    roleProfileSnapshotJson: "{}",
+    connectionId: null,
+    sessionId: null,
+    conversationId: null,
+    workspacePath: null,
+    branchName: null,
+    status: "idle",
+    lastEventAt: null,
+    budgetStateJson: null,
+    errorMessage: null,
+    createdAt: "2026-04-26T00:00:00Z",
+    updatedAt: "2026-04-26T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function makeTask(overrides: Partial<SquadTaskInfo> = {}): SquadTaskInfo {
+  return {
+    id: 200,
+    squadRunId: 1,
+    assignedRoleKind: "frontend",
+    title: "do the thing",
+    description: "",
+    inputSummary: null,
+    status: "pending",
+    dependsOnJson: null,
+    priority: 0,
+    createdAt: "2026-04-26T00:00:00Z",
+    updatedAt: "2026-04-26T00:00:00Z",
+    completedAt: null,
+    errorMessage: null,
+    ...overrides,
+  }
+}
+
+function makeArtifact(
+  overrides: Partial<SquadArtifactInfo> = {}
+): SquadArtifactInfo {
+  return {
+    id: 300,
+    squadRunId: 1,
+    squadRoleRunId: null,
+    taskId: null,
+    roleKind: null,
+    artifactType: "summary",
+    title: "summary",
+    contentJson: "{}",
+    createdAt: "2026-04-26T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function makeSnapshot(
+  overrides: Partial<SquadRunSnapshot> = {}
+): SquadRunSnapshot {
+  return {
+    run: makeRun(),
+    roles: [],
+    tasks: [],
+    artifacts: [],
+    ...overrides,
+  }
+}
+
+function makeEvent(overrides: Partial<SquadEvent>): SquadEvent {
+  return {
+    type: "squad_run_status_changed",
+    squadRunId: 1,
+    seq: 1,
+    at: "2026-04-26T00:00:00Z",
+    roleKind: null,
+    payload: null,
+    ...overrides,
+  }
+}
+
+// ---- tests -----------------------------------------------------------------
+
+describe("applySquadEvent", () => {
+  it("returns needsReload when no snapshot exists", () => {
+    const result = applySquadEvent(
+      null,
+      makeEvent({ type: "squad_task_created", payload: makeTask() })
+    )
+    expect(result.snapshot).toBeNull()
+    expect(result.changed).toBe(false)
+    expect(result.needsReload).toBe(true)
+  })
+
+  it("ignores events for a different run", () => {
+    const snapshot = makeSnapshot()
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({
+        type: "squad_task_created",
+        squadRunId: 999,
+        payload: makeTask({ squadRunId: 999 }),
+      })
+    )
+    expect(result.snapshot).toBe(snapshot)
+    expect(result.changed).toBe(false)
+    expect(result.needsReload).toBe(false)
+  })
+
+  it("patches snapshot.run on squad_run_status_changed", () => {
+    const snapshot = makeSnapshot()
+    const newRun = makeRun({ status: "completed" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_run_status_changed", payload: newRun })
+    )
+    expect(result.changed).toBe(true)
+    expect(result.snapshot?.run.status).toBe("completed")
+    // immutability: original untouched
+    expect(snapshot.run.status).toBe("running")
+  })
+
+  it("upserts role on squad_role_status_changed", () => {
+    const existing = makeRole({ id: 100, status: "idle" })
+    const snapshot = makeSnapshot({ roles: [existing] })
+    const updated = makeRole({ id: 100, status: "working" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_role_status_changed", payload: updated })
+    )
+    expect(result.changed).toBe(true)
+    expect(result.snapshot?.roles).toHaveLength(1)
+    expect(result.snapshot?.roles[0].status).toBe("working")
+  })
+
+  it("appends a brand-new role on squad_role_status_changed", () => {
+    const snapshot = makeSnapshot({ roles: [makeRole({ id: 100 })] })
+    const newRole = makeRole({ id: 101, roleKind: "backend" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_role_status_changed", payload: newRole })
+    )
+    expect(result.changed).toBe(true)
+    expect(result.snapshot?.roles).toHaveLength(2)
+  })
+
+  it("returns no-op for squad_role_connection_attached", () => {
+    const snapshot = makeSnapshot()
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({
+        type: "squad_role_connection_attached",
+        payload: { roleId: 100, connectionId: "abc" },
+      })
+    )
+    expect(result.changed).toBe(false)
+    expect(result.needsReload).toBe(false)
+    expect(result.snapshot).toBe(snapshot)
+  })
+
+  it("prepends new task on squad_task_created", () => {
+    const existing = makeTask({ id: 200, title: "old" })
+    const snapshot = makeSnapshot({ tasks: [existing] })
+    const created = makeTask({ id: 201, title: "new" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_task_created", payload: created })
+    )
+    expect(result.changed).toBe(true)
+    expect(result.snapshot?.tasks).toHaveLength(2)
+    expect(result.snapshot?.tasks[0].id).toBe(201) // prepended
+  })
+
+  it("upserts known task on squad_task_status_changed", () => {
+    const existing = makeTask({ id: 200, status: "pending" })
+    const snapshot = makeSnapshot({ tasks: [existing] })
+    const updated = makeTask({ id: 200, status: "completed" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_task_status_changed", payload: updated })
+    )
+    expect(result.changed).toBe(true)
+    expect(result.snapshot?.tasks[0].status).toBe("completed")
+  })
+
+  it("requests reload when task_status_changed references unknown task", () => {
+    const snapshot = makeSnapshot() // no tasks
+    const ghost = makeTask({ id: 999, status: "completed" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_task_status_changed", payload: ghost })
+    )
+    expect(result.changed).toBe(false)
+    expect(result.needsReload).toBe(true)
+  })
+
+  it("prepends new artifact on squad_artifact_created", () => {
+    const snapshot = makeSnapshot({ artifacts: [makeArtifact({ id: 300 })] })
+    const created = makeArtifact({ id: 301, artifactType: "plan" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_artifact_created", payload: created })
+    )
+    expect(result.changed).toBe(true)
+    expect(result.snapshot?.artifacts[0].id).toBe(301)
+    expect(result.snapshot?.artifacts).toHaveLength(2)
+  })
+
+  it("returns no-op for summary-only events", () => {
+    const snapshot = makeSnapshot()
+    const planned = applySquadEvent(
+      snapshot,
+      makeEvent({
+        type: "squad_conductor_plan_applied",
+        payload: { created: 3, skipped: [] },
+      })
+    )
+    expect(planned.changed).toBe(false)
+    expect(planned.needsReload).toBe(false)
+
+    const round = applySquadEvent(
+      snapshot,
+      makeEvent({
+        type: "squad_dispatch_round_completed",
+        payload: { dispatched: 0 },
+      })
+    )
+    expect(round.changed).toBe(false)
+    expect(round.needsReload).toBe(false)
+  })
+
+  it("returns needsReload for unknown event type", () => {
+    const snapshot = makeSnapshot()
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_something_new", payload: {} })
+    )
+    expect(result.needsReload).toBe(true)
+    expect(result.changed).toBe(false)
+  })
+
+  it("rejects malformed payloads (not an object) with needsReload", () => {
+    const snapshot = makeSnapshot()
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_task_created", payload: "not-an-object" })
+    )
+    expect(result.changed).toBe(false)
+    expect(result.needsReload).toBe(true)
+  })
+
+  it("ignores task_created whose squadRunId does not match snapshot", () => {
+    // Same outer event runId matches snapshot, but inner payload references
+    // a different run — caller should NOT mutate or refetch.
+    const snapshot = makeSnapshot()
+    const wrongRunTask = makeTask({ squadRunId: 42 })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_task_created", payload: wrongRunTask })
+    )
+    expect(result.changed).toBe(false)
+    expect(result.needsReload).toBe(false)
+  })
+
+  it("does not mutate the input snapshot when applying changes", () => {
+    const role = makeRole({ id: 100, status: "idle" })
+    const snapshot = makeSnapshot({ roles: [role] })
+    const updated = makeRole({ id: 100, status: "working" })
+    const result = applySquadEvent(
+      snapshot,
+      makeEvent({ type: "squad_role_status_changed", payload: updated })
+    )
+    expect(result.snapshot).not.toBe(snapshot)
+    expect(snapshot.roles[0].status).toBe("idle")
+    expect(result.snapshot?.roles[0].status).toBe("working")
+  })
+})

--- a/src/lib/squad-events.ts
+++ b/src/lib/squad-events.ts
@@ -1,0 +1,204 @@
+import type {
+  SquadArtifactInfo,
+  SquadEvent,
+  SquadRoleRunInfo,
+  SquadRunInfo,
+  SquadRunSnapshot,
+  SquadTaskInfo,
+} from "@/lib/types"
+
+/**
+ * Result of folding a single squad event into an existing snapshot.
+ *
+ * - `snapshot`: the patched snapshot, or `null` if the event was for a
+ *   different run and was therefore ignored.
+ * - `changed`: whether the snapshot actually changed. UI consumers can use
+ *   this to skip re-renders for no-op events.
+ * - `needsReload`: the event references an entity we don't have locally
+ *   (e.g. a brand-new role, or stale snapshot). Caller should fall back
+ *   to a full `squadGetRun` fetch.
+ */
+export interface ApplySquadEventResult {
+  snapshot: SquadRunSnapshot | null
+  changed: boolean
+  needsReload: boolean
+}
+
+function asObject(payload: unknown): Record<string, unknown> | null {
+  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>
+  }
+  return null
+}
+
+function castRunInfo(payload: unknown): SquadRunInfo | null {
+  const obj = asObject(payload)
+  if (!obj) return null
+  if (typeof obj.id !== "number" || typeof obj.status !== "string") return null
+  return obj as unknown as SquadRunInfo
+}
+
+function castRoleRunInfo(payload: unknown): SquadRoleRunInfo | null {
+  const obj = asObject(payload)
+  if (!obj) return null
+  if (typeof obj.id !== "number" || typeof obj.roleKind !== "string") {
+    return null
+  }
+  return obj as unknown as SquadRoleRunInfo
+}
+
+function castTaskInfo(payload: unknown): SquadTaskInfo | null {
+  const obj = asObject(payload)
+  if (!obj) return null
+  if (typeof obj.id !== "number" || typeof obj.status !== "string") return null
+  return obj as unknown as SquadTaskInfo
+}
+
+function castArtifactInfo(payload: unknown): SquadArtifactInfo | null {
+  const obj = asObject(payload)
+  if (!obj) return null
+  if (typeof obj.id !== "number" || typeof obj.artifactType !== "string") {
+    return null
+  }
+  return obj as unknown as SquadArtifactInfo
+}
+
+function upsertById<T extends { id: number }>(list: T[], item: T): T[] {
+  const idx = list.findIndex((x) => x.id === item.id)
+  if (idx === -1) {
+    return [...list, item]
+  }
+  const next = list.slice()
+  next[idx] = item
+  return next
+}
+
+function prependUniqueById<T extends { id: number }>(list: T[], item: T): T[] {
+  if (list.some((x) => x.id === item.id)) {
+    return list.map((x) => (x.id === item.id ? item : x))
+  }
+  return [item, ...list]
+}
+
+/**
+ * Apply a single squad event to a snapshot, returning a patched copy.
+ * Pure: never mutates inputs. Returns `needsReload: true` for events whose
+ * payload references entities the snapshot doesn't yet know about, so the
+ * caller can decide whether to fetch the authoritative snapshot.
+ */
+export function applySquadEvent(
+  snapshot: SquadRunSnapshot | null,
+  event: SquadEvent
+): ApplySquadEventResult {
+  // Snapshot is for a different run — ignore.
+  if (snapshot && snapshot.run.id !== event.squadRunId) {
+    return { snapshot, changed: false, needsReload: false }
+  }
+  // No snapshot yet — caller should fetch.
+  if (!snapshot) {
+    return { snapshot: null, changed: false, needsReload: true }
+  }
+
+  switch (event.type) {
+    case "squad_run_status_changed": {
+      const run = castRunInfo(event.payload)
+      if (!run || run.id !== snapshot.run.id) {
+        return { snapshot, changed: false, needsReload: !run }
+      }
+      if (snapshot.run === run) {
+        return { snapshot, changed: false, needsReload: false }
+      }
+      return {
+        snapshot: { ...snapshot, run },
+        changed: true,
+        needsReload: false,
+      }
+    }
+
+    case "squad_role_status_changed": {
+      const role = castRoleRunInfo(event.payload)
+      if (!role) return { snapshot, changed: false, needsReload: true }
+      if (role.squadRunId !== snapshot.run.id) {
+        return { snapshot, changed: false, needsReload: false }
+      }
+      const next = upsertById(snapshot.roles, role)
+      if (next === snapshot.roles) {
+        return { snapshot, changed: false, needsReload: false }
+      }
+      return {
+        snapshot: { ...snapshot, roles: next },
+        changed: true,
+        needsReload: false,
+      }
+    }
+
+    case "squad_role_connection_attached": {
+      // Pure side-channel notice; nothing to patch in the snapshot itself.
+      return { snapshot, changed: false, needsReload: false }
+    }
+
+    case "squad_task_created": {
+      const task = castTaskInfo(event.payload)
+      if (!task) return { snapshot, changed: false, needsReload: true }
+      if (task.squadRunId !== snapshot.run.id) {
+        return { snapshot, changed: false, needsReload: false }
+      }
+      return {
+        snapshot: {
+          ...snapshot,
+          tasks: prependUniqueById(snapshot.tasks, task),
+        },
+        changed: true,
+        needsReload: false,
+      }
+    }
+
+    case "squad_task_status_changed": {
+      const task = castTaskInfo(event.payload)
+      if (!task) return { snapshot, changed: false, needsReload: true }
+      if (task.squadRunId !== snapshot.run.id) {
+        return { snapshot, changed: false, needsReload: false }
+      }
+      // If we don't yet know about this task, surface as needsReload so the
+      // caller can refetch instead of silently dropping it.
+      const known = snapshot.tasks.some((t) => t.id === task.id)
+      if (!known) {
+        return { snapshot, changed: false, needsReload: true }
+      }
+      return {
+        snapshot: {
+          ...snapshot,
+          tasks: upsertById(snapshot.tasks, task),
+        },
+        changed: true,
+        needsReload: false,
+      }
+    }
+
+    case "squad_artifact_created": {
+      const artifact = castArtifactInfo(event.payload)
+      if (!artifact) return { snapshot, changed: false, needsReload: true }
+      if (artifact.squadRunId !== snapshot.run.id) {
+        return { snapshot, changed: false, needsReload: false }
+      }
+      return {
+        snapshot: {
+          ...snapshot,
+          artifacts: prependUniqueById(snapshot.artifacts, artifact),
+        },
+        changed: true,
+        needsReload: false,
+      }
+    }
+
+    // Summary-only events: no snapshot change required. Components that care
+    // about the summary can subscribe to the raw event channel separately.
+    case "squad_conductor_plan_applied":
+    case "squad_dispatch_round_completed":
+      return { snapshot, changed: false, needsReload: false }
+
+    default:
+      // Unknown event type: be conservative and ask for a refetch.
+      return { snapshot, changed: false, needsReload: true }
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -17,6 +17,7 @@ import type {
   AgentSkillContent,
   FolderHistoryEntry,
   FolderDetail,
+  WorkspacePreset,
   DbConversationSummary,
   ImportResult,
   OpenedTab,
@@ -50,6 +51,8 @@ import type {
   GitSettings,
   GitHubAccountsSettings,
   GitHubTokenValidation,
+  RuntimeDiagnostics,
+  AcpCacheInventory,
   McpAppType,
   LocalMcpServer,
   McpMarketplaceProvider,
@@ -317,6 +320,14 @@ export async function updateSystemLanguageSettings(
   return invoke("update_system_language_settings", { settings })
 }
 
+export async function getRuntimeDiagnostics(): Promise<RuntimeDiagnostics> {
+  return invoke("get_runtime_diagnostics")
+}
+
+export async function getAcpCacheInventory(): Promise<AcpCacheInventory> {
+  return invoke("get_acp_cache_inventory")
+}
+
 // --- Version Control ---
 
 export async function detectGit(): Promise<GitDetectResult> {
@@ -496,6 +507,20 @@ export async function saveOpenedTabs(items: OpenedTab[]): Promise<void> {
 
 export async function listOpenFolderDetails(): Promise<FolderDetail[]> {
   return invoke("list_open_folder_details")
+}
+
+export async function listAllFolderDetails(): Promise<FolderDetail[]> {
+  return invoke("list_all_folder_details")
+}
+
+export async function updateFolderWorkspacePreset(
+  folderId: number,
+  workspacePreset: WorkspacePreset | null
+): Promise<FolderDetail> {
+  return invoke("update_folder_workspace_preset", {
+    folderId,
+    workspacePreset,
+  })
 }
 
 export async function openFolderById(folderId: number): Promise<FolderDetail> {

--- a/src/lib/transport/web-transport.ts
+++ b/src/lib/transport/web-transport.ts
@@ -5,6 +5,13 @@ interface WebEvent {
   payload: unknown
 }
 
+function createClientId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `web-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
 function getToken(): string {
   return localStorage.getItem("codeg_token") ?? ""
 }
@@ -15,6 +22,7 @@ export class WebTransport implements Transport {
   private baseUrl: string
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private wsFailCount = 0
+  private clientId = createClientId()
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl
@@ -22,13 +30,20 @@ export class WebTransport implements Transport {
 
   async call<T>(command: string, args?: Record<string, unknown>): Promise<T> {
     const token = getToken()
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-Codeg-Client-Id": this.clientId,
+    }
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
+    const keepalive =
+      command === "acp_disconnect" || command === "terminal_kill"
     const res = await fetch(`${this.baseUrl}/api/${command}`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
+      headers,
       body: JSON.stringify(args ?? {}),
+      keepalive,
     })
     if (res.status === 401) {
       WebTransport.redirectToLogin()
@@ -54,8 +69,7 @@ export class WebTransport implements Transport {
     const wrappedHandler = handler as (payload: unknown) => void
     this.handlers.get(event)!.add(wrappedHandler)
 
-    // If WS is not connected but we now have a token, connect
-    if (!this.ws && getToken()) {
+    if (!this.ws) {
       this.connectWs()
     }
 
@@ -76,11 +90,11 @@ export class WebTransport implements Transport {
 
   private connectWs() {
     const token = getToken()
-    if (!token) return
-
-    const wsUrl =
-      this.baseUrl.replace(/^http/, "ws") +
-      `/ws/events?token=${encodeURIComponent(token)}`
+    const wsUrl = new URL("/ws/events", this.baseUrl)
+    if (token) {
+      wsUrl.searchParams.set("token", token)
+    }
+    wsUrl.searchParams.set("clientId", this.clientId)
     this.ws = new WebSocket(wsUrl)
 
     this.ws.onopen = () => {

--- a/src/lib/transport/web-transport.ts
+++ b/src/lib/transport/web-transport.ts
@@ -19,6 +19,10 @@ function getToken(): string {
   return localStorage.getItem("codeg_token") ?? ""
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 export class WebTransport implements Transport {
   private ws: WebSocket | null = null
   private handlers = new Map<string, Set<(payload: unknown) => void>>()
@@ -42,24 +46,66 @@ export class WebTransport implements Transport {
     }
     const keepalive =
       command === "acp_disconnect" || command === "terminal_kill"
-    const res = await fetch(`${this.baseUrl}/api/${command}`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(args ?? {}),
-      keepalive,
-    })
-    if (res.status === 401) {
-      WebTransport.redirectToLogin()
-      throw new Error("Unauthorized")
+
+    // Idempotent read commands may be retried once on transient network
+    // failure / 5xx. Non-idempotent commands (acp_prompt, terminal_create,
+    // anything that mutates) MUST NOT be retried, because the server may
+    // already have processed the first attempt.
+    const isIdempotent =
+      command.startsWith("list_") ||
+      command.startsWith("get_") ||
+      command.startsWith("acp_get_") ||
+      command.startsWith("acp_list_")
+    const maxAttempts = isIdempotent ? 2 : 1
+
+    let lastError: unknown
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      // 15s hard timeout per attempt — protects against hung connections.
+      const ctrl = new AbortController()
+      const timeoutId = setTimeout(() => ctrl.abort(), 15_000)
+      try {
+        const res = await fetch(`${this.baseUrl}/api/${command}`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(args ?? {}),
+          keepalive,
+          signal: ctrl.signal,
+        })
+        clearTimeout(timeoutId)
+
+        if (res.status === 401) {
+          WebTransport.redirectToLogin()
+          throw new Error("Unauthorized")
+        }
+        if (!res.ok) {
+          // 5xx is retriable for idempotent calls; 4xx is a real error.
+          const isTransient = res.status >= 500
+          const error = await res.json().catch(() => ({
+            code: "network_error",
+            message: `HTTP ${res.status}`,
+          }))
+          if (isTransient && attempt < maxAttempts) {
+            lastError = error
+            await sleep(250 * attempt)
+            continue
+          }
+          throw error
+        }
+        return res.json()
+      } catch (err) {
+        clearTimeout(timeoutId)
+        // AbortError / network refused are retriable for idempotent reads.
+        const isAbort = err instanceof DOMException && err.name === "AbortError"
+        const isNetwork = err instanceof TypeError
+        if ((isAbort || isNetwork) && attempt < maxAttempts) {
+          lastError = err
+          await sleep(250 * attempt)
+          continue
+        }
+        throw err
+      }
     }
-    if (!res.ok) {
-      const error = await res.json().catch(() => ({
-        code: "network_error",
-        message: `HTTP ${res.status}`,
-      }))
-      throw error
-    }
-    return res.json()
+    throw lastError ?? new Error("network failure")
   }
 
   async subscribe<T>(
@@ -118,14 +164,30 @@ export class WebTransport implements Transport {
       }
     }
 
-    this.ws.onclose = () => {
+    this.ws.onclose = (ev) => {
       this.ws = null
       this.wsFailCount++
-      if (this.wsFailCount >= 3) {
+
+      // Only force the user back to /login on explicit auth failures —
+      // either an HTTP 401 surfaced as WS close code 4401, or any 4xx.
+      // Transient network drops (sleep/wake, flaky wifi) used to log the
+      // user out after 3 attempts, which was extremely user-hostile.
+      const isAuthFailure =
+        ev.code === 4401 || (ev.code >= 4400 && ev.code < 4500)
+      if (isAuthFailure) {
         WebTransport.redirectToLogin()
         return
       }
-      this.reconnectTimer = setTimeout(() => this.connectWs(), 3000)
+
+      // Exponential backoff with ±20% jitter, capped at 30s.
+      // 1s → 2s → 4s → 8s → 16s → 30s → 30s …
+      const baseMs = Math.min(
+        30_000,
+        1000 * 2 ** Math.min(this.wsFailCount - 1, 5)
+      )
+      const jitter = baseMs * (Math.random() * 0.4 - 0.2)
+      const delay = Math.max(500, Math.round(baseMs + jitter))
+      this.reconnectTimer = setTimeout(() => this.connectWs(), delay)
     }
 
     this.ws.onerror = () => {
@@ -136,9 +198,11 @@ export class WebTransport implements Transport {
   destroy() {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
     }
     this.ws?.close()
     this.ws = null
+    this.wsFailCount = 0
     this.handlers.clear()
   }
 }

--- a/src/lib/transport/web-transport.ts
+++ b/src/lib/transport/web-transport.ts
@@ -6,7 +6,10 @@ interface WebEvent {
 }
 
 function createClientId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
     return crypto.randomUUID()
   }
   return `web-${Date.now()}-${Math.random().toString(16).slice(2)}`

--- a/src/lib/transport/web-transport.ts
+++ b/src/lib/transport/web-transport.ts
@@ -153,6 +153,12 @@ export class WebTransport implements Transport {
     this.ws.onmessage = (msg) => {
       try {
         const event = JSON.parse(msg.data) as WebEvent
+        // Server emits `__resync` when a slow socket overflows the
+        // broadcast buffer and skipped events. If nothing is subscribed
+        // we at least log it so devs see why the UI may be stale.
+        if (event.channel === "__resync" && !this.handlers.has("__resync")) {
+          console.warn("[ws] resync requested but no handler", event.payload)
+        }
         const handlers = this.handlers.get(event.channel)
         if (handlers) {
           for (const h of handlers) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,167 @@ export type AgentType =
   | "generic"
   | "cline"
 
+export type SquadRoleKind = "conductor" | "frontend" | "backend" | "worker"
+
+export type SquadRunMode = "manual" | "conductor_dispatch" | "all_hands_review"
+
+export type SquadRunStatus =
+  | "pending"
+  | "preparing"
+  | "running"
+  | "blocked"
+  | "completed"
+  | "failed"
+  | "cancelled"
+
+export type SquadRoleRunStatus =
+  | "pending"
+  | "preparing"
+  | "connecting"
+  | "connected"
+  | "prompting"
+  | "stopped"
+  | "completed"
+  | "failed"
+  | "cancelled"
+
+export type SquadTaskStatus =
+  | "pending"
+  | "assigned"
+  | "running"
+  | "blocked"
+  | "completed"
+  | "failed"
+  | "cancelled"
+
+export type SquadArtifactType =
+  | "summary"
+  | "diff"
+  | "file_patch"
+  | "review"
+  | "terminal"
+  | "plan"
+  | "warning"
+  | "log"
+
+export type SquadWorkspacePolicy =
+  | "read_only"
+  | "write_isolated"
+  | "write_shared"
+
+export interface SquadRoleProfileInfo {
+  id: number
+  folderId: number
+  roleKind: SquadRoleKind
+  enabled: boolean
+  agentType: AgentType
+  registryId: string
+  modelProviderId: number | null
+  modelId: string | null
+  envJson: string | null
+  systemPrompt: string
+  workspacePolicy: SquadWorkspacePolicy
+  defaultRunMode: SquadRunMode
+  modeId: string | null
+  configOptionsJson: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SquadRoleProfilePatch {
+  enabled?: boolean
+  agentType?: AgentType
+  registryId?: string
+  modelProviderId?: number | null
+  modelId?: string | null
+  envJson?: string | null
+  systemPrompt?: string
+  workspacePolicy?: SquadWorkspacePolicy
+  defaultRunMode?: SquadRunMode
+  modeId?: string | null
+  configOptionsJson?: string | null
+}
+
+export interface SquadRunInfo {
+  id: number
+  folderId: number
+  originConversationId: number | null
+  mode: SquadRunMode
+  status: SquadRunStatus
+  goalSummary: string
+  baseBranch: string | null
+  isolationMode: string
+  startedWithDirtyBase: boolean
+  createdAt: string
+  updatedAt: string
+  startedAt: string | null
+  completedAt: string | null
+  cancelledAt: string | null
+  errorMessage: string | null
+}
+
+export interface SquadRoleRunInfo {
+  id: number
+  squadRunId: number
+  roleKind: SquadRoleKind
+  roleProfileSnapshotJson: string
+  connectionId: string | null
+  sessionId: string | null
+  conversationId: number | null
+  workspacePath: string | null
+  branchName: string | null
+  status: SquadRoleRunStatus
+  lastEventAt: string | null
+  budgetStateJson: string | null
+  errorMessage: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SquadTaskInfo {
+  id: number
+  squadRunId: number
+  assignedRoleKind: SquadRoleKind
+  title: string
+  description: string
+  inputSummary: string | null
+  status: SquadTaskStatus
+  dependsOnJson: string | null
+  priority: number
+  createdAt: string
+  updatedAt: string
+  completedAt: string | null
+  errorMessage: string | null
+}
+
+export interface SquadArtifactInfo {
+  id: number
+  squadRunId: number
+  squadRoleRunId: number | null
+  taskId: number | null
+  roleKind: SquadRoleKind | null
+  artifactType: SquadArtifactType
+  title: string
+  contentJson: string
+  createdAt: string
+}
+
+export interface SquadRunSnapshot {
+  run: SquadRunInfo
+  roles: SquadRoleRunInfo[]
+  tasks: SquadTaskInfo[]
+  artifacts: SquadArtifactInfo[]
+}
+
+export interface SquadEvent {
+  type: string
+  squadRunId: number
+  seq: number
+  at: string
+  roleKind?: SquadRoleKind | null
+  payload?: unknown
+}
+
 export type AppErrorCode =
   | "invalid_input"
   | "configuration_missing"
@@ -514,33 +675,6 @@ export type AcpEvent =
       connection_id: string
       used: number
       size: number
-    }
-  | {
-      /** Agent has begun mid-turn context compaction. UI shows a hint. */
-      type: "compaction_started"
-      connection_id: string
-      session_id: string
-    }
-  | {
-      /** Compaction finished; clear the hint. */
-      type: "compaction_finished"
-      connection_id: string
-      session_id: string
-    }
-  | {
-      /** Non-fatal stream parse warning. Lets the UI know the stream
-       * had a hiccup instead of silently freezing. */
-      type: "stream_warning"
-      connection_id: string
-      message: string
-    }
-  | {
-      /** Watchdog aborted the turn after no agent activity for `idle_ms`. */
-      type: "turn_idle_timeout"
-      connection_id: string
-      session_id: string
-      agent_type: string
-      idle_ms: number
     }
 
 // Connection info returned by acp_list_connections

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,7 +3,7 @@ export type AgentType =
   | "codex"
   | "open_code"
   | "gemini"
-  | "open_claw"
+  | "generic"
   | "cline"
 
 export type AppErrorCode =
@@ -161,8 +161,18 @@ export interface FolderDetail {
   path: string
   git_branch: string | null
   default_agent_type: AgentType | null
+  workspace_preset: WorkspacePreset | null
   last_opened_at: string
   sort_order: number
+}
+
+export interface WorkspacePreset {
+  default_agent_type: AgentType | null
+  model_provider_id: number | null
+  approval_policy: string | null
+  skill_ids: string[]
+  mcp_server_ids: string[]
+  env_overrides: Record<string, string>
 }
 
 export interface OpenedTab {
@@ -178,6 +188,8 @@ export interface OpenedTab {
 export interface DbConversationSummary {
   id: number
   folder_id: number
+  folder_name: string | null
+  folder_path: string | null
   title: string | null
   agent_type: AgentType
   status: string
@@ -239,7 +251,7 @@ export const AGENT_DISPLAY_ORDER: AgentType[] = [
   "claude_code",
   "open_code",
   "gemini",
-  "open_claw",
+  "generic",
   "cline",
 ]
 
@@ -258,7 +270,7 @@ export const ALL_AGENT_TYPES: AgentType[] = [
   "codex",
   "open_code",
   "gemini",
-  "open_claw",
+  "generic",
   "cline",
 ]
 
@@ -273,7 +285,7 @@ export const AGENT_LABELS: Record<AgentType, string> = {
   codex: "Codex",
   open_code: "OpenCode",
   gemini: "Gemini CLI",
-  open_claw: "OpenClaw",
+  generic: "Generic",
   cline: "Cline",
 }
 
@@ -282,7 +294,7 @@ export const AGENT_COLORS: Record<AgentType, string> = {
   codex: "bg-[#7A9DFF]",
   open_code: "bg-black",
   gemini: "bg-[#3186FF]",
-  open_claw: "bg-emerald-600",
+  generic: "bg-slate-600",
   cline: "bg-purple-500",
 }
 
@@ -503,12 +515,45 @@ export type AcpEvent =
       used: number
       size: number
     }
+  | {
+      /** Agent has begun mid-turn context compaction. UI shows a hint. */
+      type: "compaction_started"
+      connection_id: string
+      session_id: string
+    }
+  | {
+      /** Compaction finished; clear the hint. */
+      type: "compaction_finished"
+      connection_id: string
+      session_id: string
+    }
+  | {
+      /** Non-fatal stream parse warning. Lets the UI know the stream
+       * had a hiccup instead of silently freezing. */
+      type: "stream_warning"
+      connection_id: string
+      message: string
+    }
+  | {
+      /** Watchdog aborted the turn after no agent activity for `idle_ms`. */
+      type: "turn_idle_timeout"
+      connection_id: string
+      session_id: string
+      agent_type: string
+      idle_ms: number
+    }
 
 // Connection info returned by acp_list_connections
 export interface ConnectionInfo {
   id: string
   agent_type: AgentType
   status: ConnectionStatus
+  owner_window_label: string
+  working_dir: string | null
+  created_at: string
+  updated_at: string
+  session_id: string | null
+  last_error: string | null
 }
 
 // ACP agent info returned by acp_list_agents
@@ -632,6 +677,97 @@ export interface SystemLanguageSettings {
   language: AppLocale
 }
 
+export interface BackendBuildInfo {
+  version: string
+  git_commit: string | null
+  built_at: string | null
+  profile: string
+}
+
+export interface FrontendBuildManifest {
+  version: string
+  git_commit: string | null
+  built_at: string | null
+}
+
+export interface BuildConsistencyInfo {
+  status: string
+  message: string
+  backend: BackendBuildInfo
+  frontend: FrontendBuildManifest | null
+  manifest_path: string
+}
+
+export interface RuntimeSecurityInfo {
+  mode: string
+  host: string | null
+  auth_enabled: boolean
+  allow_remote_access: boolean
+  insecure: boolean
+  override_active: boolean
+  static_dir: string | null
+  data_dir: string | null
+}
+
+export interface RuntimeLogEntry {
+  timestamp: string
+  level: string
+  scope: string
+  message: string
+  data?: unknown
+}
+
+export interface ConnectionLimitSnapshot {
+  current_total: number
+  global_limit: number
+  per_owner_limit: number
+  per_agent_limit: number
+  by_agent: Record<string, number>
+  recent_failures: number
+  breaker_threshold: number
+  breaker_window_seconds: number
+  breaker_cooldown_seconds: number
+  breaker_open: boolean
+  breaker_open_until: string | null
+  orphan_grace_seconds: number
+  connecting_timeout_seconds: number
+}
+
+export interface RuntimeDiagnostics {
+  build: BuildConsistencyInfo | null
+  security: RuntimeSecurityInfo | null
+  connections: ConnectionInfo[]
+  terminals: TerminalInfo[]
+  web_clients: WebClientInfo[]
+  recent_logs: RuntimeLogEntry[]
+  connection_limits: ConnectionLimitSnapshot
+}
+
+export interface WebClientInfo {
+  client_id: string
+  active_sockets: number
+  connected_at: string
+  updated_at: string
+}
+
+export interface AcpCacheEntry {
+  agent_type: AgentType
+  label: string
+  path: string
+  size_bytes: number
+  file_count: number
+  versions: string[]
+  installed_version: string | null
+  recommended_version: string | null
+}
+
+export interface AcpCacheInventory {
+  generated_at: string
+  root_path: string
+  total_size_bytes: number
+  entries: AcpCacheEntry[]
+}
+
 // --- Version Control ---
 
 export interface GitCredentials {
@@ -681,7 +817,7 @@ export type McpAppType =
   | "claude_code"
   | "codex"
   | "gemini"
-  | "open_claw"
+  | "generic"
   | "open_code"
   | "cline"
 
@@ -938,6 +1074,9 @@ export interface GitLogFileChange {
 export interface TerminalInfo {
   id: string
   title: string
+  working_dir: string
+  owner_window_label: string
+  created_at: string
 }
 
 export interface TerminalEvent {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -158,13 +158,40 @@ export interface SquadRunSnapshot {
   artifacts: SquadArtifactInfo[]
 }
 
+export type SquadEventType =
+  | "squad_run_status_changed"
+  | "squad_role_status_changed"
+  | "squad_role_connection_attached"
+  | "squad_task_created"
+  | "squad_task_status_changed"
+  | "squad_artifact_created"
+  | "squad_conductor_plan_applied"
+  | "squad_dispatch_round_completed"
+  | (string & {})
+
 export interface SquadEvent {
-  type: string
+  type: SquadEventType
   squadRunId: number
   seq: number
   at: string
   roleKind?: SquadRoleKind | null
   payload?: unknown
+}
+
+export interface SquadConductorPlanAppliedPayload {
+  createdCount: number
+  skippedCount: number
+  skippedReasons: string[]
+}
+
+export interface SquadDispatchRoundCompletedPayload {
+  considered: number
+  dispatched: Array<{
+    taskId: number
+    roleKind: SquadRoleKind
+    outcome: string
+    note: string | null
+  }>
 }
 
 export type AppErrorCode =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -639,6 +639,7 @@ export type AcpEvent =
       connection_id: string
       session_id: string
       stop_reason: string
+      agent_type: string
     }
   | {
       type: "session_started"
@@ -702,6 +703,28 @@ export type AcpEvent =
       connection_id: string
       used: number
       size: number
+    }
+  | {
+      type: "compaction_started"
+      connection_id: string
+      session_id: string
+    }
+  | {
+      type: "compaction_finished"
+      connection_id: string
+      session_id: string
+    }
+  | {
+      type: "stream_warning"
+      connection_id: string
+      message: string
+    }
+  | {
+      type: "turn_idle_timeout"
+      connection_id: string
+      session_id: string
+      agent_type: string
+      idle_ms: number
     }
 
 // Connection info returned by acp_list_connections

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config"
+import path from "node:path"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    globals: false,
+  },
+})


### PR DESCRIPTION
## Summary

Closes the long-running Squad orchestration line of work and ships
everything needed to take a Squad run from kickoff → conductor planning
→ task fan-out → per-role execution → artifact capture, fully
event-driven, and verified end-to-end on both Tauri and codeg-server
runtimes.

Highlights since branch divergence:

- **Squad core**: dispatcher, prompt builder, conductor parser,
  worktree manager (real `git worktree add` for `WriteIsolated`),
  16 Tauri commands + matching HTTP API, frontend context + types
  + aux-panel tab, mode-aware run start, ACP session_id persistence.
- **Real-time**: incremental snapshot reducer (`applySquadEvent`)
  replaces full reload; redundant `squadGetRun` refetches dropped.
- **Auto-capture (this PR's final piece)**: new
  `squad::turn_listener` eavesdrops on the existing event broadcast
  and, on `turn_complete` for a squad-bound connection, runs
  `record_turn_artifacts` → `apply_conductor_output` (Conductor
  only) → `dispatch_pending_tasks`. Keeps `acp::connection` free
  of squad-specific bookkeeping.
- **Stop semantics**: `stop_run` now waits for ACP disconnect
  before flipping role to `Stopped`.

## Reliability / infra picked up along the way

- Centralized `reqwest` client factory honoring proxy snapshot
- Broadcast capacity bumped 4096→8192 with `__resync` lag handling
- WS exponential backoff + per-call timeout & idempotent retry
- Terminal: kill the whole process tree, not just the shell
- ACP: track background tasks via `TaskTracker`
- Chat channel: unified reconnect backoff
- DB: index `(deleted_at, updated_at)` + JOIN folder
- CI: lint + type + cargo workflow on PR / push to main

## Tests

- **Rust**: `cargo test --lib --no-default-features` → 113 pass
  (42 of them under `squad::`, including 4 new `BufferStore` cases
  and 27 worktree/dispatcher/parser cases added on this branch).
- **Frontend**: introduces vitest + happy-dom; 15 cases lock down
  `applySquadEvent` (run mismatch, role upsert, task created /
  status_changed (known + ghost), artifact prepending, summary-only
  no-ops, malformed payloads, immutability).
- **Static**: `pnpm exec tsc --noEmit` clean, `pnpm lint` clean,
  `pnpm build` produces the static export, `cargo clippy --lib
  --no-default-features -- -D warnings` clean,
  `cargo check --bin codeg-server --no-default-features` clean.

## Test plan

- [ ] Run `pnpm install && pnpm test` — expect 15 pass
- [ ] Run `cd src-tauri && cargo test --lib --no-default-features`
      — expect 113 pass
- [ ] Run `cd src-tauri && cargo check --bin codeg-server
      --no-default-features` — expect clean build
- [ ] Smoke-test a Squad run end-to-end and confirm artifacts +
      task rows materialize without manual `record_turn_artifacts`
      invocation
- [ ] Confirm `stop_run` awaits ACP disconnect before status flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)