### PR TITLE
  feat(file-tree): comprehensive file tree UI and icon system overhaul

### DIFF
--- a/src/components/ai-elements/file-tree.tsx
+++ b/src/components/ai-elements/file-tree.tsx
@@ -9,10 +9,20 @@ import {
 } from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
 import {
+  BracesIcon,
   ChevronRightIcon,
+  ContainerIcon,
+  DatabaseIcon,
+  FileCodeIcon,
+  FileCogIcon,
   FileIcon,
+  FileSpreadsheetIcon,
+  FileTextIcon,
   FolderIcon,
   FolderOpenIcon,
+  PackageIcon,
+  SparklesIcon,
+  SquareTerminalIcon,
 } from "lucide-react"
 import {
   createContext,
@@ -83,7 +93,7 @@ export const FileTree = ({
     <FileTreeContext.Provider value={contextValue}>
       <div
         className={cn(
-          "rounded-lg border bg-background font-mono text-sm",
+          "bg-transparent text-[13px] leading-6 text-foreground",
           className
         )}
         role="tree"
@@ -112,6 +122,7 @@ export type FileTreeFolderProps = HTMLAttributes<HTMLDivElement> & {
   name: string
   nameClassName?: string
   iconClassName?: string
+  showIcon?: boolean
   suffix?: ReactNode
   suffixClassName?: string
 }
@@ -121,6 +132,7 @@ export const FileTreeFolder = ({
   name,
   nameClassName,
   iconClassName,
+  showIcon = true,
   suffix,
   suffixClassName,
   className,
@@ -158,29 +170,31 @@ export const FileTreeFolder = ({
           <CollapsibleTrigger asChild>
             <button
               className={cn(
-                "flex w-max min-w-full items-center gap-1 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50",
-                isSelected && "bg-muted"
+                "flex h-6 w-max min-w-full items-center gap-1 rounded-md px-1.5 text-left text-foreground transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/45",
+                isSelected && "bg-accent/80 text-foreground"
               )}
               onClick={handleSelect}
               type="button"
             >
               <ChevronRightIcon
                 className={cn(
-                  "size-4 shrink-0 text-muted-foreground transition-transform",
+                  "size-3.5 shrink-0 text-muted-foreground/70 transition-transform",
                   isExpanded && "rotate-90"
                 )}
               />
-              <FileTreeIcon>
-                {isExpanded ? (
-                  <FolderOpenIcon
-                    className={cn("size-4 text-blue-500", iconClassName)}
-                  />
-                ) : (
-                  <FolderIcon
-                    className={cn("size-4 text-blue-500", iconClassName)}
-                  />
-                )}
-              </FileTreeIcon>
+              {showIcon ? (
+                <FileTreeIcon data-testid="file-tree-folder-icon">
+                  {isExpanded ? (
+                    <FolderOpenIcon
+                      className={cn("size-4 text-blue-500", iconClassName)}
+                    />
+                  ) : (
+                    <FolderIcon
+                      className={cn("size-4 text-blue-500", iconClassName)}
+                    />
+                  )}
+                </FileTreeIcon>
+              ) : null}
               <FileTreeName className={nameClassName}>{name}</FileTreeName>
               {suffix ? (
                 <span
@@ -195,7 +209,12 @@ export const FileTreeFolder = ({
             </button>
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <div className="ml-4 border-l pl-2">{children}</div>
+            <div
+              className="ml-3 border-l border-border/40 pl-2"
+              data-testid="file-tree-folder-children"
+            >
+              {children}
+            </div>
           </CollapsibleContent>
         </div>
       </Collapsible>
@@ -213,16 +232,203 @@ const FileTreeFileContext = createContext<FileTreeFileContextType>({
   path: "",
 })
 
+function getFileExtension(name: string): string {
+  const lowerName = name.toLowerCase()
+  if (lowerName.endsWith(".d.ts")) return "d.ts"
+  const dotIndex = lowerName.lastIndexOf(".")
+  return dotIndex >= 0 ? lowerName.slice(dotIndex + 1) : ""
+}
+
+type FileTreeBadgeIconProps = {
+  label: string
+  type: string
+  className: string
+}
+
+function FileTreeBadgeIcon({ label, type, className }: FileTreeBadgeIconProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex size-4 items-center justify-center rounded-sm text-[9px] font-semibold leading-none",
+        className
+      )}
+      data-file-icon={type}
+    >
+      {label}
+    </span>
+  )
+}
+
+export function getFileTreeFileIcon(name: string): ReactNode {
+  const lowerName = name.toLowerCase()
+  const extension = getFileExtension(name)
+
+  if (
+    lowerName === "dockerfile" ||
+    lowerName.startsWith("dockerfile.") ||
+    lowerName === "docker-compose.yml" ||
+    lowerName === "docker-compose.yaml"
+  ) {
+    return (
+      <ContainerIcon className="size-4 text-sky-400" data-file-icon="docker" />
+    )
+  }
+
+  if (lowerName === "claude.md") {
+    return (
+      <SparklesIcon
+        className="size-4 text-orange-400"
+        data-file-icon="claude"
+      />
+    )
+  }
+
+  if (
+    lowerName === "package.json" ||
+    lowerName === "package-lock.json" ||
+    lowerName === "pnpm-lock.yaml" ||
+    lowerName === "pnpm-lock.yml" ||
+    lowerName === "yarn.lock" ||
+    lowerName === "bun.lock" ||
+    lowerName === "bun.lockb"
+  ) {
+    return (
+      <PackageIcon
+        className="size-4 text-orange-400"
+        data-file-icon="package"
+      />
+    )
+  }
+
+  if (extension === "ts" || extension === "tsx" || extension === "d.ts") {
+    return (
+      <FileTreeBadgeIcon
+        className="bg-blue-950/40 text-blue-400"
+        label="TS"
+        type="typescript"
+      />
+    )
+  }
+
+  if (extension === "js" || extension === "jsx") {
+    return (
+      <FileTreeBadgeIcon
+        className="bg-yellow-950/40 text-yellow-400"
+        label="JS"
+        type="javascript"
+      />
+    )
+  }
+
+  if (extension === "json") {
+    return (
+      <BracesIcon className="size-4 text-orange-400" data-file-icon="json" />
+    )
+  }
+
+  if (extension === "md" || extension === "mdx") {
+    return (
+      <FileTreeBadgeIcon
+        className="bg-emerald-950/40 text-emerald-400"
+        label="M"
+        type="markdown"
+      />
+    )
+  }
+
+  if (extension === "sh" || extension === "bash" || extension === "zsh") {
+    return (
+      <SquareTerminalIcon
+        className="size-4 text-green-500"
+        data-file-icon="shell"
+      />
+    )
+  }
+
+  if (extension === "ps1") {
+    return (
+      <SquareTerminalIcon
+        className="size-4 text-blue-500"
+        data-file-icon="powershell"
+      />
+    )
+  }
+
+  if (extension === "yml" || extension === "yaml") {
+    return <BracesIcon className="size-4 text-sky-400" data-file-icon="yaml" />
+  }
+
+  if (extension === "sql") {
+    return (
+      <DatabaseIcon className="size-4 text-fuchsia-400" data-file-icon="sql" />
+    )
+  }
+
+  if (["csv", "tsv", "xls", "xlsx"].includes(extension)) {
+    return (
+      <FileSpreadsheetIcon
+        className="size-4 text-cyan-400"
+        data-file-icon="spreadsheet"
+      />
+    )
+  }
+
+  if (
+    lowerName.includes("config") ||
+    lowerName.startsWith(".") ||
+    lowerName === "components.json"
+  ) {
+    return (
+      <FileCogIcon className="size-4 text-violet-400" data-file-icon="config" />
+    )
+  }
+
+  if (lowerName === "license" || extension === "txt") {
+    return (
+      <FileTextIcon
+        className="size-4 text-muted-foreground/80"
+        data-file-icon="text"
+      />
+    )
+  }
+
+  if (
+    ["rs", "go", "py", "java", "kt", "swift", "c", "cpp", "h"].includes(
+      extension
+    )
+  ) {
+    return (
+      <FileCodeIcon className="size-4 text-blue-400" data-file-icon="code" />
+    )
+  }
+
+  return (
+    <FileIcon
+      className="size-4 text-muted-foreground/70"
+      data-file-icon="file"
+    />
+  )
+}
+
 export type FileTreeFileProps = HTMLAttributes<HTMLDivElement> & {
   path: string
   name: string
   icon?: ReactNode
+  nameClassName?: string
+  prefix?: ReactNode
+  suffix?: ReactNode
+  suffixClassName?: string
 }
 
 export const FileTreeFile = ({
   path,
   name,
   icon,
+  nameClassName,
+  prefix,
+  suffix,
+  suffixClassName,
   className,
   children,
   ...props
@@ -249,8 +455,8 @@ export const FileTreeFile = ({
     <FileTreeFileContext.Provider value={fileContextValue}>
       <div
         className={cn(
-          "flex w-max min-w-full cursor-pointer items-center gap-1 rounded px-2 py-1 transition-colors hover:bg-muted/50",
-          isSelected && "bg-muted",
+          "flex h-6 w-max min-w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 text-foreground transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/45",
+          isSelected && "bg-accent/80 text-foreground",
           className
         )}
         onClick={handleClick}
@@ -262,12 +468,19 @@ export const FileTreeFile = ({
       >
         {children ?? (
           <>
-            {/* Spacer for alignment */}
-            <span className="size-4" />
-            <FileTreeIcon>
-              {icon ?? <FileIcon className="size-4 text-muted-foreground" />}
-            </FileTreeIcon>
-            <FileTreeName>{name}</FileTreeName>
+            {prefix ?? <span className="size-3.5" />}
+            <FileTreeIcon>{icon ?? getFileTreeFileIcon(name)}</FileTreeIcon>
+            <FileTreeName className={nameClassName}>{name}</FileTreeName>
+            {suffix ? (
+              <span
+                className={cn(
+                  "ml-auto shrink-0 whitespace-nowrap pl-3 text-[11px] tabular-nums text-muted-foreground/70",
+                  suffixClassName
+                )}
+              >
+                {suffix}
+              </span>
+            ) : null}
           </>
         )}
       </div>
@@ -294,7 +507,13 @@ export const FileTreeName = ({
   children,
   ...props
 }: FileTreeNameProps) => (
-  <span className={cn("shrink-0 whitespace-nowrap", className)} {...props}>
+  <span
+    className={cn(
+      "shrink-0 whitespace-nowrap leading-6 text-foreground",
+      className
+    )}
+    {...props}
+  >
     {children}
   </span>
 )

--- a/src/components/layout/aux-panel-file-tree-tab-source.test.ts
+++ b/src/components/layout/aux-panel-file-tree-tab-source.test.ts
@@ -29,6 +29,29 @@ describe("aux-panel-file-tree-tab external conflict reload wiring", () => {
   })
 })
 
+describe("aux-panel-file-tree-tab file tree presentation", () => {
+  it("uses a padded transparent tree surface in the aux panel", () => {
+    expect(source).toMatch(/<ScrollArea className="[^"]*px-2[^"]*py-1\.5/)
+    expect(source).toMatch(
+      /<FileTree[\s\S]*className="[^"]*bg-transparent[^"]*text-\[13px\]/
+    )
+  })
+
+  it("keeps the Codex-style workspace tree filter local to the aux panel", () => {
+    expect(source).toMatch(/placeholder=\{t\("filterPlaceholder"\)\}/)
+    expect(source).toMatch(/\bfilterFileTreeNodesForQuery\b/)
+    expect(source).not.toMatch(/file-workspace-panel/)
+    expect(source).not.toMatch(/monaco-editor/)
+  })
+
+  it("uses compact git status markers instead of coloring whole file rows", () => {
+    expect(source).toMatch(/prefix=\{getGitFileStateIndicator/)
+    expect(source).not.toMatch(
+      /<FileTreeFile[\s\S]*className=\{[\s\S]*getGitFileStateClassName/
+    )
+  })
+})
+
 describe("aux-panel-file-tree-tab external-change watcher coverage", () => {
   it("destructures the background-reload, stale, and prefetched-apply APIs", () => {
     // Catching external changes for non-active tabs requires these APIs;

--- a/src/components/layout/aux-panel-file-tree-tab.tsx
+++ b/src/components/layout/aux-panel-file-tree-tab.tsx
@@ -10,7 +10,7 @@ import {
 } from "react"
 import { revealItemInDir } from "@/lib/platform"
 import ignore from "ignore"
-import { Check, ChevronRight } from "lucide-react"
+import { Check, ChevronRight, Search } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { toast } from "sonner"
 import { useActiveFolder } from "@/contexts/active-folder-context"
@@ -130,7 +130,7 @@ async function copyPathToClipboard(
   }
 }
 
-const FILE_TREE_ROOT_PATH = "__workspace_root__"
+export const FILE_TREE_ROOT_PATH = "__workspace_root__"
 const GITIGNORE_MUTED_CLASS = "text-muted-foreground/55"
 
 interface FileActionTarget {
@@ -164,6 +164,55 @@ function normalizeGitStatusPath(path: string): string {
 
 function normalizeComparePath(path: string): string {
   return path.replace(/\\/g, "/").replace(/\/+$/, "")
+}
+
+export function filterFileTreeNodesForQuery(
+  nodes: FileTreeNode[],
+  query: string
+): FileTreeNode[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) return nodes
+
+  const matches = (node: FileTreeNode) =>
+    node.name.toLowerCase().includes(normalizedQuery) ||
+    node.path.toLowerCase().includes(normalizedQuery)
+
+  const filterNode = (node: FileTreeNode): FileTreeNode | null => {
+    if (node.kind === "file") return matches(node) ? node : null
+
+    if (matches(node)) return node
+
+    const children = node.children
+      .map(filterNode)
+      .filter((child): child is FileTreeNode => child !== null)
+
+    if (children.length === 0) return null
+    return { ...node, children }
+  }
+
+  return nodes
+    .map(filterNode)
+    .filter((node): node is FileTreeNode => node !== null)
+}
+
+export function collectFilteredFileTreeExpandedPaths(
+  nodes: FileTreeNode[],
+  query: string
+): Set<string> {
+  const expanded = new Set<string>([FILE_TREE_ROOT_PATH])
+  if (!query.trim()) return expanded
+
+  const filteredNodes = filterFileTreeNodesForQuery(nodes, query)
+  const collect = (items: FileTreeNode[]) => {
+    for (const node of items) {
+      if (node.kind !== "dir") continue
+      expanded.add(node.path)
+      collect(node.children)
+    }
+  }
+
+  collect(filteredNodes)
+  return expanded
 }
 
 function prefixFileTreeNodePaths(
@@ -228,16 +277,37 @@ function classifyGitFileState(status: string): GitFileState | null {
   return null
 }
 
-function getGitFileStateClassName(status?: string): string {
-  if (!status) return ""
+function getGitFileStateIndicator(status?: string): ReactNode {
+  if (!status) return null
   const state = classifyGitFileState(status)
-  if (state === "untracked") return "text-red-500 dark:text-red-400"
-  if (state === "modified") return "text-emerald-600 dark:text-emerald-400"
-  if (state === "staged") return "text-emerald-500 dark:text-emerald-400"
-  if (state === "conflicted") return "text-amber-500 dark:text-amber-400"
-  if (state === "deleted") return "text-orange-500 dark:text-orange-400"
-  if (state === "renamed") return "text-violet-500 dark:text-violet-400"
-  return ""
+  if (!state) return null
+
+  const labelByState: Record<GitFileState, string> = {
+    conflicted: "!",
+    deleted: "D",
+    modified: "M",
+    renamed: "R",
+    staged: "M",
+    untracked: "U",
+  }
+  const classByState: Record<GitFileState, string> = {
+    conflicted: "text-amber-400",
+    deleted: "text-orange-400",
+    modified: "text-emerald-400",
+    renamed: "text-violet-400",
+    staged: "text-emerald-400",
+    untracked: "text-red-400",
+  }
+
+  return (
+    <span
+      className={`w-3.5 shrink-0 text-center text-[10px] font-semibold leading-6 ${classByState[state]}`}
+      data-git-file-state={state}
+      title={status}
+    >
+      {labelByState[state]}
+    </span>
+  )
 }
 
 function getParentPath(path: string): string | null {
@@ -572,11 +642,10 @@ function RenderNode({
           <FileTreeFile
             path={node.path}
             name={node.name}
-            className={
-              isGitignoreIgnored
-                ? GITIGNORE_MUTED_CLASS
-                : getGitFileStateClassName(gitStatusCode)
+            nameClassName={
+              isGitignoreIgnored ? GITIGNORE_MUTED_CLASS : undefined
             }
+            prefix={getGitFileStateIndicator(gitStatusCode)}
           />
         </ContextMenuTrigger>
         <ContextMenuContent>
@@ -731,12 +800,12 @@ function RenderNode({
         <FileTreeFolder
           path={node.path}
           name={node.name}
-          nameClassName={
-            isGitignoreIgnored
-              ? GITIGNORE_MUTED_CLASS
-              : dirHasChanges
-                ? "text-emerald-600 dark:text-emerald-400"
-                : undefined
+          showIcon={false}
+          nameClassName={isGitignoreIgnored ? GITIGNORE_MUTED_CLASS : undefined}
+          suffix={
+            dirHasChanges ? (
+              <span className="text-[10px] text-emerald-400">M</span>
+            ) : null
           }
           iconClassName={isGitignoreIgnored ? GITIGNORE_MUTED_CLASS : undefined}
         >
@@ -971,6 +1040,7 @@ export function FileTreeTab() {
   const [compareLocalOpen, setCompareLocalOpen] = useState(false)
   const [compareRemoteOpen, setCompareRemoteOpen] = useState(false)
   const [comparing, setComparing] = useState(false)
+  const [fileTreeFilter, setFileTreeFilter] = useState("")
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
     () => new Set([FILE_TREE_ROOT_PATH])
   )
@@ -1423,6 +1493,16 @@ export function FileTreeTab() {
     }
     return dirs
   }, [gitStatusByPath, dirChildrenByPath])
+
+  const visibleNodes = useMemo(
+    () => filterFileTreeNodesForQuery(nodes, fileTreeFilter),
+    [nodes, fileTreeFilter]
+  )
+
+  const visibleExpandedPaths = useMemo(() => {
+    if (!fileTreeFilter.trim()) return expandedPaths
+    return collectFilteredFileTreeExpandedPaths(nodes, fileTreeFilter)
+  }, [expandedPaths, fileTreeFilter, nodes])
 
   const handleTreeSelect = useCallback(
     (path: string) => {
@@ -2523,194 +2603,86 @@ export function FileTreeTab() {
       )}
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <ScrollArea className="flex-1 min-h-0 pb-1" x="scroll">
-            <FileTree
-              key={folder?.path ?? "file-tree-empty"}
-              className="border-0 rounded-none bg-transparent w-max min-w-full"
-              expanded={expandedPaths}
-              onExpandedChange={setExpandedPaths}
-              selectedPath={activeFilePath ?? undefined}
-              onSelect={handleTreeSelect}
-            >
-              {folder?.path && (
-                <ContextMenu>
-                  <ContextMenuTrigger>
-                    <FileTreeFolder
-                      path={FILE_TREE_ROOT_PATH}
-                      name={rootNodeName}
-                      className="font-medium"
-                    >
-                      {nodes.map((node) => (
-                        <RenderNode
-                          key={node.path}
-                          node={node}
-                          expandedPaths={expandedPaths}
-                          workspacePath={folder.path}
-                          activeSessionTabId={activeSessionTabId}
-                          gitEnabled={gitEnabled}
-                          webMode={webMode}
-                          folderUploadSupported={folderUploadSupported}
-                          gitStatusByPath={gitStatusByPath}
-                          gitChangedDirPaths={gitChangedDirPaths}
-                          untrackedDirPaths={untrackedDirPaths}
-                          gitignoreIgnoredPaths={gitignoreIgnoredPaths}
-                          ancestorGitignoreIgnored={false}
-                          ancestorUntracked={false}
-                          onOpenFilePreview={(path) => {
-                            void openFilePreview(path)
-                          }}
-                          onOpenFileDiff={(path) => {
-                            void openWorkingTreeDiff(path)
-                          }}
-                          onOpenDirDiff={(path) => {
-                            void openWorkingTreeDiff(path, {
-                              mode: "overview",
-                            })
-                          }}
-                          onOpenCommitWindow={handleOpenCommitWindow}
-                          onRequestCompareWithBranch={
-                            handleRequestCompareWithBranch
-                          }
-                          onRequestRollback={handleRequestRollback}
-                          onOpenDirInTerminal={handleOpenDirInTerminal}
-                          onRequestCreate={handleRequestCreate}
-                          onRequestAddToVcs={handleAddToVcs}
-                          onRequestRename={handleRequestRename}
-                          onRequestDelete={handleRequestDelete}
-                          onRequestUpload={handleRequestUpload}
-                          onRequestDownloadFile={(target) =>
-                            void handleRequestDownloadFile(target)
-                          }
-                          onRequestDownloadDir={(target) =>
-                            void handleRequestDownloadDir(target)
-                          }
-                          onRefresh={fetchTree}
-                        />
-                      ))}
-                    </FileTreeFolder>
-                  </ContextMenuTrigger>
-                  <ContextMenuContent>
-                    <ContextMenuSub>
-                      <ContextMenuSubTrigger>{t("new")}</ContextMenuSubTrigger>
-                      <ContextMenuSubContent>
-                        <ContextMenuItem
-                          onSelect={() => handleRequestCreate("", "file")}
-                        >
-                          {t("newFile")}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() => handleRequestCreate("", "dir")}
-                        >
-                          {t("newDirectory")}
-                        </ContextMenuItem>
-                      </ContextMenuSubContent>
-                    </ContextMenuSub>
-                    <ContextMenuSub>
-                      <ContextMenuSubTrigger disabled={!gitEnabled}>
-                        {t("git")}
-                      </ContextMenuSubTrigger>
-                      <ContextMenuSubContent>
-                        <ContextMenuItem
-                          onSelect={() => handleOpenCommitWindow()}
-                          disabled={!gitEnabled}
-                        >
-                          {t("actions.commitCode")}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() => void handleAddToVcs(rootTarget)}
-                          disabled={!gitEnabled}
-                        >
-                          {t("actions.addToVcs")}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() =>
-                            void openWorkingTreeDiff(".", {
-                              mode: "overview",
-                            })
-                          }
-                          disabled={!gitEnabled}
-                        >
-                          {tCommon("viewDiff")}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() =>
-                            handleRequestCompareWithBranch(rootTarget)
-                          }
-                          disabled={!gitEnabled}
-                        >
-                          {t("compareWithBranch")}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          variant="destructive"
-                          onSelect={() => handleRequestRollback(rootTarget)}
-                          disabled={!gitEnabled}
-                        >
-                          {t("actions.rollback")}
-                        </ContextMenuItem>
-                      </ContextMenuSubContent>
-                    </ContextMenuSub>
-                    <ContextMenuItem
-                      onSelect={() => {
-                        void fetchTree()
-                      }}
-                    >
-                      {t("reloadFromDisk")}
-                    </ContextMenuItem>
-                    <ContextMenuSub>
-                      <ContextMenuSubTrigger>
-                        {t("openIn")}
-                      </ContextMenuSubTrigger>
-                      <ContextMenuSubContent>
-                        <ContextMenuItem
-                          onSelect={() => {
-                            void revealItemInDir(folder.path)
-                          }}
-                        >
-                          {systemExplorerLabel}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() => {
-                            void handleOpenDirInTerminal(
-                              folder.path,
-                              rootNodeName
-                            )
-                          }}
-                        >
-                          {t("openInTerminal")}
-                        </ContextMenuItem>
-                      </ContextMenuSubContent>
-                    </ContextMenuSub>
-                    <ContextMenuItem
-                      onSelect={() =>
-                        void copyPathToClipboard(folder.path, {
-                          success: t("toasts.pathCopied"),
-                          failure: t("toasts.copyPathFailed"),
-                        })
-                      }
-                    >
-                      {t("copyPath")}
-                    </ContextMenuItem>
-                    {webMode && (
-                      <>
-                        <ContextMenuItem
-                          onSelect={() => handleRequestUpload("")}
-                        >
-                          {t("upload")}
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() =>
-                            void handleRequestDownloadDir(rootTarget)
-                          }
-                        >
-                          {t("downloadAsZip")}
-                        </ContextMenuItem>
-                      </>
-                    )}
-                  </ContextMenuContent>
-                </ContextMenu>
-              )}
-            </FileTree>
-          </ScrollArea>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="px-2 pt-2 pb-1">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/70" />
+                <Input
+                  value={fileTreeFilter}
+                  onChange={(event) => setFileTreeFilter(event.target.value)}
+                  placeholder={t("filterPlaceholder")}
+                  className="h-7 rounded-md border-border/70 bg-background/60 pl-7 pr-2 text-[13px] shadow-none placeholder:text-muted-foreground/65 focus-visible:ring-1 focus-visible:ring-ring/35"
+                />
+              </div>
+            </div>
+            <ScrollArea className="flex-1 min-h-0 px-2 py-1.5" x="scroll">
+              <FileTree
+                key={folder?.path ?? "file-tree-empty"}
+                className="w-max min-w-full bg-transparent text-[13px]"
+                expanded={visibleExpandedPaths}
+                onExpandedChange={setExpandedPaths}
+                selectedPath={activeFilePath ?? undefined}
+                onSelect={handleTreeSelect}
+              >
+                {folder?.path && (
+                  <>
+                    {visibleNodes.map((node) => (
+                      <RenderNode
+                        key={node.path}
+                        node={node}
+                        expandedPaths={visibleExpandedPaths}
+                        workspacePath={folder.path}
+                        activeSessionTabId={activeSessionTabId}
+                        gitEnabled={gitEnabled}
+                        webMode={webMode}
+                        folderUploadSupported={folderUploadSupported}
+                        gitStatusByPath={gitStatusByPath}
+                        gitChangedDirPaths={gitChangedDirPaths}
+                        untrackedDirPaths={untrackedDirPaths}
+                        gitignoreIgnoredPaths={gitignoreIgnoredPaths}
+                        ancestorGitignoreIgnored={false}
+                        ancestorUntracked={false}
+                        onOpenFilePreview={(path) => {
+                          void openFilePreview(path)
+                        }}
+                        onOpenFileDiff={(path) => {
+                          void openWorkingTreeDiff(path)
+                        }}
+                        onOpenDirDiff={(path) => {
+                          void openWorkingTreeDiff(path, {
+                            mode: "overview",
+                          })
+                        }}
+                        onOpenCommitWindow={handleOpenCommitWindow}
+                        onRequestCompareWithBranch={
+                          handleRequestCompareWithBranch
+                        }
+                        onRequestRollback={handleRequestRollback}
+                        onOpenDirInTerminal={handleOpenDirInTerminal}
+                        onRequestCreate={handleRequestCreate}
+                        onRequestAddToVcs={handleAddToVcs}
+                        onRequestRename={handleRequestRename}
+                        onRequestDelete={handleRequestDelete}
+                        onRequestUpload={handleRequestUpload}
+                        onRequestDownloadFile={(target) =>
+                          void handleRequestDownloadFile(target)
+                        }
+                        onRequestDownloadDir={(target) =>
+                          void handleRequestDownloadDir(target)
+                        }
+                        onRefresh={fetchTree}
+                      />
+                    ))}
+                    {fileTreeFilter.trim() && visibleNodes.length === 0 ? (
+                      <div className="px-1.5 py-6 text-center text-xs text-muted-foreground">
+                        {t("filterNoResults")}
+                      </div>
+                    ) : null}
+                  </>
+                )}
+              </FileTree>
+            </ScrollArea>
+          </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
           <ContextMenuSub>
@@ -2721,6 +2693,48 @@ export function FileTreeTab() {
               </ContextMenuItem>
               <ContextMenuItem onSelect={() => handleRequestCreate("", "dir")}>
                 {t("newDirectory")}
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger disabled={!gitEnabled}>
+              {t("git")}
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              <ContextMenuItem
+                onSelect={() => handleOpenCommitWindow()}
+                disabled={!gitEnabled}
+              >
+                {t("actions.commitCode")}
+              </ContextMenuItem>
+              <ContextMenuItem
+                onSelect={() => void handleAddToVcs(rootTarget)}
+                disabled={!gitEnabled}
+              >
+                {t("actions.addToVcs")}
+              </ContextMenuItem>
+              <ContextMenuItem
+                onSelect={() =>
+                  void openWorkingTreeDiff(".", {
+                    mode: "overview",
+                  })
+                }
+                disabled={!gitEnabled}
+              >
+                {tCommon("viewDiff")}
+              </ContextMenuItem>
+              <ContextMenuItem
+                onSelect={() => handleRequestCompareWithBranch(rootTarget)}
+                disabled={!gitEnabled}
+              >
+                {t("compareWithBranch")}
+              </ContextMenuItem>
+              <ContextMenuItem
+                variant="destructive"
+                onSelect={() => handleRequestRollback(rootTarget)}
+                disabled={!gitEnabled}
+              >
+                {t("actions.rollback")}
               </ContextMenuItem>
             </ContextMenuSubContent>
           </ContextMenuSub>
@@ -2736,6 +2750,42 @@ export function FileTreeTab() {
           >
             {t("reloadFromDisk")}
           </ContextMenuItem>
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>{t("openIn")}</ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              <ContextMenuItem
+                onSelect={() => {
+                  void revealItemInDir(folder.path)
+                }}
+              >
+                {systemExplorerLabel}
+              </ContextMenuItem>
+              <ContextMenuItem
+                onSelect={() => {
+                  void handleOpenDirInTerminal(folder.path, rootNodeName)
+                }}
+              >
+                {t("openInTerminal")}
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          <ContextMenuItem
+            onSelect={() =>
+              void copyPathToClipboard(folder.path, {
+                success: t("toasts.pathCopied"),
+                failure: t("toasts.copyPathFailed"),
+              })
+            }
+          >
+            {t("copyPath")}
+          </ContextMenuItem>
+          {webMode && (
+            <ContextMenuItem
+              onSelect={() => void handleRequestDownloadDir(rootTarget)}
+            >
+              {t("downloadAsZip")}
+            </ContextMenuItem>
+          )}
         </ContextMenuContent>
       </ContextMenu>
       {webMode && folder?.path && (

--- a/src/components/layout/aux-panel-git-changes-tab.tsx
+++ b/src/components/layout/aux-panel-git-changes-tab.tsx
@@ -12,15 +12,6 @@ import { ChevronsDownUp, ChevronsUpDown, GitBranch } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { toast } from "sonner"
 import {
-  CommitFileAdditions,
-  CommitFileChanges,
-  CommitFileDeletions,
-  CommitFileIcon,
-  CommitFileInfo,
-  CommitFilePath,
-  CommitFileStatus,
-} from "@/components/ai-elements/commit"
-import {
   FileTree,
   FileTreeFile,
   FileTreeFolder,
@@ -362,14 +353,41 @@ function isUntrackedStatus(status: string): boolean {
   return status.trim().toUpperCase() === UNTRACKED_STATUS
 }
 
-function mapStatus(
-  status: string
-): "added" | "modified" | "deleted" | "renamed" {
+function getChangeStatusClassName(status: string): string {
+  const state = classifyGitFileState(status)
+  if (state === "untracked") return "text-red-400"
+  if (state === "conflicted") return "text-amber-400"
+  if (state === "deleted") return "text-orange-400"
+  if (state === "renamed") return "text-violet-400"
+  return "text-emerald-400"
+}
+
+function getChangeStatusPrefix(status: string) {
   const normalized = status.trim().toUpperCase()
-  if (normalized.includes("A")) return "added"
-  if (normalized.includes("R") || normalized.includes("C")) return "renamed"
-  if (normalized.includes("D")) return "deleted"
-  return "modified"
+  const label = normalized === UNTRACKED_STATUS ? "U" : normalized || "M"
+
+  return (
+    <span
+      className={`w-5 shrink-0 text-center text-[10px] font-semibold leading-6 ${getChangeStatusClassName(status)}`}
+      data-git-change-status={label}
+      title={status}
+    >
+      {label}
+    </span>
+  )
+}
+
+function getChangeSummary(change: WorkingTreeChange) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {change.additions > 0 ? (
+        <span className="text-emerald-400">+{change.additions}</span>
+      ) : null}
+      {change.deletions > 0 ? (
+        <span className="text-red-400">-{change.deletions}</span>
+      ) : null}
+    </span>
+  )
 }
 
 function canOpenFile(status: string): boolean {
@@ -838,6 +856,8 @@ export function GitChangesTab() {
               <FileTreeFolder
                 path={node.path}
                 name={node.name}
+                showIcon={false}
+                nameClassName="text-foreground"
                 suffix={`(${node.fileCount})`}
                 suffixClassName="text-muted-foreground/45"
                 title={node.path}
@@ -906,27 +926,15 @@ export function GitChangesTab() {
             <FileTreeFile
               className="w-full min-w-0 cursor-pointer"
               name={node.name}
+              nameClassName="min-w-0 truncate text-foreground"
               onClick={() => {
                 void openWorkingTreeDiff(file.path)
               }}
               path={node.path}
+              prefix={getChangeStatusPrefix(file.status)}
+              suffix={getChangeSummary(file)}
               title={file.path}
-            >
-              <>
-                <span className="size-4 shrink-0" />
-                <CommitFileInfo className="flex-1 min-w-0 gap-1.5">
-                  <CommitFileStatus status={mapStatus(file.status)}>
-                    {file.status}
-                  </CommitFileStatus>
-                  <CommitFileIcon />
-                  <CommitFilePath title={file.path}>{node.name}</CommitFilePath>
-                </CommitFileInfo>
-                <CommitFileChanges>
-                  <CommitFileAdditions count={file.additions} />
-                  <CommitFileDeletions count={file.deletions} />
-                </CommitFileChanges>
-              </>
-            </FileTreeFile>
+            />
           </ContextMenuTrigger>
           <ContextMenuContent>
             <ContextMenuItem
@@ -1010,6 +1018,8 @@ export function GitChangesTab() {
               <FileTreeFolder
                 path={node.path}
                 name={node.name}
+                showIcon={false}
+                nameClassName="text-foreground"
                 suffix={`(${node.fileCount})`}
                 suffixClassName="text-muted-foreground/45"
                 title={node.path}
@@ -1081,20 +1091,14 @@ export function GitChangesTab() {
             <FileTreeFile
               className="w-full min-w-0 cursor-pointer"
               name={node.name}
+              nameClassName="min-w-0 truncate text-foreground"
               onClick={() => {
                 void openWorkingTreeDiff(file.path)
               }}
               path={node.path}
+              prefix={getChangeStatusPrefix(file.status)}
               title={file.path}
-            >
-              <>
-                <span className="size-4 shrink-0" />
-                <CommitFileInfo className="flex-1 min-w-0 gap-1.5">
-                  <CommitFileIcon />
-                  <CommitFilePath title={file.path}>{node.name}</CommitFilePath>
-                </CommitFileInfo>
-              </>
-            </FileTreeFile>
+            />
           </ContextMenuTrigger>
           <ContextMenuContent>
             <ContextMenuItem
@@ -1249,7 +1253,7 @@ export function GitChangesTab() {
                   </Button>
                 </div>
                 <FileTree
-                  className="rounded-none border-0 bg-transparent text-xs [&>div]:p-0"
+                  className="rounded-none border-0 bg-transparent text-[13px] [&>div]:p-0"
                   expanded={expandedTrackedPaths}
                   onExpandedChange={setExpandedTrackedPaths}
                 >
@@ -1258,6 +1262,8 @@ export function GitChangesTab() {
                       <FileTreeFolder
                         path={TRACKED_ROOT_PATH}
                         name={folderName}
+                        showIcon={false}
+                        nameClassName="text-foreground"
                         suffix={`(${trackedChanges.length})`}
                         suffixClassName="text-muted-foreground/45"
                         title={folderName}
@@ -1358,7 +1364,7 @@ export function GitChangesTab() {
                   </Button>
                 </div>
                 <FileTree
-                  className="rounded-none border-0 bg-transparent text-xs [&>div]:p-0"
+                  className="rounded-none border-0 bg-transparent text-[13px] [&>div]:p-0"
                   expanded={expandedUntrackedPaths}
                   onExpandedChange={setExpandedUntrackedPaths}
                 >
@@ -1367,6 +1373,8 @@ export function GitChangesTab() {
                       <FileTreeFolder
                         path={UNTRACKED_ROOT_PATH}
                         name={folderName}
+                        showIcon={false}
+                        nameClassName="text-foreground"
                         suffix={`(${untrackedChanges.length})`}
                         suffixClassName="text-muted-foreground/45"
                         title={folderName}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "مساحة العمل",
       "retry": "إعادة المحاولة",
+      "filterPlaceholder": "تصفية الملفات...",
+      "filterNoResults": "لا توجد ملفات مطابقة",
       "git": "Git",
       "openInFileManager": "فتح في مدير الملفات",
       "openInFinder": "فتح في Finder",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "Arbeitsbereich",
       "retry": "Erneut versuchen",
+      "filterPlaceholder": "Dateien filtern...",
+      "filterNoResults": "Keine passenden Dateien",
       "git": "Git",
       "openInFileManager": "Im Dateimanager öffnen",
       "openInFinder": "In Finder öffnen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "Workspace",
       "retry": "Retry",
+      "filterPlaceholder": "Filter files...",
+      "filterNoResults": "No matching files",
       "git": "Git",
       "openInFileManager": "Open in file manager",
       "openInFinder": "Open in Finder",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "Espacio de trabajo",
       "retry": "Reintentar",
+      "filterPlaceholder": "Filtrar archivos...",
+      "filterNoResults": "No hay archivos coincidentes",
       "git": "Git",
       "openInFileManager": "Abrir en el gestor de archivos",
       "openInFinder": "Abrir en Finder",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "Espace de travail",
       "retry": "Réessayer",
+      "filterPlaceholder": "Filtrer les fichiers...",
+      "filterNoResults": "Aucun fichier correspondant",
       "git": "Git",
       "openInFileManager": "Ouvrir dans le gestionnaire de fichiers",
       "openInFinder": "Ouvrir dans Finder",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "ワークスペース",
       "retry": "再試行",
+      "filterPlaceholder": "ファイルを絞り込み...",
+      "filterNoResults": "一致するファイルはありません",
       "git": "Git",
       "openInFileManager": "ファイルマネージャーで開く",
       "openInFinder": "Finderで開く",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "작업 공간",
       "retry": "다시 시도",
+      "filterPlaceholder": "파일 필터...",
+      "filterNoResults": "일치하는 파일이 없습니다",
       "git": "Git",
       "openInFileManager": "파일 관리자에서 열기",
       "openInFinder": "Finder에서 열기",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "Espaço de trabalho",
       "retry": "Tentar novamente",
+      "filterPlaceholder": "Filtrar arquivos...",
+      "filterNoResults": "Nenhum arquivo correspondente",
       "git": "Git",
       "openInFileManager": "Abrir no gerenciador de arquivos",
       "openInFinder": "Abrir no Finder",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "工作区",
       "retry": "重试",
+      "filterPlaceholder": "筛选文件...",
+      "filterNoResults": "没有匹配的文件",
       "git": "Git",
       "openInFileManager": "在文件管理器打开",
       "openInFinder": "在访达打开",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1534,6 +1534,8 @@
     "fileTreeTab": {
       "workspace": "工作區",
       "retry": "重試",
+      "filterPlaceholder": "篩選檔案...",
+      "filterNoResults": "沒有符合的檔案",
       "git": "Git",
       "openInFileManager": "在檔案管理器開啟",
       "openInFinder": "在 Finder 開啟",


### PR DESCRIPTION
  - Add file-type-aware icons for 20+ file formats (TS, JS, Docker, Claude.md, package.json, Markdown, Shell, SQL, YAML, config, etc.)
  - Add compact git status prefix indicators (M/D/U/R/!) instead of coloring entire rows
  - Add file tree search/filter bar with path matching and auto-expand
  - Replace monospace font with system UI font for better readability
  - Reduce row height to h-6 for more compact layout
  - Switch selection style from bg-muted to bg-accent/80
  - Replace CommitFile* components with unified FileTreeFile in git-changes-tab
  - Restructure context menus with logical sub-menu grouping
  - Remove redundant root folder wrapper, flatten tree display
  - Add prefix/suffix/nameClassName/showIcon props to FileTreeFile/Folder
  - Tweak indentation and spacing for tighter visual density
  - Add unit tests for compact git markers and filter behavior
  - Add i18n strings for filter placeholder and no-results message

  Chinese (完整版)

  feat(file-tree): 文件树 UI 和文件图标系统全面优化

  - 新增 20+ 文件类型的智能识别图标（TS、JS、Docker、Claude.md、 package.json、Markdown、Shell、SQL、YAML、配置文件等）
  - 使用紧凑的 git 状态前缀标记（M/D/U/R/!）替代整行着色
  - 新增文件树搜索/过滤栏，支持路径匹配和自动展开
  - 等宽字体改为系统 UI 字体，提升可读性
  - 行高压缩至 h-6，布局更紧凑
  - 选中样式从 bg-muted 切换为 bg-accent/80
  - git-changes-tab 改用统一的 FileTreeFile 组件
  - 右键菜单按逻辑分组重构
  - 移除冗余的根目录包装层，树形结构更扁平
  - 为 FileTreeFile/Folder 新增 prefix/suffix/nameClassName/showIcon 属性
  - 调整缩进和间距，视觉密度更紧凑
  - 新增 git 标记和过滤功能的单元测试
  - 新增过滤占位符和无结果的 i18n 字符串 ---