### PR TITLE
fix: 调整侧边栏会话卡片的内边距和定位样式

### DIFF
--- a/src/components/conversations/sidebar-conversation-card.tsx
+++ b/src/components/conversations/sidebar-conversation-card.tsx
@@ -116,7 +116,7 @@ export const SidebarConversationCard = memo(function SidebarConversationCard({
                 "relative flex h-[1.9375rem] w-full items-center gap-[0.625rem] text-left outline-none",
                 "rounded-full text-sidebar-foreground",
                 "transition-colors duration-[120ms]",
-                "pr-[0.5rem] pl-7",
+                "pr-[0.5rem] pl-11",
                 isSelected
                   ? "bg-sidebar-primary/8"
                   : "hover:bg-[color-mix(in_oklab,var(--sidebar-accent),var(--sidebar-foreground)_2%)]"
@@ -130,7 +130,7 @@ export const SidebarConversationCard = memo(function SidebarConversationCard({
                 style={{
                   top: "-0.0625rem",
                   bottom: "-0.0625rem",
-                  left: "var(--conv-rail-axis, 0.875rem)",
+                  left: "calc(1.125em + var(--conv-rail-axis, 0.875rem))",
                   width: "0.125rem",
                   transform: "translateX(-50%)",
                 }}
@@ -138,7 +138,7 @@ export const SidebarConversationCard = memo(function SidebarConversationCard({
               <div
                 className="pointer-events-none absolute top-1/2 z-10 flex items-center justify-center"
                 style={{
-                  left: "var(--conv-rail-axis, 0.875rem)",
+                  left: "calc(1.125em + var(--conv-rail-axis, 0.875rem))",
                   width: "0.875rem",
                   height: "0.875rem",
                   transform: "translate(-50%, -50%)",


### PR DESCRIPTION
- 增大左侧内边距 (pl-7 -> pl-11)
- 优化左侧定位计算，添加 1.125em 偏移量以改善视觉对齐