### PR TITLE
优化移动端标签栏排序手势

### DIFF
--- a/src/components/files/file-workspace-tab-bar.tsx
+++ b/src/components/files/file-workspace-tab-bar.tsx
@@ -1,12 +1,15 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
-import { Reorder } from "motion/react"
+import { memo, useCallback, useEffect, useRef, useState } from "react"
+import type { PointerEvent as ReactPointerEvent } from "react"
+import { Reorder, useDragControls } from "motion/react"
 import { Code, Eye, ExternalLink, FileText, GitCompare, X } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { openPath } from "@/lib/platform"
 import { useActiveFolder } from "@/contexts/active-folder-context"
 import { useWorkspaceContext } from "@/contexts/workspace-context"
+import type { FileWorkspaceTab } from "@/contexts/workspace-context"
+import { useIsCoarsePointer } from "@/hooks/use-is-coarse-pointer"
 import { useShortcutSettings } from "@/hooks/use-shortcut-settings"
 import { matchShortcutEvent } from "@/lib/keyboard-shortcuts"
 import { cn } from "@/lib/utils"
@@ -36,7 +39,11 @@ export function FileWorkspaceTabBar() {
   const { activeFolder: folder } = useActiveFolder()
   const { shortcuts } = useShortcutSettings()
   const scrollRef = useRef<HTMLDivElement>(null)
+  const isCoarsePointer = useIsCoarsePointer()
   const [isHovered, setIsHovered] = useState(false)
+  const [touchSortingTabId, setTouchSortingTabId] = useState<string | null>(
+    null
+  )
 
   const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
     if (e.deltaY !== 0 && scrollRef.current) {
@@ -110,7 +117,10 @@ export function FileWorkspaceTabBar() {
         role="tablist"
         axis="x"
         values={fileTabs}
-        onReorder={reorderFileTabs}
+        onReorder={(nextTabs) => {
+          if (isCoarsePointer && !touchSortingTabId) return
+          reorderFileTabs(nextTabs)
+        }}
         onWheel={handleWheel}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
@@ -129,74 +139,24 @@ export function FileWorkspaceTabBar() {
         )}
       >
         {fileTabs.map((tab) => {
-          const active = tab.id === activeFileTabId
-          const isDiff = tab.kind === "diff" || tab.kind === "rich-diff"
-          const isDirty = tab.kind === "file" && Boolean(tab.isDirty)
-
           return (
-            <Reorder.Item
+            <FileWorkspaceTabItem
               key={tab.id}
-              as="div"
-              value={tab}
-              data-file-tab-id={tab.id}
-              className="shrink-0 rounded-full cursor-grab active:cursor-grabbing"
-            >
-              <ContextMenu>
-                <ContextMenuTrigger asChild>
-                  <div
-                    role="tab"
-                    aria-selected={active}
-                    onClick={() => switchFileTab(tab.id)}
-                    className={cn(
-                      "group/filetab relative flex items-center h-full gap-1.5 px-3 text-xs rounded-full",
-                      "cursor-pointer select-none shrink-0 hover:bg-primary/8 transition-colors",
-                      active
-                        ? "bg-primary/10 text-foreground"
-                        : "text-muted-foreground"
-                    )}
-                    title={tab.description ?? tab.title}
-                  >
-                    {isDiff ? (
-                      <GitCompare className="h-3.5 w-3.5" />
-                    ) : (
-                      <FileText className="h-3.5 w-3.5" />
-                    )}
-                    <span className="truncate max-w-[180px]">
-                      {tab.title}
-                      {isDirty ? " *" : ""}
-                    </span>
-                    <button
-                      type="button"
-                      className={cn(
-                        "rounded-full p-0.5 hover:bg-muted",
-                        active
-                          ? "opacity-100"
-                          : "opacity-0 group-hover/filetab:opacity-100"
-                      )}
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        closeFileTab(tab.id)
-                      }}
-                      aria-label={t("closeFileTab")}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </div>
-                </ContextMenuTrigger>
-                <ContextMenuContent>
-                  <ContextMenuItem onSelect={() => closeFileTab(tab.id)}>
-                    {t("close")}
-                  </ContextMenuItem>
-                  <ContextMenuItem onSelect={() => closeOtherFileTabs(tab.id)}>
-                    {t("closeOthers")}
-                  </ContextMenuItem>
-                  <ContextMenuSeparator />
-                  <ContextMenuItem onSelect={closeAllFileTabs}>
-                    {t("closeAll")}
-                  </ContextMenuItem>
-                </ContextMenuContent>
-              </ContextMenu>
-            </Reorder.Item>
+              tab={tab}
+              active={tab.id === activeFileTabId}
+              closeLabel={t("closeFileTab")}
+              closeText={t("close")}
+              closeOthersText={t("closeOthers")}
+              closeAllText={t("closeAll")}
+              isCoarsePointer={isCoarsePointer}
+              isTouchSorting={touchSortingTabId === tab.id}
+              onSwitch={switchFileTab}
+              onClose={closeFileTab}
+              onCloseOthers={closeOtherFileTabs}
+              onCloseAll={closeAllFileTabs}
+              onTouchSortingStart={setTouchSortingTabId}
+              onTouchSortingEnd={() => setTouchSortingTabId(null)}
+            />
           )
         })}
       </Reorder.Group>
