### PR TITLE
[codex] Add Grok ACP agent support

### DIFF
--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -171,6 +171,36 @@ async fn build_agent(
     debug_assert_eq!(meta.agent_type, agent_type);
 
     match meta.distribution {
+        AgentDistribution::LocalCommand { cmd, args, env, .. } => {
+            let merged_env = merge_agent_env(env, runtime_env);
+            let mut parts: Vec<String> = Vec::new();
+            for (k, v) in &merged_env {
+                parts.push(format!("{k}={v}"));
+            }
+            parts.push(
+                crate::commands::acp::resolve_local_command(cmd)
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|| {
+                        crate::process::normalized_program(cmd)
+                            .to_string_lossy()
+                            .to_string()
+                    }),
+            );
+            for a in args {
+                parts.push((*a).into());
+            }
+            let refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
+            let agent_name = meta.name.to_string();
+            AcpAgent::from_args(&refs)
+                .map(|a| {
+                    a.with_debug(move |line, dir| {
+                        if dir == sacp_tokio::LineDirection::Stderr {
+                            eprintln!("[ACP][{agent_name}][stderr] {line}");
+                        }
+                    })
+                })
+                .map_err(|e| AcpError::SpawnFailed(e.to_string()))
+        }
         AgentDistribution::Npx { cmd, args, env, .. } => {
             let merged_env = merge_agent_env(env, runtime_env);
             let mut parts: Vec<String> = Vec::new();

--- a/src-tauri/src/acp/preflight.rs
+++ b/src-tauri/src/acp/preflight.rs
@@ -57,6 +57,7 @@ pub async fn run_preflight(agent_type: AgentType) -> PreflightResult {
     let meta = registry::get_agent_meta(agent_type);
     debug_assert_eq!(meta.agent_type, agent_type);
     let checks = match &meta.distribution {
+        AgentDistribution::LocalCommand { cmd, .. } => check_local_command_environment(cmd).await,
         AgentDistribution::Npx { node_required, .. } => check_npm_environment(*node_required).await,
         AgentDistribution::Binary {
             version,
@@ -76,6 +77,27 @@ pub async fn run_preflight(agent_type: AgentType) -> PreflightResult {
         passed,
         checks,
     }
+}
+
+async fn check_local_command_environment(cmd: &str) -> Vec<CheckItem> {
+    let command_check = match crate::commands::acp::resolve_local_command(cmd) {
+        Some(path) => CheckItem {
+            check_id: "local_command_available".into(),
+            label: "Command".into(),
+            status: CheckStatus::Pass,
+            message: format!("{} available at {}", cmd, path.display()),
+            fixes: vec![],
+        },
+        None => CheckItem {
+            check_id: "local_command_available".into(),
+            label: "Command".into(),
+            status: CheckStatus::Fail,
+            message: format!("{cmd} is not installed or not in PATH"),
+            fixes: vec![],
+        },
+    };
+
+    vec![command_check]
 }
 
 async fn check_npm_environment(node_required: Option<&str>) -> Vec<CheckItem> {

--- a/src-tauri/src/acp/registry.rs
+++ b/src-tauri/src/acp/registry.rs
@@ -2,6 +2,12 @@ use crate::models::agent::AgentType;
 
 #[derive(Debug, Clone)]
 pub enum AgentDistribution {
+    LocalCommand {
+        cmd: &'static str,
+        args: &'static [&'static str],
+        env: &'static [(&'static str, &'static str)],
+        version_args: &'static [&'static str],
+    },
     Npx {
         version: &'static str,
         package: &'static str,
@@ -38,9 +44,9 @@ pub struct AcpAgentMeta {
 impl AcpAgentMeta {
     pub fn registry_version(&self) -> Option<&'static str> {
         match &self.distribution {
-            AgentDistribution::Npx { version, .. } | AgentDistribution::Binary { version, .. } => {
-                Some(*version)
-            }
+            AgentDistribution::Npx { version, .. }
+            | AgentDistribution::Binary { version, .. } => Some(*version),
+            AgentDistribution::LocalCommand { .. } => None,
         }
     }
 }
@@ -80,6 +86,7 @@ pub fn all_acp_agents() -> Vec<AgentType> {
         AgentType::OpenClaw,
         AgentType::OpenCode,
         AgentType::Cline,
+        AgentType::Grok,
     ]
 }
 
@@ -91,6 +98,7 @@ pub fn registry_id_for(agent_type: AgentType) -> &'static str {
         AgentType::OpenClaw => "openclaw-acp",
         AgentType::OpenCode => "opencode",
         AgentType::Cline => "cline",
+        AgentType::Grok => "grok",
     }
 }
 
@@ -102,6 +110,7 @@ pub fn from_registry_id(id: &str) -> Option<AgentType> {
         "openclaw-acp" => Some(AgentType::OpenClaw),
         "opencode" => Some(AgentType::OpenCode),
         "cline" => Some(AgentType::Cline),
+        "grok" => Some(AgentType::Grok),
         _ => None,
     }
 }
@@ -238,5 +247,41 @@ pub fn get_agent_meta(agent_type: AgentType) -> AcpAgentMeta {
                 ],
             },
         },
