### PR TITLE
feat(tabs): add reconnect action

### DIFF
--- a/src/components/tabs/tab-bar.tsx
+++ b/src/components/tabs/tab-bar.tsx
@@ -5,6 +5,7 @@ import { Reorder } from "motion/react"
 import { useAppWorkspace } from "@/contexts/app-workspace-context"
 import { useTabContext } from "@/contexts/tab-context"
 import type { TabItem as TabItemData } from "@/contexts/tab-context"
+import { useAcpActions } from "@/contexts/acp-connections-context"
 import { useWorkspaceContext } from "@/contexts/workspace-context"
 import { useIsCoarsePointer } from "@/hooks/use-is-coarse-pointer"
 import { useShortcutSettings } from "@/hooks/use-shortcut-settings"
@@ -27,6 +28,7 @@ export function TabBar() {
   } = useTabContext()
   const { allFolders, branches } = useAppWorkspace()
   const { mode, activePane, filesMaximized } = useWorkspaceContext()
+  const { reapplyConfig } = useAcpActions()
 
   const folderIndex = useMemo(() => {
     const map = new Map<number, { name: string }>()
@@ -112,6 +114,13 @@ export function TabBar() {
     []
   )
 
+  const handleReconnect = useCallback(
+    async (tabId: string) => {
+      await reapplyConfig(tabId)
+    },
+    [reapplyConfig]
+  )
+
   if (tabs.length === 0) return null
 
   return (
@@ -154,6 +163,7 @@ export function TabBar() {
             onCloseOthers={closeOtherTabs}
             onCloseAll={closeAllTabs}
             onPin={pinTab}
+            onReconnect={handleReconnect}
             onToggleTile={toggleTileMode}
             isCoarsePointer={isCoarsePointer}
             isTouchSorting={touchSortingTabId === tab.id}

--- a/src/components/tabs/tab-item.tsx
+++ b/src/components/tabs/tab-item.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useCallback, useMemo, useRef } from "react"
 import { Reorder } from "motion/react"
-import { X } from "lucide-react"
+import { RefreshCw, X } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { cn, handleMiddleClickClose } from "@/lib/utils"
 import type { ConversationStatus } from "@/lib/types"
@@ -28,6 +28,7 @@ interface TabItemProps {
   onCloseOthers: (tabId: string) => void
   onCloseAll: () => void
   onPin: (tabId: string) => void
+  onReconnect: (tabId: string) => void
   onToggleTile: () => void
   isCoarsePointer: boolean
   isTouchSorting: boolean
@@ -46,6 +47,7 @@ export const TabItem = memo(function TabItem({
   onCloseOthers,
   onCloseAll,
   onPin,
+  onReconnect,
   onToggleTile,
   isCoarsePointer,
   isTouchSorting,
@@ -98,6 +100,10 @@ export const TabItem = memo(function TabItem({
   const handleCloseOthers = useCallback(() => {
     onCloseOthers(tab.id)
   }, [onCloseOthers, tab.id])
+
+  const handleReconnect = useCallback(() => {
+    onReconnect(tab.id)
+  }, [onReconnect, tab.id])
 
   const whileDrag = useMemo(() => ({ scale: 1.03 }), [])
 
@@ -167,6 +173,11 @@ export const TabItem = memo(function TabItem({
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
+          <ContextMenuItem onSelect={handleReconnect}>
+            <RefreshCw className="h-4 w-4" />
+            {t("reconnect")}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem onSelect={handleClose}>{t("close")}</ContextMenuItem>
           <ContextMenuItem onSelect={handleCloseOthers}>
             {t("closeOthers")}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "إغلاق تبويب المحادثة",
+      "reconnect": "إعادة الاتصال",
       "close": "إغلاق",
       "closeOthers": "إغلاق البقية",
       "closeAll": "إغلاق الكل",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "Konversationstab schließen",
+      "reconnect": "Neu verbinden",
       "close": "Schließen",
       "closeOthers": "Andere schließen",
       "closeAll": "Alle schließen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "Close conversation tab",
+      "reconnect": "Reconnect",
       "close": "Close",
       "closeOthers": "Close Others",
       "closeAll": "Close All",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "Cerrar pestaña de conversación",
+      "reconnect": "Reconectar",
       "close": "Cerrar",
       "closeOthers": "Cerrar otros",
       "closeAll": "Cerrar todo",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "Fermer l’onglet de conversation",
+      "reconnect": "Reconnecter",
       "close": "Fermer",
       "closeOthers": "Fermer les autres",
       "closeAll": "Tout fermer",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "会話タブを閉じる",
+      "reconnect": "再接続",
       "close": "閉じる",
       "closeOthers": "他を閉じる",
       "closeAll": "すべて閉じる",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "대화 탭 닫기",
+      "reconnect": "다시 연결",
       "close": "닫기",
       "closeOthers": "다른 항목 닫기",
       "closeAll": "모두 닫기",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "Fechar aba de conversa",
+      "reconnect": "Reconectar",
       "close": "Fechar",
       "closeOthers": "Fechar outros",
       "closeAll": "Fechar tudo",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "关闭会话标签",
+      "reconnect": "重新连接",
       "close": "关闭",
       "closeOthers": "关闭其它",
       "closeAll": "关闭所有",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1172,6 +1172,7 @@
     },
     "tabs": {
       "closeConversationTab": "關閉會話分頁",
+      "reconnect": "重新連接",
       "close": "關閉",
       "closeOthers": "關閉其它",
       "closeAll": "關閉所有",


### PR DESCRIPTION
## Summary
- add a Reconnect action to conversation tab context menus
- wire the action to reapply the ACP configuration for the selected tab
- add localized tab menu labels for supported locales

## Notes
- Port-related config files are intentionally not changed in this PR.

## Tests
- Not run; UI-only context menu change.