@@ -234,3 +194,209 @@ export function FileWorkspaceTabBar() {
     </div>
   )
 }
+
+interface FileWorkspaceTabItemProps {
+  tab: FileWorkspaceTab
+  active: boolean
+  closeLabel: string
+  closeText: string
+  closeOthersText: string
+  closeAllText: string
+  isCoarsePointer: boolean
+  isTouchSorting: boolean
+  onSwitch: (tabId: string) => void
+  onClose: (tabId: string) => void
+  onCloseOthers: (tabId: string) => void
+  onCloseAll: () => void
+  onTouchSortingStart: (tabId: string) => void
+  onTouchSortingEnd: () => void
+}
+
+const LONG_PRESS_MS = 500
+const TOUCH_SCROLL_THRESHOLD_PX = 10
+
+const FileWorkspaceTabItem = memo(function FileWorkspaceTabItem({
+  tab,
+  active,
+  closeLabel,
+  closeText,
+  closeOthersText,
+  closeAllText,
+  isCoarsePointer,
+  isTouchSorting,
+  onSwitch,
+  onClose,
+  onCloseOthers,
+  onCloseAll,
+  onTouchSortingStart,
+  onTouchSortingEnd,
+}: FileWorkspaceTabItemProps) {
+  const dragControls = useDragControls()
+  const isDragging = useRef(false)
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const longPressActiveRef = useRef(false)
+  const suppressNextClickRef = useRef(false)
+  const isDiff = tab.kind === "diff" || tab.kind === "rich-diff"
+  const isDirty = tab.kind === "file" && Boolean(tab.isDirty)
+
+  const clearLongPressTimer = useCallback(() => {
+    if (!longPressTimerRef.current) return
+    clearTimeout(longPressTimerRef.current)
+    longPressTimerRef.current = null
+  }, [])
+
+  useEffect(() => clearLongPressTimer, [clearLongPressTimer])
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isCoarsePointer || event.pointerType === "mouse") return
+
+      clearLongPressTimer()
+      longPressActiveRef.current = false
+      touchStartRef.current = { x: event.clientX, y: event.clientY }
+
+      longPressTimerRef.current = setTimeout(() => {
+        longPressTimerRef.current = null
+        longPressActiveRef.current = true
+        suppressNextClickRef.current = true
+        onTouchSortingStart(tab.id)
+        dragControls.start(event.nativeEvent)
+      }, LONG_PRESS_MS)
+    },
+    [
+      clearLongPressTimer,
+      dragControls,
+      isCoarsePointer,
+      onTouchSortingStart,
+      tab.id,
+    ]
+  )
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isCoarsePointer || event.pointerType === "mouse") return
+
+      if (longPressActiveRef.current) {
+        event.preventDefault()
+        return
+      }
+
+      const start = touchStartRef.current
+      if (!start) return
+
+      const movedX = Math.abs(event.clientX - start.x)
+      const movedY = Math.abs(event.clientY - start.y)
+      if (
+        movedX > TOUCH_SCROLL_THRESHOLD_PX ||
+        movedY > TOUCH_SCROLL_THRESHOLD_PX
+      ) {
+        clearLongPressTimer()
+      }
+    },
+    [clearLongPressTimer, isCoarsePointer]
+  )
+
+  const handlePointerEnd = useCallback(() => {
+    clearLongPressTimer()
+    touchStartRef.current = null
+    if (longPressActiveRef.current) {
+      longPressActiveRef.current = false
+      onTouchSortingEnd()
+    }
+  }, [clearLongPressTimer, onTouchSortingEnd])
+
+  const handleSwitch = useCallback(() => {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false
+      return
+    }
+    if (isDragging.current) return
+    onSwitch(tab.id)
+  }, [onSwitch, tab.id])
+
+  return (
+    <Reorder.Item
+      as="div"
+      value={tab}
+      data-file-tab-id={tab.id}
+      drag="x"
+      dragControls={dragControls}
+      dragListener={!isCoarsePointer}
+      whileDrag={{ scale: 1.03 }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+      onDragStart={() => {
+        isDragging.current = true
+      }}
+      onDragEnd={() => {
+        onTouchSortingEnd()
+        longPressActiveRef.current = false
+        touchStartRef.current = null
+        setTimeout(() => {
+          isDragging.current = false
+        }, 200)
+      }}
+      className={cn(
+        "shrink-0 rounded-full cursor-grab active:cursor-grabbing",
+        isTouchSorting && "z-50 opacity-90 shadow-md ring-1 ring-primary/25"
+      )}
+    >
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            role="tab"
+            aria-selected={active}
+            onClick={handleSwitch}
+            className={cn(
+              "group/filetab relative flex items-center h-full gap-1.5 px-3 text-xs rounded-full",
+              "cursor-pointer select-none shrink-0 hover:bg-primary/8 transition-colors",
+              active ? "bg-primary/10 text-foreground" : "text-muted-foreground"
+            )}
+            title={tab.description ?? tab.title}
+          >
+            {isDiff ? (
+              <GitCompare className="h-3.5 w-3.5" />
+            ) : (
+              <FileText className="h-3.5 w-3.5" />
+            )}
+            <span className="truncate max-w-[180px]">
+              {tab.title}
+              {isDirty ? " *" : ""}
+            </span>
+            <button
+              type="button"
+              className={cn(
+                "rounded-full p-0.5 hover:bg-muted",
+                active
+                  ? "opacity-100"
+                  : "opacity-0 group-hover/filetab:opacity-100"
+              )}
+              onClick={(event) => {
+                event.stopPropagation()
+                onClose(tab.id)
+              }}
+              aria-label={closeLabel}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onSelect={() => onClose(tab.id)}>
+            {closeText}
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => onCloseOthers(tab.id)}>
+            {closeOthersText}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem onSelect={onCloseAll}>
+            {closeAllText}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </Reorder.Item>
+  )
+})

