### PR TITLE
fix(chat): support image paste from clipboard on Linux/Tauri

### DIFF
--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -1294,14 +1294,46 @@ export function MessageInput({
   )
 
   const handlePaste = useCallback(
-    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
       if (disabled) return
       const files = filesFromClipboard(event.clipboardData)
-      if (files.length === 0) return
-      event.preventDefault()
-      void appendFilesFromInput(files).catch((error) => {
-        console.error("[MessageInput] paste files failed:", error)
-      })
+      if (files.length > 0) {
+        event.preventDefault()
+        void appendFilesFromInput(files).catch((error) => {
+          console.error("[MessageInput] paste files failed:", error)
+        })
+        return
+      }
+
+      // Fallback for Linux/Tauri webview where DataTransfer API doesn't
+      // expose screenshot images (e.g. WeChat screenshot). The async
+      // Clipboard API can read raw image blobs when the sync paste event
+      // yields nothing.
+      if (navigator.clipboard?.read) {
+        try {
+          const items = await navigator.clipboard.read()
+          const imageFiles: File[] = []
+          for (const item of items) {
+            for (const type of item.types) {
+              if (type.startsWith("image/")) {
+                const blob = await item.getType(type)
+                const ext = type.split("/")[1] || "png"
+                imageFiles.push(
+                  new File([blob], `clipboard-image.${ext}`, { type })
+                )
+              }
+            }
+          }
+          if (imageFiles.length > 0) {
+            event.preventDefault()
+            void appendFilesFromInput(imageFiles).catch((error) => {
+              console.error("[MessageInput] paste files failed:", error)
+            })
+          }
+        } catch {
+          // Clipboard API may be blocked by permissions; silently fall through.
+        }
+      }
     },
     [appendFilesFromInput, disabled]
   )


### PR DESCRIPTION
## 问题
在 Linux 桌面版（Tauri + WebKitGTK webview）中，使用微信等截图工具复制的图片粘贴到聊天输入框无反应。

## 根因
Linux (X11/Wayland) 下，截图工具将图片写入系统剪贴板后，浏览器的 `DataTransfer` API 无法暴露图片数据：
- `clipboardData.files` 为空
- `DataTransferItem.getAsFile()` 返回 `null`

## 修复
当同步粘贴事件无法提取文件时，降级使用异步 Clipboard API (`navigator.clipboard.read()`) 读取原始图片 blob。

## 测试
- [x] 微信截图 → Ctrl+V 粘贴，图片正常显示为附件
- [x] 文件管理器复制图片文件 → Ctrl+V 粘贴，正常附加
- [x] 纯文本粘贴不受影响
