### PR TITLE
feat: 添加在 VS Code 中打开文件夹的功能

### DIFF
--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -3689,3 +3689,42 @@ async fn get_unpushed_hashes(
 
     Ok((Some(hashes), has_upstream))
 }
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn open_in_vscode(path: String) -> Result<(), AppCommandError> {
+    #[cfg(target_os = "macos")]
+    {
+        let status = crate::process::tokio_command("open")
+            .args(["-a", "Visual Studio Code", &path])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+
+        if let Ok(s) = status {
+            if s.success() {
+                return Ok(());
+            }
+        }
+    }
+
+    let status = crate::process::tokio_command("code")
+        .arg(&path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(
+            AppCommandError::dependency_missing("VS Code is not installed or available in PATH."),
+        ),
+        _ => Err(AppCommandError::dependency_missing(
+            "Failed to open VS Code.",
+        )),
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -531,6 +531,7 @@ mod tauri_app {
                 folders::add_folder_to_history,
                 folders::remove_folder_from_history,
                 folders::create_folder_directory,
+                folders::open_in_vscode,
                 folders::clone_repository,
                 folders::get_git_branch,
                 folders::git_init,

--- a/src/components/conversations/sidebar-conversation-list.tsx
+++ b/src/components/conversations/sidebar-conversation-list.tsx
@@ -36,6 +36,7 @@ import { useTerminalContext } from "@/contexts/terminal-context"
 import { useZoomLevel } from "@/hooks/use-appearance"
 import {
   importLocalConversations,
+  openInVsCode,
   openProjectBootWindow,
   updateConversationTitle,
   updateConversationStatus,
@@ -172,6 +173,7 @@ const FolderHeader = memo(function FolderHeader({
   onChangeColor,
   onOpenInSystemExplorer,
   onOpenInTerminal,
+  onOpenInVsCode,
   isDragging,
   dragControls,
   t,
@@ -191,6 +193,7 @@ const FolderHeader = memo(function FolderHeader({
   onChangeColor: (folderId: number, color: string) => void
   onOpenInSystemExplorer: (folderId: number) => void
   onOpenInTerminal: (folderId: number) => void
+  onOpenInVsCode: (folderId: number) => void
   isDragging?: boolean
   dragControls: DragControls
   t: ReturnType<typeof useTranslations>
@@ -329,6 +332,12 @@ const FolderHeader = memo(function FolderHeader({
             <ContextMenuItem onSelect={() => onOpenInTerminal(folderId)}>
               {tFileTree("openInTerminal")}
             </ContextMenuItem>
+            <ContextMenuItem
+              disabled={!isDesktopMode}
+              onSelect={() => onOpenInVsCode(folderId)}
+            >
+              {tFileTree("openInVsCode")}
+            </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuSub>
         <ContextMenuSeparator />
@@ -400,6 +409,7 @@ interface FolderGroupItemProps {
   onChangeColor: (folderId: number, color: string) => void
   onOpenInSystemExplorer: (folderId: number) => void
   onOpenInTerminal: (folderId: number) => void
+  onOpenInVsCode: (folderId: number) => void
   onSelect: (id: number, agentType: string) => void
   onDoubleClick: (id: number, agentType: string) => void
   onRename: (id: number, newTitle: string) => Promise<void>
@@ -436,6 +446,7 @@ function FolderGroupItem({
   onChangeColor,
   onOpenInSystemExplorer,
   onOpenInTerminal,
+  onOpenInVsCode,
   onSelect,
   onDoubleClick,
   onRename,
@@ -512,6 +523,7 @@ function FolderGroupItem({
             onChangeColor={onChangeColor}
             onOpenInSystemExplorer={onOpenInSystemExplorer}
             onOpenInTerminal={onOpenInTerminal}
+            onOpenInVsCode={onOpenInVsCode}
             isDragging={dragging}
             dragControls={dragControls}
             t={t}
@@ -692,6 +704,18 @@ export function SidebarConversationList({
       }
     },
     [folderIndex, createTerminalInDirectory, tFileTree]
+  )
+
+  const handleOpenFolderInVsCode = useCallback(
+    (folderId: number) => {
+      const folder = folderIndex.get(folderId)
+      if (!folder) return
+      void openInVsCode(folder.path).catch((err) => {
+        console.error("[openInVsCode] failed:", err)
+        toast.error(tFileTree("toasts.openDirectoryFailed"))
+      })
+    },
+    [folderIndex, tFileTree]
   )
 
   const scrollRootRef = useRef<OverlayScrollbarsComponentRef>(null)
@@ -1166,6 +1190,7 @@ export function SidebarConversationList({
                           handleOpenFolderInSystemExplorer
                         }
                         onOpenInTerminal={handleOpenFolderInTerminal}
+                        onOpenInVsCode={handleOpenFolderInVsCode}
                         onSelect={handleSelect}
                         onDoubleClick={handleDoubleClick}
                         onRename={handleRename}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "مجلد",
       "openIn": "فتح في",
       "openInTerminal": "فتح في الطرفية",
+      "openInVsCode": "فتح في VS Code",
       "actions": {
         "select": "تحديد",
         "unselect": "إلغاء التحديد",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "Verzeichnis",
       "openIn": "Öffnen in",
       "openInTerminal": "Im Terminal öffnen",
+      "openInVsCode": "In VS Code öffnen",
       "actions": {
         "select": "Auswählen",
         "unselect": "Auswahl aufheben",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "Directory",
       "openIn": "Open in",
       "openInTerminal": "Open in terminal",
+      "openInVsCode": "Open in VS Code",
       "actions": {
         "select": "Select",
         "unselect": "Unselect",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "Directorio",
       "openIn": "Abrir en",
       "openInTerminal": "Abrir en terminal",
+      "openInVsCode": "Abrir en VS Code",
       "actions": {
         "select": "Seleccionar",
         "unselect": "Deseleccionar",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "Répertoire",
       "openIn": "Ouvrir dans",
       "openInTerminal": "Ouvrir dans le terminal",
+      "openInVsCode": "Ouvrir dans VS Code",
       "actions": {
         "select": "Sélectionner",
         "unselect": "Désélectionner",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "ディレクトリ",
       "openIn": "で開く",
       "openInTerminal": "ターミナルで開く",
+      "openInVsCode": "VS Code で開く",
       "actions": {
         "select": "選択",
         "unselect": "選択解除",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "디렉터리",
       "openIn": "열기",
       "openInTerminal": "터미널에서 열기",
+      "openInVsCode": "VS Code 에서 열기",
       "actions": {
         "select": "선택",
         "unselect": "선택 해제",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "Diretório",
       "openIn": "Abrir em",
       "openInTerminal": "Abrir no terminal",
+      "openInVsCode": "Abrir no VS Code",
       "actions": {
         "select": "Selecionar",
         "unselect": "Desmarcar",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "目录",
       "openIn": "打开于",
       "openInTerminal": "在终端打开",
+      "openInVsCode": "在VS Code中打开",
       "actions": {
         "select": "选择",
         "unselect": "取消选择",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1427,6 +1427,7 @@
       "newDirectory": "目錄",
       "openIn": "開啟於",
       "openInTerminal": "在終端開啟",
+      "openInVsCode": "在VS Code中開啟",
       "actions": {
         "select": "選擇",
         "unselect": "取消選擇",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -735,6 +735,10 @@ export async function createFolderDirectory(path: string): Promise<void> {
   return getTransport().call("create_folder_directory", { path })
 }
 
+export async function openInVsCode(path: string): Promise<void> {
+  return getTransport().call("open_in_vscode", { path })
+}
+
 export async function cloneRepository(
   url: string,
   targetDir: string,


### PR DESCRIPTION
支持通过右键菜单在 Visual Studio Code 中打开文件夹。macOS 平台使用 `open -a` 命令，其他平台使用 CLI 命令。仅在桌面模式下可用。