### PR TITLE
[codex] Add paginated conversation detail API for mobile

### DIFF
--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -14,6 +14,27 @@ use crate::parsers::hermes::HermesParser;
 use crate::parsers::openclaw::OpenClawParser;
 use crate::parsers::opencode::OpenCodeParser;
 use crate::parsers::{path_eq_for_matching, AgentParser, ParseError};
+
+const DEFAULT_CONVERSATION_TURNS_PAGE_SIZE: usize = 30;
+
+fn paginate_turns(
+    turns: Vec<MessageTurn>,
+    before_turn_index: Option<usize>,
+    page_size: Option<usize>,
+) -> (Vec<MessageTurn>, bool, Option<usize>, usize) {
+    let total = turns.len();
+    let page_size = page_size.unwrap_or(DEFAULT_CONVERSATION_TURNS_PAGE_SIZE).max(1);
+    let end = before_turn_index.unwrap_or(total).min(total);
+    let start = end.saturating_sub(page_size);
+    let has_more_history = start > 0;
+    let next_before_turn_index = has_more_history.then_some(start);
+    (
+        turns[start..end].to_vec(),
+        has_more_history,
+        next_before_turn_index,
+        page_size,
+    )
+}
 use crate::web::event_bridge::{
     emit_event, ConversationChange, EventEmitter, TabsChanged, CONVERSATION_CHANGED_EVENT,
     TABS_CHANGED_EVENT,
@@ -821,6 +842,50 @@ pub async fn get_folder_conversation(
     .await
 }
 
+pub async fn get_folder_conversation_paginated_core(
+    conn: &sea_orm::DatabaseConnection,
+    manager: &crate::acp::manager::ConnectionManager,
+    emitter: &EventEmitter,
+    conversation_id: i32,
+    before_turn_index: Option<usize>,
+    page_size: Option<usize>,
+) -> Result<DbConversationDetailPage, AppCommandError> {
+    let detail =
+        get_folder_conversation_with_live_core(conn, manager, emitter, conversation_id).await?;
+    let (turns, has_more_history, next_before_turn_index, page_size) =
+        paginate_turns(detail.turns, before_turn_index, page_size);
+    Ok(DbConversationDetailPage {
+        summary: detail.summary,
+        turns,
+        has_more_history,
+        next_before_turn_index,
+        page_size,
+        session_stats: detail.session_stats,
+        in_flight_user_turn_id: detail.in_flight_user_turn_id,
+    })
+}
+
+#[cfg(feature = "tauri-runtime")]
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn get_folder_conversation_paginated(
+    app: tauri::AppHandle,
+    db: tauri::State<'_, AppDatabase>,
+    manager: tauri::State<'_, crate::acp::manager::ConnectionManager>,
+    conversation_id: i32,
+    before_turn_index: Option<usize>,
+    page_size: Option<usize>,
+) -> Result<DbConversationDetailPage, AppCommandError> {
+    get_folder_conversation_paginated_core(
+        &db.conn,
+        &manager,
+        &EventEmitter::Tauri(app),
+        conversation_id,
+        before_turn_index,
+        page_size,
+    )
+    .await
+}
+
 /// Emit a `conversation://changed` Upsert for `conversation_id` so every
 /// client's sidebar inserts-or-replaces the row in real time. Re-fetches the
 /// fresh summary via `get_by_id`, which filters out soft-deleted rows — so an
@@ -1562,6 +1627,63 @@ mod tests {
             model: None,
             completed_at: completed.then_some(ts),
         }
+    }
+
+    fn pagination_turns(count: usize) -> Vec<MessageTurn> {
+        (0..count)
+            .map(|index| user_text_turn(&format!("turn-{index}"), "turn", at(index as i64)))
+            .collect()
+    }
+
+    #[test]
+    fn paginate_turns_returns_latest_default_page() {
+        let (page, has_more_history, next_before_turn_index, page_size) =
+            paginate_turns(pagination_turns(100), None, None);
+
+        assert_eq!(page.len(), 30);
+        assert_eq!(page.first().map(|turn| turn.id.as_str()), Some("turn-70"));
+        assert_eq!(page.last().map(|turn| turn.id.as_str()), Some("turn-99"));
+        assert!(has_more_history);
+        assert_eq!(next_before_turn_index, Some(70));
+        assert_eq!(page_size, 30);
+    }
+
+    #[test]
+    fn paginate_turns_returns_page_before_cursor() {
+        let (page, has_more_history, next_before_turn_index, page_size) =
+            paginate_turns(pagination_turns(100), Some(70), Some(30));
+
+        assert_eq!(page.len(), 30);
+        assert_eq!(page.first().map(|turn| turn.id.as_str()), Some("turn-40"));
+        assert_eq!(page.last().map(|turn| turn.id.as_str()), Some("turn-69"));
+        assert!(has_more_history);
+        assert_eq!(next_before_turn_index, Some(40));
+        assert_eq!(page_size, 30);
+    }
+
+    #[test]
+    fn paginate_turns_marks_first_page_as_complete_history() {
+        let (page, has_more_history, next_before_turn_index, page_size) =
+            paginate_turns(pagination_turns(12), Some(12), Some(30));
+
+        assert_eq!(page.len(), 12);
+        assert_eq!(page.first().map(|turn| turn.id.as_str()), Some("turn-0"));
+        assert_eq!(page.last().map(|turn| turn.id.as_str()), Some("turn-11"));
+        assert!(!has_more_history);
+        assert_eq!(next_before_turn_index, None);
+        assert_eq!(page_size, 30);
+    }
+
+    #[test]
+    fn paginate_turns_clamps_zero_page_size_to_one() {
+        let (page, has_more_history, next_before_turn_index, page_size) =
+            paginate_turns(pagination_turns(3), None, Some(0));
+
+        assert_eq!(page.len(), 1);
+        assert_eq!(page.first().map(|turn| turn.id.as_str()), Some("turn-2"));
+        assert!(has_more_history);
+        assert_eq!(next_before_turn_index, Some(2));
+        assert_eq!(page_size, 1);
     }
 
     fn pending_text(message_id: &str, text: &str) -> crate::acp::session_state::PendingUserMessage {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -782,6 +782,7 @@ mod tauri_app {
                 conversations::save_opened_tabs,
                 conversations::import_local_conversations,
                 conversations::get_folder_conversation,
+                conversations::get_folder_conversation_paginated,
                 conversations::list_folders,
                 conversations::get_stats,
                 conversations::get_sidebar_data,

--- a/src-tauri/src/models/conversation.rs
+++ b/src-tauri/src/models/conversation.rs
@@ -91,6 +91,19 @@ pub struct DbConversationDetail {
     pub in_flight_user_turn_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct DbConversationDetailPage {
+    pub summary: DbConversationSummary,
+    pub turns: Vec<MessageTurn>,
+    pub has_more_history: bool,
+    pub next_before_turn_index: Option<usize>,
+    pub page_size: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_stats: Option<SessionStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_flight_user_turn_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FolderInfo {
     pub path: String,

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -14,8 +14,8 @@ pub use agent::AgentType;
 pub use chat_channel::{ChannelStatusInfo, ChatChannelInfo, ChatChannelMessageLogInfo};
 pub use conversation::{
     AgentConversationCount, AgentStats, ConversationDetail, ConversationSummary,
-    DbConversationDetail, DbConversationSummary, FolderInfo, ImportResult, SessionStats,
-    SidebarData,
+    DbConversationDetail, DbConversationDetailPage, DbConversationSummary, FolderInfo,
+    ImportResult, SessionStats, SidebarData,
 };
 pub use folder::{
     FolderCommandInfo, FolderDetail, FolderHistoryEntry, OpenedTab, OpenedTabsSnapshot,

--- a/src-tauri/src/web/handlers/conversations.rs
+++ b/src-tauri/src/web/handlers/conversations.rs
@@ -127,6 +127,14 @@ pub struct GetFolderConversationParams {
     pub conversation_id: i32,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetFolderConversationPaginatedParams {
+    pub conversation_id: i32,
+    pub before_turn_index: Option<usize>,
+    pub page_size: Option<usize>,
+}
+
 pub async fn get_folder_conversation(
     Extension(state): Extension<Arc<AppState>>,
     Json(params): Json<GetFolderConversationParams>,
@@ -137,6 +145,23 @@ pub async fn get_folder_conversation(
         &state.connection_manager,
         &state.emitter,
         params.conversation_id,
+    )
+    .await?;
+    Ok(Json(result))
+}
+
+pub async fn get_folder_conversation_paginated(
+    Extension(state): Extension<Arc<AppState>>,
+    Json(params): Json<GetFolderConversationPaginatedParams>,
+) -> Result<Json<DbConversationDetailPage>, AppCommandError> {
+    let db = &state.db;
+    let result = conv_commands::get_folder_conversation_paginated_core(
+        &db.conn,
+        &state.connection_manager,
+        &state.emitter,
+        params.conversation_id,
+        params.before_turn_index,
+        params.page_size,
     )
     .await?;
     Ok(Json(result))

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -97,6 +97,10 @@ pub fn build_router(
             post(handlers::conversations::get_folder_conversation),
         )
         .route(
+            "/get_folder_conversation_paginated",
+            post(handlers::conversations::get_folder_conversation_paginated),
+        )
+        .route(
             "/list_opened_tabs",
             post(handlers::conversations::list_opened_tabs),
         )

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   ConversationSummary,
   ConversationDetail,
   DbConversationDetail,
+  DbConversationDetailPage,
   FolderInfo,
   AgentStats,
   SidebarData,
@@ -888,6 +889,18 @@ export async function getFolderConversation(
   conversationId: number
 ): Promise<DbConversationDetail> {
   return getTransport().call("get_folder_conversation", { conversationId })
+}
+
+export async function getFolderConversationPaginated(params: {
+  conversationId: number
+  beforeTurnIndex?: number | null
+  pageSize?: number | null
+}): Promise<DbConversationDetailPage> {
+  return getTransport().call("get_folder_conversation_paginated", {
+    conversationId: params.conversationId,
+    beforeTurnIndex: params.beforeTurnIndex ?? null,
+    pageSize: params.pageSize ?? null,
+  })
 }
 
 export async function removeFolderFromHistory(path: string): Promise<void> {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -5,6 +5,7 @@ import type {
   ConversationSummary,
   ConversationDetail,
   DbConversationDetail,
+  DbConversationDetailPage,
   FolderInfo,
   AgentStats,
   SidebarData,
@@ -589,6 +590,18 @@ export async function getFolderConversation(
   conversationId: number
 ): Promise<DbConversationDetail> {
   return invoke("get_folder_conversation", { conversationId })
+}
+
+export async function getFolderConversationPaginated(params: {
+  conversationId: number
+  beforeTurnIndex?: number | null
+  pageSize?: number | null
+}): Promise<DbConversationDetailPage> {
+  return invoke("get_folder_conversation_paginated", {
+    conversationId: params.conversationId,
+    beforeTurnIndex: params.beforeTurnIndex ?? null,
+    pageSize: params.pageSize ?? null,
+  })
 }
 
 export async function removeFolderFromHistory(path: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -381,6 +381,16 @@ export interface DbConversationDetail {
   in_flight_user_turn_id?: string | null
 }
 
+export interface DbConversationDetailPage {
+  summary: DbConversationSummary
+  turns: MessageTurn[]
+  has_more_history: boolean
+  next_before_turn_index?: number | null
+  page_size: number
+  session_stats?: SessionStats | null
+  in_flight_user_turn_id?: string | null
+}
+
 export type ConversationStatus =
   | "in_progress"
   | "pending_review"


### PR DESCRIPTION
## Summary

This is a conflict-free replacement for #283, rebased on the current `xintaofei/codeg:main`.

It adds a mobile-oriented paginated conversation detail API while leaving the existing full-detail API intact:

- adds `DbConversationDetailPage` for summaries plus a window of turns
- adds `get_folder_conversation_paginated` for both Tauri commands and the Axum web API
- exposes the new API through the frontend API/Tauri wrappers and TypeScript types
- adds unit coverage for pagination boundaries

## Rebase notes

The old #283 branch conflicted in `src/components/message/message-list-view.tsx`. That file was only carrying a formatting/layout conflict from the old branch, not the paginated API behavior, so this replacement keeps the current `main` version of that component and retains only the API/model/client changes.

The compile issue after replaying the old commit was caused by the new `DbConversationDetailPage` model not being exported through `src-tauri/src/models/mod.rs`, while the command and web handler modules rely on `crate::models::*`. This PR exports the type at the model boundary instead of adding one-off imports in each consumer.

## Compatibility

The existing `get_folder_conversation` response shape and route remain unchanged. Mobile clients can opt into `get_folder_conversation_paginated` with optional `beforeTurnIndex` and `pageSize` parameters. The first call defaults to the latest 30 turns, then older pages can be requested with `next_before_turn_index` while `has_more_history` is true.

## Validation

- `cargo test --no-default-features --lib paginate_turns`
- `cargo check --no-default-features --bin codeg-server`
- `pnpm exec eslint src/lib/api.ts src/lib/tauri.ts src/lib/types.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`
