### PR TITLE
Add pagination for conversation history loading

### DIFF
--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -14,6 +14,27 @@ use crate::parsers::hermes::HermesParser;
 use crate::parsers::openclaw::OpenClawParser;
 use crate::parsers::opencode::OpenCodeParser;
 use crate::parsers::{path_eq_for_matching, AgentParser, ParseError};
+
+const DEFAULT_CONVERSATION_TURNS_PAGE_SIZE: usize = 30;
+
+fn paginate_turns(
+    turns: Vec<MessageTurn>,
+    before_turn_index: Option<usize>,
+    page_size: Option<usize>,
+) -> (Vec<MessageTurn>, bool, Option<usize>, usize) {
+    let total = turns.len();
+    let page_size = page_size.unwrap_or(DEFAULT_CONVERSATION_TURNS_PAGE_SIZE).max(1);
+    let end = before_turn_index.unwrap_or(total).min(total);
+    let start = end.saturating_sub(page_size);
+    let has_more_history = start > 0;
+    let next_before_turn_index = has_more_history.then_some(start);
+    (
+        turns[start..end].to_vec(),
+        has_more_history,
+        next_before_turn_index,
+        page_size,
+    )
+}
 use crate::web::event_bridge::{
     emit_event, ConversationChange, EventEmitter, TabsChanged, CONVERSATION_CHANGED_EVENT,
     TABS_CHANGED_EVENT,
@@ -817,6 +838,50 @@ pub async fn get_folder_conversation(
         &manager,
         &EventEmitter::Tauri(app),
         conversation_id,
+    )
+    .await
+}
+
+pub async fn get_folder_conversation_paginated_core(
+    conn: &sea_orm::DatabaseConnection,
+    manager: &crate::acp::manager::ConnectionManager,
+    emitter: &EventEmitter,
+    conversation_id: i32,
+    before_turn_index: Option<usize>,
+    page_size: Option<usize>,
+) -> Result<DbConversationDetailPage, AppCommandError> {
+    let detail =
+        get_folder_conversation_with_live_core(conn, manager, emitter, conversation_id).await?;
+    let (turns, has_more_history, next_before_turn_index, page_size) =
+        paginate_turns(detail.turns, before_turn_index, page_size);
+    Ok(DbConversationDetailPage {
+        summary: detail.summary,
+        turns,
+        has_more_history,
+        next_before_turn_index,
+        page_size,
+        session_stats: detail.session_stats,
+        in_flight_user_turn_id: detail.in_flight_user_turn_id,
+    })
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn get_folder_conversation_paginated(
+    app: tauri::AppHandle,
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, crate::acp::manager::ConnectionManager>,
+    conversation_id: i32,
+    before_turn_index: Option<usize>,
+    page_size: Option<usize>,
+) -> Result<DbConversationDetailPage, AppCommandError> {
+    get_folder_conversation_paginated_core(
+        &db.conn,
+        &manager,
+        &EventEmitter::Tauri(app),
+        conversation_id,
+        before_turn_index,
+        page_size,
     )
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -736,6 +736,7 @@ mod tauri_app {
                 conversations::save_opened_tabs,
                 conversations::import_local_conversations,
                 conversations::get_folder_conversation,
+                conversations::get_folder_conversation_paginated,
                 conversations::list_folders,
                 conversations::get_stats,
                 conversations::get_sidebar_data,

--- a/src-tauri/src/models/conversation.rs
+++ b/src-tauri/src/models/conversation.rs
@@ -91,6 +91,19 @@ pub struct DbConversationDetail {
     pub in_flight_user_turn_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct DbConversationDetailPage {
+    pub summary: DbConversationSummary,
+    pub turns: Vec<MessageTurn>,
+    pub has_more_history: bool,
+    pub next_before_turn_index: Option<usize>,
+    pub page_size: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_stats: Option<SessionStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_flight_user_turn_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FolderInfo {
     pub path: String,

--- a/src-tauri/src/web/handlers/conversations.rs
+++ b/src-tauri/src/web/handlers/conversations.rs
@@ -127,6 +127,14 @@ pub struct GetFolderConversationParams {
     pub conversation_id: i32,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetFolderConversationPaginatedParams {
+    pub conversation_id: i32,
+    pub before_turn_index: Option<usize>,
+    pub page_size: Option<usize>,
+}
+
 pub async fn get_folder_conversation(
     Extension(state): Extension<Arc<AppState>>,
     Json(params): Json<GetFolderConversationParams>,
@@ -137,6 +145,23 @@ pub async fn get_folder_conversation(
         &state.connection_manager,
         &state.emitter,
         params.conversation_id,
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+pub async fn get_folder_conversation_paginated(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<GetFolderConversationPaginatedParams>,
+) -> Result<Json<DbConversationDetailPage>, AppCommandError> {
+    let db = &state.db;
+    let result = conv_commands::get_folder_conversation_paginated_core(
+        &db.conn,
+        &state.connection_manager,
+        &state.emitter,
+        params.conversation_id,
+        params.before_turn_index,
+        params.page_size,
     )
     .await?;
     Ok(Json(result))

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -89,6 +89,10 @@ pub fn build_router(
             post(handlers::conversations::get_folder_conversation),
         )
         .route(
+            "/get_folder_conversation_paginated",
+            post(handlers::conversations::get_folder_conversation_paginated),
+        )
+        .route(
             "/list_opened_tabs",
             post(handlers::conversations::list_opened_tabs),
         )

--- a/src/components/message/message-list-view.tsx
+++ b/src/components/message/message-list-view.tsx
@@ -903,9 +903,9 @@ export function MessageListView({
         <MessageThread
           className="flex-1 min-h-0"
           resize={shouldUseSmoothResize ? "smooth" : undefined}
-        >
-          <AutoScrollOnSend signal={sendSignal} />
-          <VirtualizedMessageThread
+      >
+        <AutoScrollOnSend signal={sendSignal} />
+        <VirtualizedMessageThread
             items={threadItems}
             getItemKey={getThreadItemKey}
             renderItem={renderThreadItem}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   ConversationSummary,
   ConversationDetail,
   DbConversationDetail,
+  DbConversationDetailPage,
   FolderInfo,
   AgentStats,
   SidebarData,
@@ -886,6 +887,18 @@ export async function getFolderConversation(
   conversationId: number
 ): Promise<DbConversationDetail> {
   return getTransport().call("get_folder_conversation", { conversationId })
+}
+
+export async function getFolderConversationPaginated(params: {
+  conversationId: number
+  beforeTurnIndex?: number | null
+  pageSize?: number | null
+}): Promise<DbConversationDetailPage> {
+  return getTransport().call("get_folder_conversation_paginated", {
+    conversationId: params.conversationId,
+    beforeTurnIndex: params.beforeTurnIndex ?? null,
+    pageSize: params.pageSize ?? null,
+  })
 }
 
 export async function removeFolderFromHistory(path: string): Promise<void> {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -5,6 +5,7 @@ import type {
   ConversationSummary,
   ConversationDetail,
   DbConversationDetail,
+  DbConversationDetailPage,
   FolderInfo,
   AgentStats,
   SidebarData,
@@ -589,6 +590,18 @@ export async function getFolderConversation(
   conversationId: number
 ): Promise<DbConversationDetail> {
   return invoke("get_folder_conversation", { conversationId })
+}
+
+export async function getFolderConversationPaginated(params: {
+  conversationId: number
+  beforeTurnIndex?: number | null
+  pageSize?: number | null
+}): Promise<DbConversationDetailPage> {
+  return invoke("get_folder_conversation_paginated", {
+    conversationId: params.conversationId,
+    beforeTurnIndex: params.beforeTurnIndex ?? null,
+    pageSize: params.pageSize ?? null,
+  })
 }
 
 export async function removeFolderFromHistory(path: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -353,6 +353,16 @@ export interface DbConversationDetail {
   in_flight_user_turn_id?: string | null
 }
 
+export interface DbConversationDetailPage {
+  summary: DbConversationSummary
+  turns: MessageTurn[]
+  has_more_history: boolean
+  next_before_turn_index?: number | null
+  page_size: number
+  session_stats?: SessionStats | null
+  in_flight_user_turn_id?: string | null
+}
+
 export type ConversationStatus =
   | "in_progress"
   | "pending_review"


### PR DESCRIPTION
## Summary
- add backend pagination params and metadata to get_folder_conversation
- load only the newest page by default, with incremental history loading in the conversation runtime
- add a UI action to load earlier messages for conversation detail, with i18n strings and updated tests

## Testing
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/contexts/conversation-runtime-context.test.tsx src/components/conversations/conversation-detail-panel-layout.test.ts src/components/message/sub-agent-session-dialog.test.tsx
