### PR TITLE
修复移动端 Web 控件可访问性问题

### DIFF
--- a/src/app/workspace/layout.tsx
+++ b/src/app/workspace/layout.tsx
@@ -749,7 +749,7 @@ function FolderLayoutShell({ children }: { children: React.ReactNode }) {
   const isMobile = useIsMobile()
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden">
+    <div className="fixed inset-0 flex flex-col overflow-hidden bg-background text-foreground pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]">
       <FolderTitleBar />
       {isMobile ? (
         <MobileFolderWorkspaceShell>{children}</MobileFolderWorkspaceShell>

--- a/src/components/conversations/sidebar-conversation-list.tsx
+++ b/src/components/conversations/sidebar-conversation-list.tsx
@@ -267,13 +267,13 @@ const FolderHeader = memo(function FolderHeader({
               title={t("newConversation")}
               aria-label={t("newConversation")}
               className={cn(
-                "mr-[0.25rem] flex h-[1.25rem] w-[1.25rem] shrink-0 items-center justify-center",
-                "rounded-[0.25rem] cursor-pointer outline-none text-muted-foreground/80",
-                "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-                "transition-opacity duration-150 hover:text-sidebar-foreground"
+                "mr-[0.125rem] flex h-7 w-7 shrink-0 items-center justify-center",
+                "rounded-[0.375rem] cursor-pointer outline-none text-muted-foreground/80",
+                "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 [@media(hover:none)]:opacity-100",
+                "transition-[opacity,color,background-color] duration-150 hover:bg-sidebar-accent hover:text-sidebar-foreground"
               )}
             >
-              <Plus className="h-[0.75rem] w-[0.75rem]" />
+              <Plus className="h-[0.875rem] w-[0.875rem]" />
             </button>
           </div>
         </div>

--- a/src/components/message/virtualized-message-thread.tsx
+++ b/src/components/message/virtualized-message-thread.tsx
@@ -73,7 +73,7 @@ export function VirtualizedMessageThread<T>({
   return (
     <MessageThreadContent
       className={cn("mx-0 max-w-none p-0", contentClassName)}
-      scrollClassName="scrollbar-thin [overflow-anchor:none]"
+      scrollClassName="scrollbar-thin overscroll-contain [overflow-anchor:none]"
       {...contentProps}
     >
       {items.length === 0 ? (


### PR DESCRIPTION
## 变更内容

- 将 workspace 外壳固定到视口，避免移动端浏览器把整个应用外壳滚出屏幕。
- 给消息滚动容器增加 `overscroll-contain`，减少滚动链传递到页面本身。
- 让侧边栏项目目录的新建会话 `+` 按钮在无 hover 的触摸设备上保持可见，并增大触摸区域。

Fixes #121

## 验证

- `pnpm build`
- `pnpm eslint src/app/workspace/layout.tsx src/components/conversations/sidebar-conversation-list.tsx src/components/message/virtualized-message-thread.tsx`
- `cargo build --bin codeg-server --no-default-features`

备注：当前 Windows 工作区全量 `pnpm eslint .` 会被既有 CRLF 换行符触发的 Prettier `Delete ␍` 报错卡住，和本次改动逻辑无关。