### PR TITLE
fix(chat): show full model name on hover

### DIFF
--- a/src/components/chat/dropdown-radio-item-content.tsx
+++ b/src/components/chat/dropdown-radio-item-content.tsx
@@ -12,7 +12,7 @@ export function DropdownRadioItemContent({
   const normalizedDescription = description?.trim()
 
   return (
-    <div className="w-full min-w-0 pr-2">
+    <div className="w-full min-w-0 pr-2" title={label}>
       <p className="truncate">{label}</p>
       {normalizedDescription ? (
         <p className="text-muted-foreground mt-0.5 text-xs leading-snug whitespace-pre-wrap wrap-break-word">

--- a/src/components/chat/session-config-selector.tsx
+++ b/src/components/chat/session-config-selector.tsx
@@ -44,7 +44,10 @@ export function SessionConfigSelector({
         <span className="min-w-0 flex-1 truncate font-medium">
           {option.name}
         </span>
-        <span className="max-w-[10rem] shrink-0 truncate text-xs text-muted-foreground">
+        <span
+          className="max-w-[10rem] shrink-0 truncate text-xs text-muted-foreground"
+          title={currentLabel}
+        >
           {currentLabel}
         </span>
       </DropdownMenuSubTrigger>
@@ -68,6 +71,7 @@ export function SessionConfigSelector({
                     <DropdownMenuRadioItem
                       key={`${group.group}-${item.value}`}
                       value={item.value}
+                      title={item.name}
                     >
                       <DropdownRadioItemContent
                         label={item.name}
@@ -78,7 +82,11 @@ export function SessionConfigSelector({
                 </Fragment>
               ))
             : option.kind.options.map((item) => (
-                <DropdownMenuRadioItem key={item.value} value={item.value}>
+                <DropdownMenuRadioItem
+                  key={item.value}
+                  value={item.value}
+                  title={item.name}
+                >
                   <DropdownRadioItemContent
                     label={item.name}
                     description={item.description}
@@ -112,7 +120,7 @@ export function InlineSessionConfigSelector({
         <Button
           variant="ghost"
           size="xs"
-          title={option.description ?? option.name}
+          title={currentLabel}
           className="min-w-0 gap-0.5 px-1 text-muted-foreground"
         >
           <span className="max-w-[10rem] truncate">{currentLabel}</span>
@@ -142,6 +150,7 @@ export function InlineSessionConfigSelector({
                     <DropdownMenuRadioItem
                       key={`${group.group}-${item.value}`}
                       value={item.value}
+                      title={item.name}
                     >
                       <DropdownRadioItemContent
                         label={item.name}
@@ -152,7 +161,11 @@ export function InlineSessionConfigSelector({
                 </Fragment>
               ))
             : option.kind.options.map((item) => (
-                <DropdownMenuRadioItem key={item.value} value={item.value}>
+                <DropdownMenuRadioItem
+                  key={item.value}
+                  value={item.value}
+                  title={item.name}
+                >
                   <DropdownRadioItemContent
                     label={item.name}
                     description={item.description}


### PR DESCRIPTION
## Summary
- Add hover title text for model options in the chat input model selector.
- Add hover title text for the selected model label when it is truncated.

## Why
When choosing a model, long model names are truncated with ellipsis, making it hard to tell which model is which. Hovering now shows the complete model name.

## Notes
- No port-related configuration files were changed.

## Checks
- pnpm eslint src/components/chat/session-config-selector.tsx src/components/chat/dropdown-radio-item-content.tsx
- git diff --check