--- a/src/components/tabs/tab-bar.tsx
+++ b/src/components/tabs/tab-bar.tsx
@@ -5,6 +5,7 @@ import { Reorder } from "motion/react"
 import { useAppWorkspace } from "@/contexts/app-workspace-context"
 import { useTabContext } from "@/contexts/tab-context"
 import { useWorkspaceContext } from "@/contexts/workspace-context"
+import { useIsCoarsePointer } from "@/hooks/use-is-coarse-pointer"
 import { useShortcutSettings } from "@/hooks/use-shortcut-settings"
 import { matchShortcutEvent } from "@/lib/keyboard-shortcuts"
 import { TabItem } from "./tab-item"
@@ -34,7 +35,11 @@ export function TabBar() {
 
   const { shortcuts } = useShortcutSettings()
   const scrollRef = useRef<HTMLDivElement>(null)
+  const isCoarsePointer = useIsCoarsePointer()
   const [isHovered, setIsHovered] = useState(false)
+  const [touchSortingTabId, setTouchSortingTabId] = useState<string | null>(
+    null
+  )
 
   const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
     if (e.deltaY !== 0 && scrollRef.current) {
@@ -77,7 +82,10 @@ export function TabBar() {
       role="tablist"
       axis="x"
       values={tabs}
-      onReorder={reorderTabs}
+      onReorder={(nextTabs) => {
+        if (isCoarsePointer && !touchSortingTabId) return
+        reorderTabs(nextTabs)
+      }}
       onWheel={handleWheel}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
@@ -111,6 +119,10 @@ export function TabBar() {
             onCloseAll={closeAllTabs}
             onPin={pinTab}
             onToggleTile={toggleTileMode}
+            isCoarsePointer={isCoarsePointer}
+            isTouchSorting={touchSortingTabId === tab.id}
+            onTouchSortingStart={setTouchSortingTabId}
+            onTouchSortingEnd={() => setTouchSortingTabId(null)}
           />
         )
       })}