+        AgentType::Grok => AcpAgentMeta {
+            agent_type,
+            name: "Grok",
+            description: "xAI's coding agent CLI",
+            distribution: AgentDistribution::LocalCommand {
+                cmd: "grok",
+                args: &["agent", "stdio"],
+                env: &[],
+                version_args: &["version"],
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grok_is_registered_as_local_stdio_agent() {
+        assert!(all_acp_agents().contains(&AgentType::Grok));
+        assert_eq!(registry_id_for(AgentType::Grok), "grok");
+        assert_eq!(from_registry_id("grok"), Some(AgentType::Grok));
+
+        let meta = get_agent_meta(AgentType::Grok);
+        assert_eq!(meta.name, "Grok");
+        assert_eq!(meta.registry_version(), None);
+
+        match meta.distribution {
+            AgentDistribution::LocalCommand { cmd, args, env, .. } => {
+                assert_eq!(cmd, "grok");
+                assert_eq!(args, &["agent", "stdio"]);
+                assert!(env.is_empty());
+            }
+            other => panic!("expected local command distribution, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -30,6 +30,8 @@ const NPM_PREFIX_TIMEOUT: Duration = Duration::from_millis(1500);
 
 static NPM_GLOBAL_PREFIX_CACHE: tokio::sync::OnceCell<PathBuf> = tokio::sync::OnceCell::const_new();
 
+const GROK_CLI_BASE_URL: &str = "https://storage.googleapis.com/grok-build-public-artifacts/cli";
+
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 struct AcpAgentsUpdatedEventPayload {
@@ -140,6 +142,21 @@ pub(crate) async fn resolve_npx_command(cmd: &str) -> Option<PathBuf> {
         return Some(path);
     }
     resolve_npx_command_from_current_npm_prefix(cmd).await
+}
+
+pub(crate) fn resolve_local_command(cmd: &str) -> Option<PathBuf> {
+    if let Some(path) = resolve_command_on_path(cmd) {
+        return Some(path);
+    }
+
+    let home = dirs::home_dir()?;
+    let candidates = [
+        home.join(".local").join("bin").join(cmd),
+        home.join(".grok").join("bin").join(cmd),
+    ];
+    candidates
+        .into_iter()
+        .find(|path| is_executable_command_candidate(path))
 }
 
 #[derive(Default)]
@@ -256,6 +273,16 @@ fn is_npm_command_candidate(path: &Path) -> bool {
 
 #[cfg(not(windows))]
 fn is_npm_command_candidate(path: &Path) -> bool {
+    is_executable_command_candidate(path)
+}
+
+#[cfg(windows)]
+fn is_executable_command_candidate(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(not(windows))]
+fn is_executable_command_candidate(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
 
     path.is_file()
@@ -278,6 +305,15 @@ fn is_npm_command_candidate(path: &Path) -> bool {
 pub(crate) async fn verify_agent_installed(agent_type: AgentType) -> Result<(), AcpError> {
     let meta = registry::get_agent_meta(agent_type);
     match meta.distribution {
+        registry::AgentDistribution::LocalCommand { cmd, .. } => {
+            if resolve_local_command(cmd).is_none() {
+                return Err(AcpError::SdkNotInstalled(format!(
+                    "{} is not installed. Please install it in Agent Settings.",
+                    meta.name
+                )));
+            }
+            Ok(())
+        }
         registry::AgentDistribution::Npx { cmd, .. } => {
             if !is_cmd_available(cmd).await {
                 // INVARIANT: the substring "is not installed" is matched
@@ -369,6 +405,25 @@ async fn npm_list_version(
 async fn detect_local_version(agent_type: AgentType) -> Option<String> {
     let meta = registry::get_agent_meta(agent_type);
     match meta.distribution {
+        registry::AgentDistribution::LocalCommand {
+            cmd, version_args, ..
+        } => {
+            let command_path = resolve_local_command(cmd)?;
+            let mut command = crate::process::tokio_command(command_path);
+            for arg in version_args {
+                command.arg(arg);
+            }
+            let output = command.output().await.ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            stdout
+                .split_whitespace()
+                .chain(stderr.split_whitespace())
+                .find_map(normalize_version_candidate)
+        }
         registry::AgentDistribution::Npx { cmd, package, .. } => {
             if !is_cmd_available(cmd).await {
                 return None;
@@ -383,6 +438,46 @@ async fn detect_local_version(agent_type: AgentType) -> Option<String> {
                 .flatten()
         }
     }
+}
+
+async fn detect_registry_version(agent_type: AgentType) -> Option<String> {
+    let meta = registry::get_agent_meta(agent_type);
+    match meta.distribution {
+        registry::AgentDistribution::LocalCommand { cmd, .. } if agent_type == AgentType::Grok => {
+            if let Some(command_path) = resolve_local_command(cmd) {
+                let output = crate::process::tokio_command(command_path)
+                    .arg("update")
+                    .arg("--check")
+                    .arg("--json")
+                    .output()
+                    .await
+                    .ok()?;
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let json: serde_json::Value = serde_json::from_str(&stdout).ok()?;
+                    if let Some(version) = json
+                        .get("latestVersion")
+                        .and_then(|value| value.as_str())
+                        .and_then(normalize_version_candidate)
+                    {
+                        return Some(version);
+                    }
+                }
+            }
+            fetch_grok_channel_version("stable").await
+        }
+        _ => meta.registry_version().map(ToString::to_string),
+    }
+}
+
+async fn fetch_grok_channel_version(channel: &str) -> Option<String> {
+    let url = format!("{GROK_CLI_BASE_URL}/{channel}");
+    let resp = reqwest::get(url).await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body = resp.text().await.ok()?;
+    normalize_version_candidate(body.trim())
 }
 
 /// Official npm registry URL – used to bypass local mirror configurations that
@@ -455,6 +550,73 @@ async fn run_npm_streaming(
         .wait()
         .await
         .map_err(|e| AcpError::protocol(format!("failed to wait for npm process: {e}")))?;
+
+    Ok((status.success(), collected_stderr))
+}
+
+async fn run_shell_streaming(
+    command: &str,
+    task_id: &str,
+    emitter: &EventEmitter,
+) -> Result<(bool, String), AcpError> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    let mut cmd = crate::process::tokio_command("bash");
+    cmd.arg("-lc")
+        .arg(command)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| AcpError::protocol(format!("failed to spawn shell command: {e}")))?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let emitter_clone = emitter.clone();
+    let task_id_owned = task_id.to_string();
+
+    let stdout_handle = tokio::spawn({
+        let emitter = emitter_clone.clone();
+        let task_id = task_id_owned.clone();
+        async move {
+            if let Some(out) = stdout {
+                let reader = BufReader::new(out);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    emit_agent_install_event(&emitter, &task_id, AgentInstallEventKind::Log, &line);
+                }
+            }
+        }
+    });
+
+    let stderr_handle = tokio::spawn({
+        let emitter = emitter_clone;
+        let task_id = task_id_owned;
+        async move {
+            let mut collected = String::new();
+            if let Some(err) = stderr {
+                let reader = BufReader::new(err);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    emit_agent_install_event(&emitter, &task_id, AgentInstallEventKind::Log, &line);
+                    if !collected.is_empty() {
+                        collected.push('\n');
+                    }
+                    collected.push_str(&line);
+                }
+            }
+            collected
+        }
+    });
+
+    let (_, stderr_result) = tokio::join!(stdout_handle, stderr_handle);
+    let collected_stderr = stderr_result.unwrap_or_default();
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| AcpError::protocol(format!("failed to wait for shell command: {e}")))?;
 
     Ok((status.success(), collected_stderr))
 }
@@ -716,6 +878,151 @@ async fn uninstall_npm_from_user_prefix(package_name: &str) -> Result<(), AcpErr
     }
 
     Ok(())
+}
+
+const GROK_INSTALL_COMMAND: &str = "curl -fsSL https://x.ai/cli/install.sh | bash";
+
+async fn prepare_local_command_agent(
+    agent_type: AgentType,
+    cmd: &str,
+    force_reinstall: bool,
+    task_id: &str,
+    emitter: &EventEmitter,
+) -> Result<String, AcpError> {
+    if agent_type != AgentType::Grok {
+        return Err(AcpError::protocol(format!(
+            "local install is not supported for {}",
+            registry::get_agent_meta(agent_type).name
+        )));
+    }
+
+    if resolve_local_command(cmd).is_some() {
+        let update_command = if force_reinstall {
+            "grok update --force-reinstall"
+        } else {
+            "grok update"
+        };
+        emit_agent_install_event(
+            emitter,
+            task_id,
+            AgentInstallEventKind::Log,
+            format!("$ {update_command}"),
+        );
+        let (success, stderr) = run_shell_streaming(update_command, task_id, emitter).await?;
+        if !success {
+            let err = stderr.trim();
+            return Err(AcpError::protocol(if err.is_empty() {
+                "failed to update Grok CLI".to_string()
+            } else {
+                format!("failed to update Grok CLI: {err}")
+            }));
+        }
+    } else {
+        emit_agent_install_event(
+            emitter,
+            task_id,
+            AgentInstallEventKind::Log,
+            format!("$ {GROK_INSTALL_COMMAND}"),
+        );
+        let (success, stderr) = run_shell_streaming(GROK_INSTALL_COMMAND, task_id, emitter).await?;
+        if !success {
+            let err = stderr.trim();
+            return Err(AcpError::protocol(if err.is_empty() {
+                "failed to install Grok CLI".to_string()
+            } else {
+                format!("failed to install Grok CLI: {err}")
+            }));
+        }
+    }
+
+    detect_local_version(agent_type)
+        .await
+        .ok_or_else(|| AcpError::protocol("Grok CLI installed but version could not be detected"))
+}
+
+fn remove_local_command_agent(agent_type: AgentType, cmd: &str) -> Result<(), AcpError> {
+    if agent_type != AgentType::Grok {
+        return Err(AcpError::protocol(format!(
+            "local uninstall is not supported for {}",
+            registry::get_agent_meta(agent_type).name
+        )));
+    }
+
+    let home =
+        dirs::home_dir().ok_or_else(|| AcpError::protocol("failed to determine home directory"))?;
+    let grok_bin = home.join(".grok").join("bin");
+    let grok_downloads = home.join(".grok").join("downloads");
+    let local_bin = home.join(".local").join("bin");
+    let candidates = [
+        grok_bin.join(cmd),
+        grok_bin.join("agent"),
+        local_bin.join(cmd),
+        local_bin.join("agent"),
+        PathBuf::from("/usr/local/bin").join(cmd),
+        PathBuf::from("/usr/local/bin").join("agent"),
+    ];
+    let mut removed_any = false;
+    for path in candidates {
+        if is_grok_installer_link(&path, &grok_bin)? {
+            fs::remove_file(&path).map_err(|e| {
+                AcpError::protocol(format!("failed to remove {}: {e}", path.display()))
+            })?;
+            removed_any = true;
+        }
+    }
+
+    if grok_downloads.exists() {
+        for entry in fs::read_dir(&grok_downloads).map_err(|e| {
+            AcpError::protocol(format!("failed to read {}: {e}", grok_downloads.display()))
+        })? {
+            let path = entry
+                .map_err(|e| AcpError::protocol(format!("failed to read Grok download: {e}")))?
+                .path();
+            let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if file_name.starts_with("grok-") {
+                fs::remove_file(&path).map_err(|e| {
+                    AcpError::protocol(format!("failed to remove {}: {e}", path.display()))
+                })?;
+                removed_any = true;
+            }
+        }
+    }
+
+    if !removed_any && resolve_local_command(cmd).is_some() {
+        return Err(AcpError::protocol(format!(
+            "{cmd} is installed outside the managed Grok CLI paths; remove it manually"
+        )));
+    }
+
+    Ok(())
+}
+
+fn is_grok_installer_link(path: &Path, grok_bin: &Path) -> Result<bool, AcpError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    if path.starts_with(grok_bin) {
+        return Ok(true);
+    }
+    let metadata = fs::symlink_metadata(path).map_err(|e| {
+        AcpError::protocol(format!("failed to inspect {}: {e}", path.display()))
+    })?;
+    if !metadata.file_type().is_symlink() {
+        return Ok(false);
+    }
+    let target = fs::read_link(path).map_err(|e| {
+        AcpError::protocol(format!("failed to inspect {}: {e}", path.display()))
+    })?;
+    let absolute_target = if target.is_absolute() {
+        target
+    } else {
+        path.parent()
+            .map(|parent| parent.join(&target))
+            .unwrap_or(target)
+    };
+    Ok(absolute_target.starts_with(grok_bin))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1579,6 +1886,14 @@ pub(crate) fn skill_storage_spec(agent_type: AgentType) -> Option<SkillStorageSp
                 ".claude/skills",
             ],
         }),
+        AgentType::Grok => Some(SkillStorageSpec {
+            kind: SkillStorageKind::SkillDirectoryOnly,
+            global_dirs: vec![
+                home_dir_or_default().join(".grok").join("skills"),
+                home_dir_or_default().join(".agents").join("skills"),
+            ],
+            project_rel_dirs: vec![".grok/skills", ".agents/skills"],
+        }),
     }
 }
 
@@ -2069,7 +2384,7 @@ fn cascade_update_agent_config(
                 serde_json::to_string(&patch).map_err(|e| AcpError::protocol(e.to_string()))?;
             persist_agent_local_config_json(agent_type, Some(&patch_str))?;
         }
-        AgentType::Cline => {}
+        AgentType::Cline | AgentType::Grok => {}
     }
     Ok(())
 }
