### PR TITLE
fix(workspace): use --no-optional-locks for watcher git commands

### DIFF
--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -1568,6 +1568,21 @@ pub async fn git_status(
     path: String,
     show_all_untracked: Option<bool>,
 ) -> Result<Vec<GitStatusEntry>, AppCommandError> {
+    git_status_with_options(path, show_all_untracked, false).await
+}
+
+pub(crate) async fn git_status_no_optional_locks(
+    path: String,
+    show_all_untracked: Option<bool>,
+) -> Result<Vec<GitStatusEntry>, AppCommandError> {
+    git_status_with_options(path, show_all_untracked, true).await
+}
+
+async fn git_status_with_options(
+    path: String,
+    show_all_untracked: Option<bool>,
+    no_optional_locks: bool,
+) -> Result<Vec<GitStatusEntry>, AppCommandError> {
     ensure_git_repo(&path)?;
 
     let untracked_mode = if show_all_untracked.unwrap_or(false) {
@@ -1575,7 +1590,11 @@ pub async fn git_status(
     } else {
         "-unormal"
     };
-    let output = crate::process::tokio_command("git")
+    let mut command = crate::process::tokio_command("git");
+    if no_optional_locks {
+        command.arg("--no-optional-locks");
+    }
+    let output = command
         .args(["-c", "core.quotePath=false"])
         .args(["status", "--porcelain=v1", untracked_mode])
         .current_dir(&path)

--- a/src-tauri/src/workspace_state/mod.rs
+++ b/src-tauri/src/workspace_state/mod.rs
@@ -654,6 +654,7 @@ fn parse_numstat_value(raw: &str) -> i32 {
 async fn git_numstat_map(path: &str) -> HashMap<String, (i32, i32)> {
     async fn run_numstat(path: &str, args: &[&str]) -> Option<HashMap<String, (i32, i32)>> {
         let output = crate::process::tokio_command("git")
+            .arg("--no-optional-locks")
             .args(args)
             .current_dir(path)
             .output()
@@ -706,7 +707,7 @@ async fn collect_git_snapshot(path: &str) -> Result<Vec<WorkspaceGitEntry>, AppC
     // status + numstat don't depend on each other; run concurrently to cut
     // per-flush latency roughly in half on large repos.
     let (status_entries, stats) = tokio::join!(
-        folders::git_status(path.to_string(), Some(true)),
+        folders::git_status_no_optional_locks(path.to_string(), Some(true)),
         git_numstat_map(path),
     );
     let status_entries = status_entries?;


### PR DESCRIPTION
## 问题

codeg 的文件系统 watcher 在检测到变化时调用 `git status` 和 `git diff --numstat` 刷新面板状态。
这些命令会创建 `index.lock`，当 AI agent 同时执行 git 操作时，双方争抢锁文件导致其中一方失败。
agent 越活跃（频繁写文件），watcher 触发越频繁，冲突概率越高。

## 修复

为 watcher 的所有 git 调用添加 `--no-optional-locks` 标志。
这是 Git 官方为只读查询场景设计的选项，使 git 不写入 `index.lock`，从根本上消除与 agent 的锁竞争。

## 改动

- `src-tauri/src/workspace_state/mod.rs` — watcher 的 `git status` 和 `git diff --numstat` 加 `--no-optional-locks`
- `src-tauri/src/commands/folders.rs` — 前端主动调用的 `git_status` command 同样加 `--no-optional-locks`，保持一致