--- a/src/components/tabs/tab-item.tsx
+++ b/src/components/tabs/tab-item.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { memo, useCallback, useRef } from "react"
-import { Reorder } from "motion/react"
+import { memo, useCallback, useEffect, useRef } from "react"
+import type { PointerEvent as ReactPointerEvent } from "react"
+import { Reorder, useDragControls } from "motion/react"
 import { X } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { cn } from "@/lib/utils"
@@ -28,7 +29,14 @@ interface TabItemProps {
   onCloseAll: () => void
   onPin: (tabId: string) => void
   onToggleTile: () => void
+  isCoarsePointer: boolean
+  isTouchSorting: boolean
+  onTouchSortingStart: (tabId: string) => void
+  onTouchSortingEnd: () => void
 }
+
+const LONG_PRESS_MS = 500
+const TOUCH_SCROLL_THRESHOLD_PX = 10
 
 export const TabItem = memo(function TabItem({
   tab,
@@ -42,10 +50,19 @@ export const TabItem = memo(function TabItem({
   onCloseAll,
   onPin,
   onToggleTile,
+  isCoarsePointer,
+  isTouchSorting,
+  onTouchSortingStart,
+  onTouchSortingEnd,
 }: TabItemProps) {
   const t = useTranslations("Folder.tabs")
+  const dragControls = useDragControls()
   const isDragging = useRef(false)
   const itemRef = useRef<HTMLDivElement>(null)
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const longPressActiveRef = useRef(false)
+  const suppressNextClickRef = useRef(false)
 
   const resolvedFolderName = folderName ?? String(tab.folderId)
   const tooltip = folderBranch
@@ -61,7 +78,19 @@ export const TabItem = memo(function TabItem({
     el.style.userSelect = ""
   }, [])
 
+  const clearLongPressTimer = useCallback(() => {
+    if (!longPressTimerRef.current) return
+    clearTimeout(longPressTimerRef.current)
+    longPressTimerRef.current = null
+  }, [])
+
+  useEffect(() => clearLongPressTimer, [clearLongPressTimer])
+
   const handleClick = useCallback(() => {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false
+      return
+    }
     if (isDragging.current) return
     onSwitch(tab.id)
   }, [onSwitch, tab.id])
@@ -81,23 +110,96 @@ export const TabItem = memo(function TabItem({
     onCloseOthers(tab.id)
   }, [onCloseOthers, tab.id])
 
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isCoarsePointer || event.pointerType === "mouse") return
+
+      clearLongPressTimer()
+      longPressActiveRef.current = false
+      touchStartRef.current = { x: event.clientX, y: event.clientY }
+
+      longPressTimerRef.current = setTimeout(() => {
+        longPressTimerRef.current = null
+        longPressActiveRef.current = true
+        suppressNextClickRef.current = true
+        onTouchSortingStart(tab.id)
+        dragControls.start(event.nativeEvent)
+      }, LONG_PRESS_MS)
+    },
+    [
+      clearLongPressTimer,
+      dragControls,
+      isCoarsePointer,
+      onTouchSortingStart,
+      tab.id,
+    ]
+  )
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isCoarsePointer || event.pointerType === "mouse") return
+
+      if (longPressActiveRef.current) {
+        event.preventDefault()
+        return
+      }
+
+      const start = touchStartRef.current
+      if (!start) return
+
+      const movedX = Math.abs(event.clientX - start.x)
+      const movedY = Math.abs(event.clientY - start.y)
+      if (
+        movedX > TOUCH_SCROLL_THRESHOLD_PX ||
+        movedY > TOUCH_SCROLL_THRESHOLD_PX
+      ) {
+        clearLongPressTimer()
+      }
+    },
+    [clearLongPressTimer, isCoarsePointer]
+  )
+
+  const handlePointerEnd = useCallback(() => {
+    clearLongPressTimer()
+    touchStartRef.current = null
+    if (longPressActiveRef.current) {
+      longPressActiveRef.current = false
+      onTouchSortingEnd()
+    }
+  }, [clearLongPressTimer, onTouchSortingEnd])
+
   return (
     <Reorder.Item
       ref={itemRef}
       as="div"
       value={tab}
       data-tab-id={tab.id}
+      drag="x"
+      dragControls={dragControls}
+      dragListener={!isCoarsePointer}
+      whileDrag={{ scale: 1.03 }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
       onDragStart={() => {
         isDragging.current = true
       }}
       onDragEnd={() => {
+        onTouchSortingEnd()
+        longPressActiveRef.current = false
+        touchStartRef.current = null
         setTimeout(() => {
           isDragging.current = false
           clearResidualStyles()
         }, 200)
       }}
       onLayoutAnimationComplete={clearResidualStyles}
-      className="shrink-0 rounded-full cursor-grab active:cursor-grabbing active:opacity-90 active:shadow-md active:z-50"
+      className={cn(
+        "shrink-0 rounded-full cursor-grab active:cursor-grabbing",
+        !isCoarsePointer && "active:opacity-90 active:shadow-md active:z-50",
+        isTouchSorting && "z-50 opacity-90 shadow-md ring-1 ring-primary/25"
+      )}
     >
       <ContextMenu>
         <ContextMenuTrigger asChild>

--- a/src/hooks/use-is-coarse-pointer.ts
+++ b/src/hooks/use-is-coarse-pointer.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export function useIsCoarsePointer() {
+  const [isCoarsePointer, setIsCoarsePointer] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia("(pointer: coarse)")
+    const update = () => setIsCoarsePointer(query.matches)
+
+    update()
+    query.addEventListener("change", update)
+    return () => query.removeEventListener("change", update)
+  }, [])
+
+  return isCoarsePointer
+}


### PR DESCRIPTION
## 变更内容

- 移动端标签栏默认保留横向滚动，不再在普通滑动时触发排序。
- 粗指针设备上仅在长按 500ms 后启用拖动排序，长按前移动超过 10px 会取消排序并交给滚动。
- 长按排序时增加轻微放大、阴影和描边反馈，松手后恢复普通模式。
- 会话标签栏和文件工作区标签栏使用同一套移动端手势规则，桌面端仍保持直接拖动排序。

## 验证

- `pnpm eslint src/hooks/use-is-coarse-pointer.ts src/components/tabs/tab-bar.tsx src/components/tabs/tab-item.tsx src/components/files/file-workspace-tab-bar.tsx`
- `pnpm tsc --noEmit`
- `pnpm build`

## 说明

- 全量 `pnpm eslint .` 当前会因为仓库内大量既有 CRLF/Prettier 行尾问题失败，本次没有批量改动无关文件。