@@ -2366,6 +2681,15 @@ pub(crate) async fn acp_get_agent_status_core(
         .map_err(|e| AcpError::protocol(e.to_string()))?;
 
     let (available, installed_version) = match &meta.distribution {
+        registry::AgentDistribution::LocalCommand { cmd, .. } => {
+            let available = resolve_local_command(cmd).is_some();
+            let detected = if available {
+                detect_local_version(agent_type).await
+            } else {
+                None
+            };
+            (available, detected)
+        }
         registry::AgentDistribution::Npx { cmd, .. } => (
             true,
             resolve_npx_command(cmd)
@@ -2426,6 +2750,15 @@ pub(crate) async fn acp_list_agents_core(db: &AppDatabase) -> Result<Vec<AcpAgen
         let setting = settings_map.get(&agent_type);
         let meta = registry::get_agent_meta(agent_type);
         let (available, dist_type, local_installed_version) = match &meta.distribution {
+            registry::AgentDistribution::LocalCommand { cmd, .. } => {
+                let available = resolve_local_command(cmd).is_some();
+                let detected = if available {
+                    detect_local_version(agent_type).await
+                } else {
+                    None
+                };
+                (available, "local", detected)
+            }
             registry::AgentDistribution::Npx { cmd, .. } => {
                 // Keep the list path bounded: each list request probes npm
                 // global prefix at most once, then reuses the result across
@@ -2477,8 +2810,9 @@ pub(crate) async fn acp_list_agents_core(db: &AppDatabase) -> Result<Vec<AcpAgen
             }
         }
         let sort_order = setting.map(|m| m.sort_order).unwrap_or(idx as i32);
-        // Persist detected version to DB for binary agents (npx written during install/upgrade)
-        if dist_type == "binary" {
+        let registry_version = detect_registry_version(agent_type).await;
+        // Persist detected version to DB for binary/local agents (npx written during install/upgrade)
+        if dist_type == "binary" || dist_type == "local" {
             let _ = agent_setting_service::set_installed_version(
                 &db.conn,
                 agent_type,
@@ -2510,7 +2844,7 @@ pub(crate) async fn acp_list_agents_core(db: &AppDatabase) -> Result<Vec<AcpAgen
         agents.push(AcpAgentInfo {
             agent_type,
             registry_id: registry::registry_id_for(agent_type).to_string(),
-            registry_version: meta.registry_version().map(ToString::to_string),
+            registry_version,
             name: meta.name.to_string(),
             description: meta.description.to_string(),
             available,
@@ -2892,7 +3226,8 @@ pub(crate) async fn acp_download_agent_binary_core(
             emit_acp_agents_updated(emitter, "binary_downloaded", Some(agent_type));
             Ok(())
         }
-        registry::AgentDistribution::Npx { .. } => Err(AcpError::protocol(
+        registry::AgentDistribution::Npx { .. }
+        | registry::AgentDistribution::LocalCommand { .. } => Err(AcpError::protocol(
             "download is only supported for binary agents",
         )),
     };
@@ -3049,7 +3384,8 @@ pub(crate) async fn acp_prepare_npx_agent_core(
             emit_acp_agents_updated(emitter, "npx_prepared", Some(agent_type));
             Ok(resolved)
         }
-        registry::AgentDistribution::Binary { .. } => Err(AcpError::protocol(
+        registry::AgentDistribution::Binary { .. }
+        | registry::AgentDistribution::LocalCommand { .. } => Err(AcpError::protocol(
             "prepare is only supported for npx agents",
         )),
     };
@@ -3114,6 +3450,95 @@ pub async fn acp_prepare_npx_agent(
     .await
 }
 
+pub(crate) async fn acp_prepare_local_agent_core(
+    agent_type: AgentType,
+    force_reinstall: bool,
+    task_id: String,
+    db: &AppDatabase,
+    emitter: &EventEmitter,
+) -> Result<String, AcpError> {
+    emit_agent_install_event(emitter, &task_id, AgentInstallEventKind::Started, "");
+
+    let meta = registry::get_agent_meta(agent_type);
+    let result = match meta.distribution {
+        registry::AgentDistribution::LocalCommand { cmd, .. } => {
+            let default = agent_setting_service::AgentDefaultInput {
+                agent_type,
+                registry_id: registry::registry_id_for(agent_type).to_string(),
+                default_sort_order: i32::MAX / 2,
+            };
+            agent_setting_service::ensure_defaults(&db.conn, &[default])
+                .await
+                .map_err(|e| AcpError::protocol(e.to_string()))?;
+
+            emit_agent_install_event(
+                emitter,
+                &task_id,
+                AgentInstallEventKind::Log,
+                format!("Preparing {} local CLI...", meta.name),
+            );
+            let resolved =
+                prepare_local_command_agent(agent_type, cmd, force_reinstall, &task_id, emitter)
+                    .await?;
+
+            agent_setting_service::set_installed_version(
+                &db.conn,
+                agent_type,
+                Some(resolved.clone()),
+            )
+            .await
+            .map_err(|e| AcpError::protocol(e.to_string()))?;
+            emit_acp_agents_updated(emitter, "local_prepared", Some(agent_type));
+            Ok(resolved)
+        }
+        registry::AgentDistribution::Npx { .. } | registry::AgentDistribution::Binary { .. } => {
+            Err(AcpError::protocol(
+                "prepare local is only supported for local command agents",
+            ))
+        }
+    };
+
+    match &result {
+        Ok(version) => {
+            emit_agent_install_event(
+                emitter,
+                &task_id,
+                AgentInstallEventKind::Completed,
+                format!("{} v{version} is ready", meta.name),
+            );
+        }
+        Err(e) => {
+            emit_agent_install_event(
+                emitter,
+                &task_id,
+                AgentInstallEventKind::Failed,
+                e.to_string(),
+            );
+        }
+    }
+    result
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn acp_prepare_local_agent(
+    agent_type: AgentType,
+    force_reinstall: Option<bool>,
+    task_id: String,
+    db: State<'_, AppDatabase>,
+    app: tauri::AppHandle,
+) -> Result<String, AcpError> {
+    let emitter = EventEmitter::Tauri(app);
+    acp_prepare_local_agent_core(
+        agent_type,
+        force_reinstall.unwrap_or(false),
+        task_id,
+        &db,
+        &emitter,
+    )
+    .await
+}
+
 pub(crate) async fn acp_uninstall_agent_core(
     agent_type: AgentType,
     task_id: String,
@@ -3137,6 +3562,9 @@ pub(crate) async fn acp_uninstall_agent_core(
             }
             registry::AgentDistribution::Npx { package, .. } => {
                 uninstall_npm_global_package(package).await?;
+            }
+            registry::AgentDistribution::LocalCommand { cmd, .. } => {
+                remove_local_command_agent(agent_type, cmd)?;
             }
         }
 

--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -173,6 +173,11 @@ pub async fn get_conversation(
             AgentType::Gemini => Box::new(GeminiParser::new()),
             AgentType::OpenClaw => Box::new(OpenClawParser::new()),
             AgentType::Cline => Box::new(ClineParser::new()),
+            AgentType::Grok => {
+                return Err(AppCommandError::invalid_input(
+                    "Grok transcript import is not supported yet",
+                ))
+            }
         };
 
         parser
@@ -288,6 +293,14 @@ pub async fn get_folder_conversation_core(
         .await
         .map_err(AppCommandError::from)?;
 
+    if summary.agent_type == AgentType::Grok {
+        return Ok(DbConversationDetail {
+            summary,
+            turns: vec![],
+            session_stats: None,
+        });
+    }
+
     let (turns, session_stats, resolved_ext_id) = if let Some(ref ext_id) = summary.external_id {
         let at = summary.agent_type;
         let eid = ext_id.clone();
@@ -307,6 +320,11 @@ pub async fn get_folder_conversation_core(
                 AgentType::Gemini => Box::new(GeminiParser::new()),
                 AgentType::OpenClaw => Box::new(OpenClawParser::new()),
                 AgentType::Cline => Box::new(ClineParser::new()),
+                AgentType::Grok => {
+                    return Err(AppCommandError::invalid_input(
+                        "Grok transcript import is not supported yet",
+                    ))
+                }
             };
             match parser.get_conversation(&eid) {
                 Ok(d) => Ok((d.turns, d.session_stats, None)),

--- a/src-tauri/src/commands/experts.rs
+++ b/src-tauri/src/commands/experts.rs
@@ -779,6 +779,7 @@ fn supported_agents() -> Vec<AgentType> {
         AgentType::Gemini,
         AgentType::OpenClaw,
         AgentType::Cline,
+        AgentType::Grok,
     ];
     ALL.iter()
         .filter(|a| skill_storage_spec(**a).is_some())

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -54,6 +54,7 @@ pub enum McpAppType {
     OpenClaw,
     OpenCode,
     Cline,
+    Grok,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -367,6 +368,7 @@ pub async fn mcp_upsert_local_server(
         McpAppType::OpenClaw,
         McpAppType::OpenCode,
         McpAppType::Cline,
+        McpAppType::Grok,
     ];
 
     for app in all_apps {
@@ -421,6 +423,7 @@ pub async fn mcp_remove_server(
             McpAppType::OpenClaw,
             McpAppType::OpenCode,
             McpAppType::Cline,
+            McpAppType::Grok,
         ],
     };
 
@@ -637,6 +640,10 @@ fn cline_config_path() -> PathBuf {
         .join("cline_mcp_settings.json")
 }
 
+fn grok_config_path() -> PathBuf {
+    home_dir_or_default().join(".grok").join("config.toml")
+}
+
 fn read_json_file(path: &Path) -> Result<Value, AppCommandError> {
     if !path.exists() {
         return Ok(json!({}));
@@ -683,6 +690,42 @@ fn read_codex_root_toml() -> Result<toml::Value, AppCommandError> {
 
 fn write_codex_root_toml(root: &toml::Value) -> Result<(), AppCommandError> {
     let path = codex_config_toml_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(AppCommandError::io)?;
+    }
+
+    let serialized = toml::to_string_pretty(root).map_err(|e| {
+        mcp_configuration_invalid(format!(
+            "failed to serialize TOML for {}: {e}",
+            path.display()
+        ))
+    })?;
+    fs::write(&path, format!("{serialized}\n")).map_err(AppCommandError::io)
+}
+
+fn read_grok_root_toml() -> Result<toml::Value, AppCommandError> {
+    let path = grok_config_path();
+    if !path.exists() {
+        return Ok(toml::Value::Table(toml::map::Map::new()));
+    }
+
+    let raw = fs::read_to_string(&path).map_err(AppCommandError::io)?;
+    let parsed = raw.parse::<toml::Value>().map_err(|e| {
+        mcp_configuration_invalid(format!("invalid TOML at {}: {e}", path.display()))
+    })?;
+
+    if !parsed.is_table() {
+        return Err(mcp_configuration_invalid(format!(
+            "invalid TOML root at {}: expected table",
+            path.display()
+        )));
+    }
+
+    Ok(parsed)
+}
+
+fn write_grok_root_toml(root: &toml::Value) -> Result<(), AppCommandError> {
+    let path = grok_config_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(AppCommandError::io)?;
     }
@@ -1410,6 +1453,113 @@ fn canonical_to_codex_entry(spec: &Value) -> Result<toml::Value, AppCommandError
     Ok(toml::Value::Table(table))
 }
 
+fn canonical_to_grok_entry(spec: &Value) -> Result<toml::Value, AppCommandError> {
+    let canonical = canonicalize_spec(spec, "Grok conversion")?;
+    let obj = canonical
+        .as_object()
+        .ok_or_else(|| mcp_invalid_input("Grok conversion: canonical spec must be an object"))?;
+
+    let typ = obj.get("type").and_then(Value::as_str).unwrap_or("stdio");
+    let mut table = toml::map::Map::new();
+
+    match typ {
+        "stdio" => {
+            let command = obj.get("command").and_then(Value::as_str).ok_or_else(|| {
+                mcp_invalid_input("Grok conversion: stdio MCP spec missing command")
+            })?;
+            table.insert(
+                "command".to_string(),
+                toml::Value::String(command.to_string()),
+            );
+
+            if let Some(args) = obj.get("args").and_then(Value::as_array) {
+                let values = args
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|value| toml::Value::String(value.to_string()))
+                    .collect::<Vec<_>>();
+                if !values.is_empty() {
+                    table.insert("args".to_string(), toml::Value::Array(values));
+                }
+            }
+
+            if let Some(env) = obj.get("env").and_then(Value::as_object) {
+                let mut env_table = toml::map::Map::new();
+                for (key, value) in env {
+                    let Some(text) = value.as_str() else {
+                        continue;
+                    };
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        env_table.insert(key.to_string(), toml::Value::String(trimmed.to_string()));
+                    }
+                }
+                if !env_table.is_empty() {
+                    table.insert("env".to_string(), toml::Value::Table(env_table));
+                }
+            }
+
+            if let Some(cwd) = obj
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                table.insert("cwd".to_string(), toml::Value::String(cwd.to_string()));
+            }
+        }
+        "http" | "sse" => {
+            table.insert("type".to_string(), toml::Value::String(typ.to_string()));
+            let url = obj.get("url").and_then(Value::as_str).ok_or_else(|| {
+                mcp_invalid_input("Grok conversion: remote MCP spec missing url")
+            })?;
+            table.insert("url".to_string(), toml::Value::String(url.to_string()));
+
+            if let Some(headers) = obj.get("headers").and_then(Value::as_object) {
+                let mut headers_table = toml::map::Map::new();
+                for (key, value) in headers {
+                    let Some(text) = value.as_str() else {
+                        continue;
+                    };
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() {
+                        headers_table
+                            .insert(key.to_string(), toml::Value::String(trimmed.to_string()));
+                    }
+                }
+                if !headers_table.is_empty() {
+                    table.insert("headers".to_string(), toml::Value::Table(headers_table));
+                }
+            }
+        }
+        _ => {
+            return Err(mcp_invalid_input(format!(
+                "Grok conversion: unsupported MCP type '{typ}'"
+            )));
+        }
+    }
+
+    for (key, value) in obj {
+        if key == "type"
+            || key == "command"
+            || key == "args"
+            || key == "env"
+            || key == "cwd"
+            || key == "url"
+            || key == "headers"
+        {
+            continue;
+        }
+        if let Some(converted) = json_to_toml_value(value) {
+            table.insert(key.to_string(), converted);
+        }
+    }
+
+    Ok(toml::Value::Table(table))
+}
+
 fn read_claude_servers() -> Result<BTreeMap<String, Value>, AppCommandError> {
     let path = claude_config_path();
     let root = read_json_file(&path)?;
@@ -2027,6 +2177,89 @@ fn remove_cline_server(id: &str) -> Result<bool, AppCommandError> {
     Ok(removed)
 }
 
+// ---------------------------------------------------------------------------
+// Grok  (~/.grok/config.toml  →  [mcp_servers.<name>])
+// ---------------------------------------------------------------------------
+
+fn read_grok_servers() -> Result<BTreeMap<String, Value>, AppCommandError> {
+    let root = read_grok_root_toml()?;
+    let mut out = BTreeMap::new();
+
+    let Some(servers) = root.get("mcp_servers").and_then(toml::Value::as_table) else {
+        return Ok(out);
+    };
+
+    for (id, entry) in servers {
+        match codex_entry_to_canonical(id, entry) {
+            Ok(normalized) => {
+                out.insert(id.to_string(), normalized);
+            }
+            Err(err) => {
+                eprintln!("[MCP] skip invalid Grok MCP entry id={id}: {err}");
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn upsert_grok_server(id: &str, spec: &Value) -> Result<(), AppCommandError> {
+    let mut root = read_grok_root_toml()?;
+    let table = root.as_table_mut().ok_or_else(|| {
+        mcp_configuration_invalid(format!(
+            "invalid TOML root in {}: expected table",
+            grok_config_path().display()
+        ))
+    })?;
+
+    if !table
+        .get("mcp_servers")
+        .map(toml::Value::is_table)
+        .unwrap_or(false)
+    {
+        table.insert(
+            "mcp_servers".to_string(),
+            toml::Value::Table(toml::map::Map::new()),
+        );
+    }
+
+    let servers = table
+        .get_mut("mcp_servers")
+        .and_then(toml::Value::as_table_mut)
+        .ok_or_else(|| {
+            mcp_configuration_invalid(format!(
+                "invalid mcp_servers in {}",
+                grok_config_path().display()
+            ))
+        })?;
+    servers.insert(id.to_string(), canonical_to_grok_entry(spec)?);
+
+    write_grok_root_toml(&root)
+}
+
+fn remove_grok_server(id: &str) -> Result<bool, AppCommandError> {
+    let path = grok_config_path();
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let mut root = read_grok_root_toml()?;
+    let Some(table) = root.as_table_mut() else {
+        return Ok(false);
+    };
+    let removed = table
+        .get_mut("mcp_servers")
+        .and_then(toml::Value::as_table_mut)
+        .map(|servers| servers.remove(id).is_some())
+        .unwrap_or(false);
+
+    if removed {
+        write_grok_root_toml(&root)?;
+    }
+
+    Ok(removed)
+}
+
 fn scan_local_servers() -> Result<Vec<LocalMcpServer>, AppCommandError> {
     let mut merged: BTreeMap<String, (Value, BTreeSet<McpAppType>)> = BTreeMap::new();
 
@@ -2072,6 +2305,13 @@ fn scan_local_servers() -> Result<Vec<LocalMcpServer>, AppCommandError> {
         entry.1.insert(McpAppType::Cline);
     }
 
+    for (id, spec) in read_grok_servers()? {
+        let entry = merged
+            .entry(id)
+            .or_insert_with(|| (spec.clone(), BTreeSet::new()));
+        entry.1.insert(McpAppType::Grok);
+    }
+
     Ok(merged
         .into_iter()
         .map(|(id, (spec, apps))| LocalMcpServer {
@@ -2095,6 +2335,7 @@ fn upsert_server_for_app(app: McpAppType, id: &str, spec: &Value) -> Result<(), 
         McpAppType::Gemini => upsert_gemini_server(id, spec),
         McpAppType::OpenClaw => upsert_openclaw_server(id, spec),
         McpAppType::Cline => upsert_cline_server(id, spec),
+        McpAppType::Grok => upsert_grok_server(id, spec),
     }
 }
 
@@ -2109,6 +2350,7 @@ pub fn read_servers_for_agent_type(
         AgentType::Gemini => read_gemini_servers(),
         AgentType::OpenClaw => read_openclaw_servers(),
         AgentType::Cline => read_cline_servers(),
+        AgentType::Grok => read_grok_servers(),
     }
 }
 
@@ -2120,6 +2362,7 @@ fn remove_server_for_app(app: McpAppType, id: &str) -> Result<bool, AppCommandEr
         McpAppType::Gemini => remove_gemini_server(id),
         McpAppType::OpenClaw => remove_openclaw_server(id),
         McpAppType::Cline => remove_cline_server(id),
+        McpAppType::Grok => remove_grok_server(id),
     }
 }
 

--- a/src-tauri/src/db/service/agent_setting_service.rs
+++ b/src-tauri/src/db/service/agent_setting_service.rs
@@ -34,6 +34,7 @@ fn default_enabled(agent_type: AgentType) -> bool {
             | AgentType::OpenCode
             | AgentType::OpenClaw
             | AgentType::Cline
+            | AgentType::Grok
     )
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -774,6 +774,7 @@ mod tauri_app {
                 acp_commands::acp_download_agent_binary,
                 acp_commands::acp_detect_agent_local_version,
                 acp_commands::acp_prepare_npx_agent,
+                acp_commands::acp_prepare_local_agent,
                 acp_commands::acp_uninstall_agent,
                 acp_commands::acp_update_agent_preferences,
                 acp_commands::acp_update_agent_env,

--- a/src-tauri/src/models/agent.rs
+++ b/src-tauri/src/models/agent.rs
@@ -10,6 +10,7 @@ pub enum AgentType {
     Gemini,
     OpenClaw,
     Cline,
+    Grok,
 }
 
 impl fmt::Display for AgentType {
@@ -21,6 +22,7 @@ impl fmt::Display for AgentType {
             AgentType::Gemini => write!(f, "Gemini CLI"),
             AgentType::OpenClaw => write!(f, "OpenClaw"),
             AgentType::Cline => write!(f, "Cline"),
+            AgentType::Grok => write!(f, "Grok"),
         }
     }
 }

--- a/src-tauri/src/web/handlers/acp.rs
+++ b/src-tauri/src/web/handlers/acp.rs
@@ -595,6 +595,33 @@ pub async fn acp_prepare_npx_agent(
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AcpPrepareLocalAgentParams {
+    pub agent_type: AgentType,
+    #[serde(default)]
+    pub force_reinstall: bool,
+    pub task_id: String,
+}
+
+pub async fn acp_prepare_local_agent(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<AcpPrepareLocalAgentParams>,
+) -> Result<Json<String>, AppCommandError> {
+    let db = &state.db;
+    let emitter = state.emitter.clone();
+    let result = acp_commands::acp_prepare_local_agent_core(
+        params.agent_type,
+        params.force_reinstall,
+        params.task_id,
+        db,
+        &emitter,
+    )
+    .await
+    .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))?;
+    Ok(Json(result))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AcpUninstallAgentParams {
     pub agent_type: AgentType,
     pub task_id: String,

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -490,6 +490,10 @@ pub fn build_router(
             post(handlers::acp::acp_prepare_npx_agent),
         )
         .route(
+            "/acp_prepare_local_agent",
+            post(handlers::acp::acp_prepare_local_agent),
+        )
+        .route(
             "/acp_uninstall_agent",
             post(handlers::acp::acp_uninstall_agent),
         )

--- a/src/components/agent-icon.tsx
+++ b/src/components/agent-icon.tsx
@@ -4,7 +4,7 @@ import type { AgentType } from "@/lib/types"
 import { AGENT_COLORS } from "@/lib/types"
 import { cn } from "@/lib/utils"
 
-import { Cline, GeminiCLI, OpenClaw, OpenCode } from "@lobehub/icons"
+import { Cline, GeminiCLI, Grok, OpenClaw, OpenCode } from "@lobehub/icons"
 
 interface AgentIconProps {
   agentType: AgentType
@@ -91,6 +91,7 @@ const COLOR_ICONS: Partial<Record<AgentType, AnyIcon>> = {
 const MONO_ICONS: Partial<Record<AgentType, AnyIcon>> = {
   open_code: OpenCode,
   cline: Cline,
+  grok: Grok,
 }
 
 // Text-color versions for Mono icons

--- a/src/components/settings/acp-agent-settings.tsx
+++ b/src/components/settings/acp-agent-settings.tsx
@@ -71,6 +71,7 @@ import {
   acpDownloadAgentBinary,
   acpListAgents,
   acpPreflight,
+  acpPrepareLocalAgent,
   acpPrepareNpxAgent,
   acpReorderAgents,
   acpUninstallAgent,
@@ -149,8 +150,11 @@ type RunningActionKind =
   | "upgrade_binary"
   | "install_npx"
   | "upgrade_npx"
+  | "install_local"
+  | "upgrade_local"
   | "uninstall_binary"
   | "uninstall_npx"
+  | "uninstall_local"
   | "redownload_binary"
 
 type UiFixAction =
@@ -162,8 +166,11 @@ type UiFixAction =
         | "upgrade_binary"
         | "install_npx"
         | "upgrade_npx"
+        | "install_local"
+        | "upgrade_local"
         | "uninstall_binary"
         | "uninstall_npx"
+        | "uninstall_local"
         | "install_opencode_plugins"
       payload: string
     }
@@ -2429,6 +2436,157 @@ function hasComparableVersion(
 }
 
 function buildVersionCheck(agent: AcpAgentInfo): UiCheckItem | null {
+  if (agent.distribution_type === "local") {
+    const remoteVersion = agent.registry_version ?? "unknown"
+    const localVersion =
+      agent.installed_version ??
+      acpText("version.notInstalled", "Not installed")
+    const versionText = acpText(
+      "version.remoteLocal",
+      "Remote: {remoteVersion} · Local: {localVersion}",
+      { remoteVersion, localVersion }
+    )
+
+    if (!agent.available) {
+      return {
+        check_id: "version_status",
+        label: acpText("version.statusLabel", "Version Status"),
+        status: "fail",
+        message: acpText(
+          "version.localCommandUnavailable",
+          "{versionText}. Local CLI command is not available.",
+          { versionText }
+        ),
+        fixes: [
+          {
+            label: acpText("actions.install", "Install"),
+            kind: "install_local",
+            payload: agent.agent_type,
+          },
+        ],
+      }
+    }
+
+    if (!agent.installed_version) {
+      return {
+        check_id: "version_status",
+        label: acpText("version.statusLabel", "Version Status"),
+        status: "fail",
+        message: acpText(
+          "version.clickInstall",
+          "{versionText}. Click Install on the right.",
+          { versionText }
+        ),
+        fixes: [
+          {
+            label: acpText("actions.install", "Install"),
+            kind: "install_local",
+            payload: agent.agent_type,
+          },
+        ],
+      }
+    }
+
+    if (
+      agent.registry_version &&
+      hasComparableVersion(agent.registry_version) &&
+      !hasComparableVersion(agent.installed_version)
+    ) {
+      return {
+        check_id: "version_status",
+        label: acpText("version.statusLabel", "Version Status"),
+        status: "warn",
+        message: acpText(
+          "version.localUnrecognized",
+          "{versionText}. Local version is not comparable; try upgrade to overwrite install.",
+          { versionText }
+        ),
+        fixes: [
+          {
+            label: acpText("actions.upgrade", "Upgrade"),
+            kind: "upgrade_local",
+            payload: agent.agent_type,
+          },
+          {
+            label: acpText("actions.uninstall", "Uninstall"),
+            kind: "uninstall_local",
+            payload: agent.agent_type,
+          },
+        ],
+      }
+    }
+
+    if (
+      hasComparableVersion(agent.registry_version) &&
+      hasComparableVersion(agent.installed_version) &&
+      compareVersion(agent.installed_version, agent.registry_version) < 0
+    ) {
+      return {
+        check_id: "version_status",
+        label: acpText("version.statusLabel", "Version Status"),
+        status: "warn",
+        message: acpText(
+          "version.upgradeAvailable",
+          "{versionText}. Upgrade available.",
+          { versionText }
+        ),
+        fixes: [
+          {
+            label: acpText("actions.upgrade", "Upgrade"),
+            kind: "upgrade_local",
+            payload: agent.agent_type,
+          },
+          {
+            label: acpText("actions.uninstall", "Uninstall"),
+            kind: "uninstall_local",
+            payload: agent.agent_type,
+          },
+        ],
+      }
+    }
+
+    if (!agent.registry_version) {
+      return {
+        check_id: "version_status",
+        label: acpText("version.statusLabel", "Version Status"),
+        status: "warn",
+        message: acpText(
+          "version.remoteUnavailable",
+          "{versionText}. Remote version is currently unavailable.",
+          { versionText }
+        ),
+        fixes: [
+          {
+            label: acpText("actions.upgrade", "Upgrade"),
+            kind: "upgrade_local",
+            payload: agent.agent_type,
+          },
+          {
+            label: acpText("actions.uninstall", "Uninstall"),
+            kind: "uninstall_local",
+            payload: agent.agent_type,
+          },
+        ],
+      }
+    }
+
+    return {
+      check_id: "version_status",
+      label: acpText("version.statusLabel", "Version Status"),
+      status: "pass",
+      message: acpText("version.latest", "{versionText}. Already latest.", {
+        versionText,
+      }),
+      fixes: [
+        {
+          label: acpText("actions.uninstall", "Uninstall"),
+          kind: "uninstall_local",
+          payload: agent.agent_type,
+        },
+      ],
+    }
+  }
+
   if (agent.distribution_type !== "binary" && agent.distribution_type !== "npx")
     return null
 
@@ -3235,6 +3393,88 @@ export function AcpAgentSettings() {
     [runPreflight, t, installStream.start]
   )
 
+  const runLocalAction = useCallback(
+    async (agent: AcpAgentInfo, mode: "install" | "upgrade") => {
+      if (busyActionRef.current.has(agent.agent_type)) return
+      busyActionRef.current.add(agent.agent_type)
+      setBusyBinaryAction((prev) => ({ ...prev, [agent.agent_type]: true }))
+      setRunningActionKind((prev) => ({
+        ...prev,
+        [agent.agent_type]:
+          mode === "install" ? "install_local" : "upgrade_local",
+      }))
+      const taskId = randomUUID()
+      setStreamAgentType(agent.agent_type)
+      await installStream.start(taskId)
+      try {
+        const installedVersion = await acpPrepareLocalAgent(
+          agent.agent_type,
+          taskId,
+          mode === "upgrade"
+        )
+        setAgents((prev) =>
+          prev.map((item) =>
+            item.agent_type === agent.agent_type
+              ? {
+                  ...item,
+                  available: true,
+                  installed_version: installedVersion,
+                }
+              : item
+          )
+        )
+        await runPreflight(agent.agent_type)
+        const detectedVersion = await acpDetectAgentLocalVersion(
+          agent.agent_type
+        )
+        if (detectedVersion && detectedVersion !== installedVersion) {
+          setAgents((prev) =>
+            prev.map((item) =>
+              item.agent_type === agent.agent_type
+                ? { ...item, installed_version: detectedVersion }
+                : item
+            )
+          )
+        }
+        const finalVersion = detectedVersion ?? installedVersion
+        toast.success(
+          t("toasts.agentActionCompleted", {
+            name: agent.name,
+            action:
+              mode === "upgrade" ? t("actions.upgrade") : t("actions.install"),
+          }),
+          {
+            description: finalVersion
+              ? t("toasts.localVersion", { version: finalVersion })
+              : t("toasts.installCompletedVersionLater"),
+          }
+        )
+      } catch (err) {
+        const message = toErrorMessage(err)
+        toast.error(
+          t("toasts.agentActionFailed", {
+            name: agent.name,
+            action:
+              mode === "upgrade" ? t("actions.upgrade") : t("actions.install"),
+          }),
+          {
+            description: message,
+          }
+        )
+        throw err
+      } finally {
+        busyActionRef.current.delete(agent.agent_type)
+        setBusyBinaryAction((prev) => ({ ...prev, [agent.agent_type]: false }))
+        setRunningActionKind((prev) => ({
+          ...prev,
+          [agent.agent_type]: undefined,
+        }))
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runPreflight, t, installStream.start]
+  )
+
   const runUninstallAction = useCallback(
     async (agent: AcpAgentInfo) => {
       if (busyActionRef.current.has(agent.agent_type)) return
@@ -3245,7 +3485,9 @@ export function AcpAgentSettings() {
         [agent.agent_type]:
           agent.distribution_type === "binary"
             ? "uninstall_binary"
-            : "uninstall_npx",
+            : agent.distribution_type === "local"
+              ? "uninstall_local"
+              : "uninstall_npx",
       }))
       const taskId = randomUUID()
       setStreamAgentType(agent.agent_type)
@@ -3255,7 +3497,14 @@ export function AcpAgentSettings() {
         setAgents((prev) =>
           prev.map((item) =>
             item.agent_type === agent.agent_type
-              ? { ...item, installed_version: null }
+              ? {
+                  ...item,
+                  available:
+                    agent.distribution_type === "local"
+                      ? false
+                      : item.available,
+                  installed_version: null,
+                }
               : item
           )
         )
@@ -3309,7 +3558,19 @@ export function AcpAgentSettings() {
       await runNpxAction(agent, "upgrade")
       return
     }
-    if (action.kind === "uninstall_binary" || action.kind === "uninstall_npx") {
+    if (action.kind === "install_local") {
+      await runLocalAction(agent, "install")
+      return
+    }
+    if (action.kind === "upgrade_local") {
+      await runLocalAction(agent, "upgrade")
+      return
+    }
+    if (
+      action.kind === "uninstall_binary" ||
+      action.kind === "uninstall_npx" ||
+      action.kind === "uninstall_local"
+    ) {
       setUninstallConfirmAgent(agent)
       return
     }
@@ -3420,8 +3681,11 @@ export function AcpAgentSettings() {
                         "upgrade_binary",
                         "install_npx",
                         "upgrade_npx",
+                        "install_local",
+                        "upgrade_local",
                         "uninstall_binary",
                         "uninstall_npx",
+                        "uninstall_local",
                         "redownload_binary",
                         "install_opencode_plugins",
                       ].includes(fix.kind)
@@ -3435,14 +3699,17 @@ export function AcpAgentSettings() {
                     {runningActionKind[agent.agent_type] === fix.kind ? (
                       <Loader2 className="h-3 w-3 animate-spin" />
                     ) : fix.kind === "download_binary" ||
-                      fix.kind === "install_npx" ? (
+                      fix.kind === "install_npx" ||
+                      fix.kind === "install_local" ? (
                       <Download className="h-3 w-3" />
                     ) : fix.kind === "upgrade_binary" ||
                       fix.kind === "upgrade_npx" ||
+                      fix.kind === "upgrade_local" ||
                       fix.kind === "redownload_binary" ? (
                       <Wrench className="h-3 w-3" />
                     ) : fix.kind === "uninstall_binary" ||
-                      fix.kind === "uninstall_npx" ? (
+                      fix.kind === "uninstall_npx" ||
+                      fix.kind === "uninstall_local" ? (
                       <Trash2 className="h-3 w-3" />
                     ) : fix.kind === "install_opencode_plugins" ? (
                       <Download className="h-3 w-3" />
@@ -7176,7 +7443,7 @@ supports_websockets = true`}
                       </Button>
                     </div>
                   </div>
-                ) : (
+                ) : selectedAgent.agent_type === "grok" ? null : (
                   <div className="space-y-3 rounded-md border bg-muted/10 p-3">
                     <div>
                       <label className="text-xs font-medium">

--- a/src/components/settings/mcp-settings.tsx
+++ b/src/components/settings/mcp-settings.tsx
@@ -89,6 +89,7 @@ const APP_OPTIONS: { value: McpAppType; label: string }[] = [
   { value: "open_claw", label: "OpenClaw" },
   { value: "open_code", label: "OpenCode" },
   { value: "cline", label: "Cline" },
+  { value: "grok", label: "Grok" },
 ]
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -250,6 +251,7 @@ function appsToDraft(apps: McpAppType[]): Record<McpAppType, boolean> {
     open_claw: appSet.has("open_claw"),
     open_code: appSet.has("open_code"),
     cline: appSet.has("cline"),
+    grok: appSet.has("grok"),
   }
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -259,6 +259,18 @@ export async function acpPrepareNpxAgent(
   })
 }
 
+export async function acpPrepareLocalAgent(
+  agentType: AgentType,
+  taskId: string,
+  forceReinstall: boolean = false
+): Promise<string> {
+  return getTransport().call("acp_prepare_local_agent", {
+    agentType,
+    taskId,
+    forceReinstall,
+  })
+}
+
 export async function acpUninstallAgent(
   agentType: AgentType,
   taskId: string

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ export type AgentType =
   | "gemini"
   | "open_claw"
   | "cline"
+  | "grok"
 
 export type AppErrorCode =
   | "invalid_input"
@@ -295,6 +296,7 @@ export const AGENT_DISPLAY_ORDER: AgentType[] = [
   "gemini",
   "open_claw",
   "cline",
+  "grok",
 ]
 
 const AGENT_DISPLAY_ORDER_INDEX = new Map(
@@ -314,6 +316,7 @@ export const ALL_AGENT_TYPES: AgentType[] = [
   "gemini",
   "open_claw",
   "cline",
+  "grok",
 ]
 
 export const MODEL_PROVIDER_AGENT_TYPES: AgentType[] = [
@@ -329,6 +332,7 @@ export const AGENT_LABELS: Record<AgentType, string> = {
   gemini: "Gemini CLI",
   open_claw: "OpenClaw",
   cline: "Cline",
+  grok: "Grok",
 }
 
 export const AGENT_COLORS: Record<AgentType, string> = {
@@ -338,6 +342,7 @@ export const AGENT_COLORS: Record<AgentType, string> = {
   gemini: "bg-[#3186FF]",
   open_claw: "bg-emerald-600",
   cline: "bg-purple-500",
+  grok: "bg-[#111111]",
 }
 
 // ACP connection status (matches Rust ConnectionStatus)
@@ -885,6 +890,7 @@ export type McpAppType =
   | "open_claw"
   | "open_code"
   | "cline"
+  | "grok"
 
 export interface LocalMcpServer {
   id: string


### PR DESCRIPTION
## Summary
- add Grok as an ACP local-command agent using `grok agent stdio`
- add Grok install, update, uninstall, local version, and remote version handling based on the official Grok CLI flow
- add Grok UI support in agent settings, icons, MCP settings, expert skills, and default agent metadata
- avoid loading Grok DB conversations through unsupported transcript import paths

## Details
Grok is registered as a local command distribution instead of an npm package. The app resolves the local `grok` binary, checks `grok version`, uses `grok update --check --json` or the stable channel metadata for remote versions, installs through the official `https://x.ai/cli/install.sh` script, and removes installer-managed Grok binaries/downloads without deleting auth/config data.

The Agent SDK settings page now treats Grok like the other managed agents for install/update/uninstall and version display, while hiding the generic config-management panel because Grok is managed through its own CLI configuration.

## Validation
- `git diff --check`
- `cargo check`
- `cargo test acp::registry::tests::grok_is_registered_as_local_stdio_agent --lib`
- `corepack pnpm eslint src/components/settings/acp-agent-settings.tsx src/components/settings/mcp-settings.tsx src/components/agent-icon.tsx src/lib/api.ts src/lib/types.ts`
- `corepack pnpm build`
