### PR TITLE
Expand local Codex session scanning

### DIFF
--- a/docs/plans/2026-06-27-session-scan-fusion.md
+++ b/docs/plans/2026-06-27-session-scan-fusion.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Expand Codeg's local Codex/Claude history discovery while keeping the existing clean Codeg UI and avoiding direct native transcript write-back.
+**Goal:** Expand Codeg's local Codex/Claude history discovery and make imported native sessions resume through the native tools while keeping the existing clean Codeg UI and avoiding direct native transcript write-back.
 
-**Architecture:** Phase 1 changes the Rust backend only. `CodexParser` moves from one `base_dir` to ordered session roots, scans active and archived roots, deduplicates by native session id, and keeps existing `ConversationSummary`/`ConversationDetail` interfaces. Phase 2 remains design-only in this plan: reverse sync is resume-based and does not fabricate Codex/Claude JSONL.
+**Architecture:** Phase 1 changes the Rust backend parser roots. `CodexParser` moves from one `base_dir` to ordered session roots, scans active and archived roots, deduplicates by native session id, and keeps existing `ConversationSummary`/`ConversationDetail` interfaces. Phase 2 is delivered in the same branch by verifying and tightening the existing `external_id -> acp_connect(sessionId)` resume path for imported Codex/Claude conversations; it does not fabricate Codex/Claude JSONL.
 
 **Tech Stack:** Rust 2021, Tauri backend, `walkdir`, `chrono`, existing Codeg parser traits, Rust unit tests in `src-tauri/src/parsers`.
 
@@ -27,6 +27,7 @@
 - Modify `docs/specs/2026-06-27-session-scan-fusion-design.md`: already done; keep it as the source design.
 - No frontend files change in Phase 1.
 - No database migrations change in Phase 1.
+- Phase 2 may modify `src/components/conversations/conversation-detail-panel.tsx`, `src/contexts/acp-connections-context.tsx`, `src/hooks/use-connection-lifecycle.ts`, and tests only if the existing imported-session resume path is not already covered.
 
 ---
 
@@ -618,11 +619,163 @@ git commit -m "feat: archive codex active and archived transcripts"
 
 ---
 
-### Task 5: Focused Verification and Phase 2 Reverse Sync Follow-Up
+### Task 5: Resume-Based Reverse Sync Verification
+
+**Files:**
+- Test: `src/components/conversations/conversation-detail-panel-layout.test.tsx` or nearest existing conversation-detail test
+- Test: `src/contexts/acp-connections-context.test.tsx`
+- Modify: `src/components/conversations/conversation-detail-panel.tsx` only if tests expose a missing imported-session resume guard
+- Modify: `src/contexts/acp-connections-context.tsx` only if tests expose session id loss before `acpConnect`
+- Modify: `src/hooks/use-connection-lifecycle.ts` only if tests expose stale `sessionIdRef` behavior
+
+**Interfaces:**
+- Consumes: imported conversation `summary.external_id`
+- Consumes: `useConnectionLifecycle({ sessionId })`
+- Consumes: `acpConnect(agentType, workingDir, sessionId, ...)`
+- Produces: imported Codex/Claude conversations auto-connect with native `sessionId`
+
+- [ ] **Step 1: Add frontend test proving imported history passes external_id to lifecycle**
+
+Locate the nearest existing test that renders `ConversationDetailPanel` with a persisted conversation detail. Add a test equivalent to:
+
+```tsx
+it("passes imported native external_id as sessionId when auto-connecting", async () => {
+  mockUseConversationDetail.mockReturnValue({
+    detail: {
+      summary: {
+        id: 42,
+        external_id: "native-session-123",
+        agent_type: "codex",
+        title: "Imported Codex",
+      },
+      turns: [],
+    },
+    loading: false,
+    error: null,
+    acpLoadError: null,
+  })
+
+  renderConversationDetailPanel({
+    conversationId: 42,
+    agentType: "codex",
+    workingDir: "G:\\\\CTF",
+    isActive: true,
+  })
+
+  await waitFor(() => {
+    expect(mockUseConnectionLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentType: "codex",
+        sessionId: "native-session-123",
+        conversationId: 42,
+      })
+    )
+  })
+})
+```
+
+Use the repository's actual mocks and helper names. The assertion must prove `external_id` reaches `useConnectionLifecycle` as `sessionId`.
+
+- [ ] **Step 2: Run test and verify current behavior**
+
+Run the relevant Vitest file:
+
+```powershell
+pnpm test src/components/conversations/conversation-detail-panel-layout.test.tsx
+```
+
+Expected: PASS if the existing code already routes imported `external_id` correctly; FAIL if the test helper exposes a missing guard.
+
+- [ ] **Step 3: Add ACP context test proving sessionId reaches acpConnect**
+
+In `src/contexts/acp-connections-context.test.tsx`, add or adapt a test equivalent to:
+
+```tsx
+it("passes imported native session id to acpConnect", async () => {
+  const { actions } = renderAcpConnectionsProvider()
+
+  await act(async () => {
+    await actions.connect(
+      "conv-42",
+      "codex",
+      "G:\\\\CTF",
+      "native-session-123",
+      42
+    )
+  })
+
+  expect(acpConnectMock).toHaveBeenCalledWith(
+    "codex",
+    "G:\\\\CTF",
+    "native-session-123",
+    expect.anything(),
+    expect.anything()
+  )
+})
+```
+
+Use the repository's actual provider/test harness. The assertion must prove no layer strips `sessionId` before `acpConnect`.
+
+- [ ] **Step 4: Run ACP context test**
+
+Run:
+
+```powershell
+pnpm test src/contexts/acp-connections-context.test.tsx
+```
+
+Expected: PASS if existing code already supports resume-based reverse sync.
+
+- [ ] **Step 5: Fix only if a test fails**
+
+If Step 1 fails, keep `conversation-detail-panel.tsx` behavior aligned with this existing logic:
+
+```tsx
+const externalId =
+  detail?.summary.external_id ?? runtimeSession?.externalId ?? undefined
+
+const awaitingHistoricalSessionId =
+  hasPersistedConversation && selectedAgent !== "cline" && detailLoading
+```
+
+If Step 3 fails, keep `acp-connections-context.tsx` behavior aligned with this existing call:
+
+```tsx
+const connectionId = await acpConnect(
+  agentType,
+  workingDir,
+  sessionId,
+  savedPrefs.modeId,
+  savedPrefs.configValues
+)
+```
+
+Do not add JSONL write-back. Do not add a new runtime mode unless these tests prove the existing path cannot support imported-session resume.
+
+- [ ] **Step 6: Add user-facing note only if needed**
+
+If current UI does not make native resume behavior discoverable, add a short tooltip or session details copy near the existing external id display:
+
+```tsx
+Native session id. When this conversation is continued, Codeg resumes this native session instead of rewriting the transcript directly.
+```
+
+Do not add a new button in this task unless existing UX has no way to continue imported sessions.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add src/components/conversations src/contexts src/hooks
+git commit -m "test: cover imported native session resume"
+```
+
+---
+
+### Task 6: Focused Verification and PR
 
 **Files:**
 - Modify: `docs/specs/2026-06-27-session-scan-fusion-design.md` only if implementation changed the accepted design
-- No code required for Phase 2 in this task
+- No direct transcript write-back is allowed
 
 **Interfaces:**
 - Consumes: all previous tasks
@@ -681,18 +834,18 @@ gh pr create --repo xintaofei/codeg --head hight456789:fusion/session-scan-roots
 
 Expected: draft PR URL printed.
 
-- [ ] **Step 6: Record Phase 2 reverse sync as follow-up**
+- [ ] **Step 6: Record reverse sync behavior in PR body**
 
 Add this paragraph to the PR body or follow-up issue if requested:
 
 ```markdown
-Reverse sync follow-up: imported Codex/Claude conversations should continue through native resume flows (`codex resume <session>` / `claude --resume <session>`) so the native tools remain the transcript writers. Codeg metadata should stay in Codeg storage keyed by `(agent_type, external_id)`.
+Reverse sync behavior: imported Codex/Claude conversations continue through native resume flows by passing `external_id` as the native session id to Codeg's ACP connect path. Native tools remain the transcript writers. Codeg metadata stays in Codeg storage keyed by `(agent_type, external_id)`.
 ```
 
 ---
 
 ## Self-Review
 
-- Spec coverage: Task 1-4 cover Codex active/archived/default/extra root scanning, dedupe, detail lookup, and archive/export source inclusion. Claude remains unchanged unless a test later proves path matching gaps, matching the spec. Phase 2 reverse sync is explicitly documented as follow-up and not implemented in Phase 1.
+- Spec coverage: Task 1-4 cover Codex active/archived/default/extra root scanning, dedupe, detail lookup, and archive/export source inclusion. Claude remains unchanged unless a test later proves path matching gaps, matching the spec. Task 5 covers same-branch resume-based reverse sync by testing the imported `external_id` path through frontend lifecycle and ACP connect.
 - Placeholder scan: No TODO/TBD placeholders.
 - Type consistency: `resolve_codex_session_roots()` and `resolve_codex_session_roots_from(...)` are defined before use; `CodexParser::with_session_roots(...)` is test-only; `candidate_jsonl_files()` is private to the parser.

--- a/docs/plans/2026-06-27-session-scan-fusion.md
+++ b/docs/plans/2026-06-27-session-scan-fusion.md
@@ -1,0 +1,698 @@
+# Session Scan Fusion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand Codeg's local Codex/Claude history discovery while keeping the existing clean Codeg UI and avoiding direct native transcript write-back.
+
+**Architecture:** Phase 1 changes the Rust backend only. `CodexParser` moves from one `base_dir` to ordered session roots, scans active and archived roots, deduplicates by native session id, and keeps existing `ConversationSummary`/`ConversationDetail` interfaces. Phase 2 remains design-only in this plan: reverse sync is resume-based and does not fabricate Codex/Claude JSONL.
+
+**Tech Stack:** Rust 2021, Tauri backend, `walkdir`, `chrono`, existing Codeg parser traits, Rust unit tests in `src-tauri/src/parsers`.
+
+## Global Constraints
+
+- Preserve Codeg's current UI and conversation database schema.
+- Do not merge desktop-cc-gui's full session catalog UI or runtime model.
+- Do not read another application's private SQLite state.
+- Do not start Codex or Claude processes just to list history.
+- Do not directly fabricate or rewrite Codex/Claude JSONL transcripts.
+- Missing roots return empty results or partial results; unreadable files are skipped consistently with current parser behavior.
+- Use `CODEG_CODEX_HOME_DIRS` for explicitly configured extra Codex/provider homes.
+
+---
+
+## File Structure
+
+- Modify `src-tauri/src/parsers/codex.rs`: add Codex session root resolution, multi-root parser state, list/detail search, and focused tests.
+- Modify `src-tauri/src/parsers/mod.rs`: update Codex external transcript sources to include active and archived roots.
+- Modify `docs/specs/2026-06-27-session-scan-fusion-design.md`: already done; keep it as the source design.
+- No frontend files change in Phase 1.
+- No database migrations change in Phase 1.
+
+---
+
+### Task 1: Codex Session Root Resolver
+
+**Files:**
+- Modify: `src-tauri/src/parsers/codex.rs`
+
+**Interfaces:**
+- Produces: `pub(crate) fn resolve_codex_session_roots() -> Vec<PathBuf>`
+- Produces: `fn resolve_codex_session_roots_from(codex_home_env: Option<OsString>, extra_homes_env: Option<OsString>, home_dir: Option<PathBuf>) -> Vec<PathBuf>`
+- Consumes: existing `resolve_codex_home_dir_from(...) -> PathBuf`
+
+- [ ] **Step 1: Write failing tests for default active and archived roots**
+
+Add this test module content inside the existing `#[cfg(test)] mod tests` in `src-tauri/src/parsers/codex.rs`:
+
+```rust
+#[test]
+fn codex_session_roots_include_sessions_and_archived_sessions() {
+    let home = PathBuf::from("/Users/default");
+    let roots = resolve_codex_session_roots_from(None, None, Some(home));
+
+    assert_eq!(
+        roots,
+        vec![
+            PathBuf::from("/Users/default/.codex/sessions"),
+            PathBuf::from("/Users/default/.codex/archived_sessions"),
+        ]
+    );
+}
+
+#[test]
+fn codex_session_roots_honor_codex_home_override() {
+    let roots = resolve_codex_session_roots_from(
+        Some(std::ffi::OsString::from("/tmp/custom-codex")),
+        None,
+        Some(PathBuf::from("/Users/default")),
+    );
+
+    assert_eq!(
+        roots,
+        vec![
+            PathBuf::from("/tmp/custom-codex/sessions"),
+            PathBuf::from("/tmp/custom-codex/archived_sessions"),
+        ]
+    );
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test codex_session_roots_include_sessions_and_archived_sessions codex_session_roots_honor_codex_home_override
+```
+
+Expected: FAIL because `resolve_codex_session_roots_from` does not exist.
+
+- [ ] **Step 3: Implement root resolver**
+
+In `src-tauri/src/parsers/codex.rs`, change imports:
+
+```rust
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+```
+
+Add these functions after `resolve_codex_home_dir_from`:
+
+```rust
+pub(crate) fn resolve_codex_session_roots() -> Vec<PathBuf> {
+    resolve_codex_session_roots_from(
+        std::env::var_os("CODEX_HOME"),
+        std::env::var_os("CODEG_CODEX_HOME_DIRS"),
+        dirs::home_dir(),
+    )
+}
+
+fn resolve_codex_session_roots_from(
+    codex_home_env: Option<OsString>,
+    extra_homes_env: Option<OsString>,
+    home_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let primary_home = resolve_codex_home_dir_from(codex_home_env, home_dir);
+    let mut homes = vec![primary_home];
+
+    if let Some(extra_homes) = extra_homes_env {
+        for home in std::env::split_paths(&extra_homes) {
+            if !home.as_os_str().is_empty() {
+                homes.push(home);
+            }
+        }
+    }
+
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    for home in homes {
+        for root in [home.join("sessions"), home.join("archived_sessions")] {
+            if seen.insert(root.clone()) {
+                roots.push(root);
+            }
+        }
+    }
+    roots
+}
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test codex_session_roots_include_sessions_and_archived_sessions codex_session_roots_honor_codex_home_override
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add src-tauri/src/parsers/codex.rs
+git commit -m "feat: resolve codex session roots"
+```
+
+---
+
+### Task 2: Codex Parser Multi-Root Listing
+
+**Files:**
+- Modify: `src-tauri/src/parsers/codex.rs`
+
+**Interfaces:**
+- Consumes: `resolve_codex_session_roots() -> Vec<PathBuf>`
+- Produces: `CodexParser { session_roots: Vec<PathBuf> }`
+- Produces: `fn list_candidate_jsonl_files(&self) -> Vec<PathBuf>`
+
+- [ ] **Step 1: Write failing tests for archived scan and dedupe**
+
+Add helper and tests in `src-tauri/src/parsers/codex.rs` test module:
+
+```rust
+fn write_codex_rollout(path: &PathBuf, id: &str, cwd: &str, timestamp: &str, title: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent");
+    }
+    let content = format!(
+        "{{\"timestamp\":\"{timestamp}\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{id}\",\"cwd\":\"{cwd}\",\"git\":{{\"branch\":\"main\"}}}}}}\n\
+         {{\"timestamp\":\"{timestamp}\",\"type\":\"event_msg\",\"payload\":{{\"type\":\"user_message\",\"message\":\"{title}\"}}}}\n"
+    );
+    std::fs::write(path, content).expect("write rollout");
+}
+
+#[test]
+fn list_conversations_scans_archived_session_roots() {
+    let base = std::env::temp_dir().join(format!(
+        "codeg-codex-roots-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let archived = base.join("archived_sessions").join("2026").join("06").join("27");
+    write_codex_rollout(
+        &archived.join("rollout-2026-06-27T00-00-00-archived.jsonl"),
+        "archived-1",
+        "/repo",
+        "2026-06-27T00:00:00Z",
+        "archived prompt",
+    );
+
+    let parser = CodexParser::with_session_roots(vec![
+        base.join("sessions"),
+        base.join("archived_sessions"),
+    ]);
+    let summaries = parser.list_conversations().expect("list conversations");
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, "archived-1");
+    assert_eq!(summaries[0].title.as_deref(), Some("archived prompt"));
+
+    std::fs::remove_dir_all(base).expect("cleanup");
+}
+
+#[test]
+fn list_conversations_dedupes_duplicate_session_ids_by_newest_timestamp() {
+    let base = std::env::temp_dir().join(format!(
+        "codeg-codex-dedupe-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let active = base.join("sessions").join("2026").join("06").join("27");
+    let archived = base.join("archived_sessions").join("2026").join("06").join("27");
+    write_codex_rollout(
+        &archived.join("rollout-2026-06-27T00-00-00-same.jsonl"),
+        "same-1",
+        "/repo",
+        "2026-06-27T00:00:00Z",
+        "older archived prompt",
+    );
+    write_codex_rollout(
+        &active.join("rollout-2026-06-27T01-00-00-same.jsonl"),
+        "same-1",
+        "/repo",
+        "2026-06-27T01:00:00Z",
+        "newer active prompt",
+    );
+
+    let parser = CodexParser::with_session_roots(vec![
+        base.join("sessions"),
+        base.join("archived_sessions"),
+    ]);
+    let summaries = parser.list_conversations().expect("list conversations");
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, "same-1");
+    assert_eq!(summaries[0].title.as_deref(), Some("newer active prompt"));
+
+    std::fs::remove_dir_all(base).expect("cleanup");
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test list_conversations_scans_archived_session_roots list_conversations_dedupes_duplicate_session_ids_by_newest_timestamp
+```
+
+Expected: FAIL because `with_session_roots` does not exist and parser only has `base_dir`.
+
+- [ ] **Step 3: Replace single base dir with session roots**
+
+In `src-tauri/src/parsers/codex.rs`, replace:
+
+```rust
+pub struct CodexParser {
+    base_dir: PathBuf,
+}
+```
+
+with:
+
+```rust
+pub struct CodexParser {
+    session_roots: Vec<PathBuf>,
+}
+```
+
+Replace `new()` and test constructors with:
+
+```rust
+pub fn new() -> Self {
+    Self {
+        session_roots: resolve_codex_session_roots(),
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub fn with_base_dir(base_dir: PathBuf) -> Self {
+    Self {
+        session_roots: vec![base_dir],
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub fn with_session_roots(session_roots: Vec<PathBuf>) -> Self {
+    Self { session_roots }
+}
+```
+
+Add helper methods inside `impl CodexParser`:
+
+```rust
+fn candidate_jsonl_files(&self) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for root in &self.session_roots {
+        if !root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+            let path = entry.path().to_path_buf();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let fname = path.file_name().unwrap_or_default().to_string_lossy();
+            if fname.starts_with("rollout-") {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn dedupe_conversations(
+    conversations: Vec<ConversationSummary>,
+) -> Vec<ConversationSummary> {
+    let mut by_id: HashMap<String, ConversationSummary> = HashMap::new();
+    for summary in conversations {
+        match by_id.get(&summary.id) {
+            Some(existing) if existing.started_at >= summary.started_at => {}
+            _ => {
+                by_id.insert(summary.id.clone(), summary);
+            }
+        }
+    }
+    let mut conversations: Vec<ConversationSummary> = by_id.into_values().collect();
+    conversations.sort_by_key(|b| std::cmp::Reverse(b.started_at));
+    conversations
+}
+```
+
+Replace `list_conversations` with:
+
+```rust
+fn list_conversations(&self) -> Result<Vec<ConversationSummary>, ParseError> {
+    let mut conversations = Vec::new();
+
+    for path in self.candidate_jsonl_files() {
+        match self.parse_jsonl_summary(&path) {
+            Ok(Some(summary)) => conversations.push(summary),
+            _ => continue,
+        }
+    }
+
+    Ok(Self::dedupe_conversations(conversations))
+}
+```
+
+- [ ] **Step 4: Run tests and verify pass**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test list_conversations_scans_archived_session_roots list_conversations_dedupes_duplicate_session_ids_by_newest_timestamp
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run existing Codex parser tests**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test codex
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src-tauri/src/parsers/codex.rs
+git commit -m "feat: scan multiple codex session roots"
+```
+
+---
+
+### Task 3: Codex Detail Lookup Across Roots
+
+**Files:**
+- Modify: `src-tauri/src/parsers/codex.rs`
+
+**Interfaces:**
+- Consumes: `CodexParser::candidate_jsonl_files() -> Vec<PathBuf>`
+- Produces: root-wide `get_conversation(&self, conversation_id: &str)`
+
+- [ ] **Step 1: Write failing test for archived detail lookup**
+
+Add this test:
+
+```rust
+#[test]
+fn get_conversation_searches_archived_session_roots() {
+    let base = std::env::temp_dir().join(format!(
+        "codeg-codex-detail-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let archived = base.join("archived_sessions").join("2026").join("06").join("27");
+    write_codex_rollout(
+        &archived.join("rollout-2026-06-27T00-00-00-detail.jsonl"),
+        "detail-1",
+        "/repo",
+        "2026-06-27T00:00:00Z",
+        "detail prompt",
+    );
+
+    let parser = CodexParser::with_session_roots(vec![
+        base.join("sessions"),
+        base.join("archived_sessions"),
+    ]);
+    let detail = parser
+        .get_conversation("detail-1")
+        .expect("load archived detail");
+
+    assert_eq!(detail.id, "detail-1");
+
+    std::fs::remove_dir_all(base).expect("cleanup");
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test get_conversation_searches_archived_session_roots
+```
+
+Expected: FAIL if `get_conversation` still references removed `base_dir` or does not search all roots.
+
+- [ ] **Step 3: Implement all-root detail search**
+
+Replace `get_conversation` in `impl AgentParser for CodexParser` with:
+
+```rust
+fn get_conversation(&self, conversation_id: &str) -> Result<ConversationDetail, ParseError> {
+    let files = self.candidate_jsonl_files();
+
+    for path in &files {
+        if let Ok(Some(summary)) = self.parse_jsonl_summary(path) {
+            if summary.id == conversation_id {
+                return self.parse_conversation_detail(path, conversation_id);
+            }
+        }
+    }
+
+    for path in files {
+        let fname = path.file_name().unwrap_or_default().to_string_lossy();
+        if fname.contains(conversation_id) {
+            return self.parse_conversation_detail(&path, conversation_id);
+        }
+    }
+
+    Err(ParseError::ConversationNotFound(
+        conversation_id.to_string(),
+    ))
+}
+```
+
+- [ ] **Step 4: Run test and verify pass**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test get_conversation_searches_archived_session_roots
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run parser test group**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test codex
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src-tauri/src/parsers/codex.rs
+git commit -m "feat: load codex details from all roots"
+```
+
+---
+
+### Task 4: External Transcript Sources Include Archived Codex Sessions
+
+**Files:**
+- Modify: `src-tauri/src/parsers/mod.rs`
+- Modify: `src-tauri/src/parsers/codex.rs`
+
+**Interfaces:**
+- Consumes: `codex::resolve_codex_session_roots() -> Vec<PathBuf>`
+- Produces: `external_transcript_sources()` returns Codex active and archived roots
+
+- [ ] **Step 1: Add test for Codex external sources**
+
+Add a test module near the bottom of `src-tauri/src/parsers/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod external_source_tests {
+    use super::*;
+
+    #[test]
+    fn external_sources_include_codex_active_and_archived_roots() {
+        let sources = external_transcript_sources();
+        let codex_roots: Vec<String> = sources
+            .iter()
+            .filter(|source| source.agent == "codex")
+            .map(|source| source.root.to_string_lossy().replace('\\', "/"))
+            .collect();
+
+        assert!(
+            codex_roots.iter().any(|root| root.ends_with("/sessions")),
+            "codex sessions root missing: {codex_roots:?}"
+        );
+        assert!(
+            codex_roots
+                .iter()
+                .any(|root| root.ends_with("/archived_sessions")),
+            "codex archived_sessions root missing: {codex_roots:?}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test and verify failure**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test external_sources_include_codex_active_and_archived_roots
+```
+
+Expected: FAIL because only `sessions` is listed.
+
+- [ ] **Step 3: Update external sources**
+
+In `src-tauri/src/parsers/mod.rs`, replace the single Codex `ExternalSource` entry:
+
+```rust
+ExternalSource {
+    agent: "codex",
+    root: codex::resolve_codex_home_dir().join("sessions"),
+    is_file: false,
+    include_top: None,
+},
+```
+
+with dynamic extension after the initial vector is created. Remove the single Codex entry from the `vec![...]`, then add:
+
+```rust
+    for root in codex::resolve_codex_session_roots() {
+        sources.push(ExternalSource {
+            agent: "codex",
+            root,
+            is_file: false,
+            include_top: None,
+        });
+    }
+```
+
+Place the loop after the initial `vec![...]` and before the OpenClaw home block so Codex sources are included once.
+
+- [ ] **Step 4: Run test and verify pass**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test external_sources_include_codex_active_and_archived_roots
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run backup-related external parser tests**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test external
+```
+
+Expected: PASS or no unrelated failures.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add src-tauri/src/parsers/mod.rs src-tauri/src/parsers/codex.rs
+git commit -m "feat: archive codex active and archived transcripts"
+```
+
+---
+
+### Task 5: Focused Verification and Phase 2 Reverse Sync Follow-Up
+
+**Files:**
+- Modify: `docs/specs/2026-06-27-session-scan-fusion-design.md` only if implementation changed the accepted design
+- No code required for Phase 2 in this task
+
+**Interfaces:**
+- Consumes: all previous tasks
+- Produces: a branch ready to push and review
+
+- [ ] **Step 1: Run focused Rust tests**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test codex
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run parser module tests**
+
+Run:
+
+```powershell
+cd src-tauri
+cargo test parsers
+```
+
+Expected: PASS or identify unrelated pre-existing failures before proceeding.
+
+- [ ] **Step 3: Inspect diff**
+
+Run:
+
+```powershell
+git diff --stat origin/main..HEAD
+git diff origin/main..HEAD -- src-tauri/src/parsers/codex.rs src-tauri/src/parsers/mod.rs docs/specs/2026-06-27-session-scan-fusion-design.md
+```
+
+Expected: diff contains only parser/root/source/spec changes.
+
+- [ ] **Step 4: Push branch to fork**
+
+Run:
+
+```powershell
+git push -u fork fusion/session-scan-roots
+```
+
+Expected: branch pushed to `https://github.com/hight456789/codeg`.
+
+- [ ] **Step 5: Create PR draft**
+
+Run:
+
+```powershell
+gh pr create --repo xintaofei/codeg --head hight456789:fusion/session-scan-roots --base main --draft --title "Expand local Codex session scanning" --body "Adds multi-root Codex history scanning for active and archived sessions while preserving Codeg's existing UI. Reverse sync remains resume-based and does not write native JSONL directly."
+```
+
+Expected: draft PR URL printed.
+
+- [ ] **Step 6: Record Phase 2 reverse sync as follow-up**
+
+Add this paragraph to the PR body or follow-up issue if requested:
+
+```markdown
+Reverse sync follow-up: imported Codex/Claude conversations should continue through native resume flows (`codex resume <session>` / `claude --resume <session>`) so the native tools remain the transcript writers. Codeg metadata should stay in Codeg storage keyed by `(agent_type, external_id)`.
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1-4 cover Codex active/archived/default/extra root scanning, dedupe, detail lookup, and archive/export source inclusion. Claude remains unchanged unless a test later proves path matching gaps, matching the spec. Phase 2 reverse sync is explicitly documented as follow-up and not implemented in Phase 1.
+- Placeholder scan: No TODO/TBD placeholders.
+- Type consistency: `resolve_codex_session_roots()` and `resolve_codex_session_roots_from(...)` are defined before use; `CodexParser::with_session_roots(...)` is test-only; `candidate_jsonl_files()` is private to the parser.

--- a/docs/plans/2026-06-27-session-scan-fusion.md
+++ b/docs/plans/2026-06-27-session-scan-fusion.md
@@ -844,6 +844,12 @@ Reverse sync behavior: imported Codex/Claude conversations continue through nati
 
 ---
 
+## Plan Adjustment
+
+Before implementation, Task 4's original "one Codex `ExternalSource` per session root" approach was rejected because active and archived roots can contain the same relative year/month/file layout. With the same `agent: "codex"` archive namespace, that can collide during external transcript backup.
+
+Task 4 now uses the primary Codex home as the external archive root and sets `include_top: Some(&["sessions", "archived_sessions"])`, preserving both top-level directories. Extra homes from `CODEG_CODEX_HOME_DIRS` remain import-scan roots in this branch and are intentionally not archived until the external source model has a safe namespace for multiple Codex homes.
+
 ## Self-Review
 
 - Spec coverage: Task 1-4 cover Codex active/archived/default/extra root scanning, dedupe, detail lookup, and archive/export source inclusion. Claude remains unchanged unless a test later proves path matching gaps, matching the spec. Task 5 covers same-branch resume-based reverse sync by testing the imported `external_id` path through frontend lifecycle and ACP connect.

--- a/docs/specs/2026-06-27-session-scan-fusion-design.md
+++ b/docs/specs/2026-06-27-session-scan-fusion-design.md
@@ -6,6 +6,8 @@ Keep Codeg's existing workspace UI and conversation model, while importing the u
 
 The first implementation phase expands Codeg's backend parsers and import path so Codex and Claude history discovery finds more local sessions without adding a new catalog UI.
 
+A later phase adds reverse sync through native resume flows so continuing an imported Codex or Claude session from Codeg can still let the native tool own its transcript writes.
+
 ## Current Codeg Behavior
 
 Codeg already has a clean conversation sidebar and local import flow. The backend discovers external conversations through `AgentParser` implementations and imports matches into Codeg's database.
@@ -39,6 +41,7 @@ Claude discovery should keep Codeg's current UI model but improve path matching 
 - Do not read another application's private SQLite state in phase one.
 - Do not start or depend on Codex/Claude runtime processes just to list history.
 - Do not change Codeg's conversation database schema unless tests prove it is necessary.
+- Do not directly fabricate or rewrite Codex/Claude JSONL transcripts for reverse sync.
 
 ## Architecture
 
@@ -87,6 +90,28 @@ If the existing `ExternalSource` shape cannot represent multiple Codex roots cle
 Do not redesign the Claude parser in phase one. Add regression tests around Windows path normalization and project directory matching if current helpers already cover the behavior.
 
 Only change Claude code if a test proves current matching misses a real path shape from the user's environment.
+
+## Reverse Sync Phase 2
+
+Reverse sync means Codeg can continue work from an imported native session while preserving the native tool as the writer of its own transcript.
+
+The preferred implementation is resume-based:
+
+- For imported Codex conversations, Codeg launches the existing Codex ACP/runtime resume path using the imported `external_id` as the native session id.
+- For imported Claude conversations, Codeg launches the existing Claude resume path with `claude --resume <session_id>` or the equivalent runtime adapter flow.
+- The native tool writes its own transcript updates.
+- Codeg observes the resumed runtime stream and updates its own DB/sidebar state from runtime events and later parser refreshes.
+
+Codeg-owned metadata remains in Codeg storage:
+
+- Folder assignment.
+- Pin state.
+- Manual title override.
+- Notes or future Codeg-only annotations.
+
+This metadata should not be written into Codex/Claude JSONL files. If native transcript files cannot represent a Codeg-only field, Codeg stores a sidecar mapping keyed by `(agent_type, external_id)`.
+
+Direct JSONL write-back is an explicit non-default future experiment. It must stay behind an opt-in flag and require strict schema validation, append-only writes, backup-before-write, and parser round-trip tests for each engine version it supports.
 
 ## UI Behavior
 

--- a/docs/specs/2026-06-27-session-scan-fusion-design.md
+++ b/docs/specs/2026-06-27-session-scan-fusion-design.md
@@ -6,7 +6,7 @@ Keep Codeg's existing workspace UI and conversation model, while importing the u
 
 The first implementation phase expands Codeg's backend parsers and import path so Codex and Claude history discovery finds more local sessions without adding a new catalog UI.
 
-A later phase adds reverse sync through native resume flows so continuing an imported Codex or Claude session from Codeg can still let the native tool own its transcript writes.
+The same branch also verifies resume-based reverse sync: continuing an imported Codex or Claude session from Codeg should still let the native tool own its transcript writes.
 
 ## Current Codeg Behavior
 
@@ -91,11 +91,11 @@ Do not redesign the Claude parser in phase one. Add regression tests around Wind
 
 Only change Claude code if a test proves current matching misses a real path shape from the user's environment.
 
-## Reverse Sync Phase 2
+## Resume-Based Reverse Sync
 
 Reverse sync means Codeg can continue work from an imported native session while preserving the native tool as the writer of its own transcript.
 
-The preferred implementation is resume-based:
+The implementation is resume-based:
 
 - For imported Codex conversations, Codeg launches the existing Codex ACP/runtime resume path using the imported `external_id` as the native session id.
 - For imported Claude conversations, Codeg launches the existing Claude resume path with `claude --resume <session_id>` or the equivalent runtime adapter flow.

--- a/docs/specs/2026-06-27-session-scan-fusion-design.md
+++ b/docs/specs/2026-06-27-session-scan-fusion-design.md
@@ -83,7 +83,9 @@ Detail lookup should:
 
 Update `external_transcript_sources()` so Codex archive/export includes both `sessions` and `archived_sessions`.
 
-If the existing `ExternalSource` shape cannot represent multiple Codex roots cleanly, add multiple Codex sources with distinct archive labels, or add a helper that expands agent roots before archiving. Prefer the smaller change that does not alter backup restore semantics for other agents.
+Use the resolved primary Codex home as the archive source root with `include_top: Some(&["sessions", "archived_sessions"])`. This preserves the top-level directory name in backup paths and avoids active/archive files with the same relative year/month/file layout colliding under one `external/codex` namespace.
+
+Extra homes from `CODEG_CODEX_HOME_DIRS` are scanned for import in phase one. They are not added to archive/export until the external source model can namespace multiple Codex homes without restore ambiguity.
 
 ### Claude Path Matching
 

--- a/docs/specs/2026-06-27-session-scan-fusion-design.md
+++ b/docs/specs/2026-06-27-session-scan-fusion-design.md
@@ -1,0 +1,139 @@
+# Session Scan Fusion Design
+
+## Goal
+
+Keep Codeg's existing workspace UI and conversation model, while importing the useful local-history scan coverage from `desktop-cc-gui`.
+
+The first implementation phase expands Codeg's backend parsers and import path so Codex and Claude history discovery finds more local sessions without adding a new catalog UI.
+
+## Current Codeg Behavior
+
+Codeg already has a clean conversation sidebar and local import flow. The backend discovers external conversations through `AgentParser` implementations and imports matches into Codeg's database.
+
+The Codex parser currently scans only `resolve_codex_home_dir()/sessions` and only `rollout-*.jsonl` files. The external archive source also only includes `CODEX_HOME/sessions`.
+
+Claude scans `CLAUDE_CONFIG_DIR/projects` and imports sessions whose persisted folder path matches the selected Codeg folder.
+
+## Desired Behavior
+
+Codex discovery should scan all relevant local history roots:
+
+- Default Codex home `~/.codex/sessions`.
+- Default Codex home `~/.codex/archived_sessions`.
+- `$CODEX_HOME/sessions` when `CODEX_HOME` is set.
+- `$CODEX_HOME/archived_sessions` when `CODEX_HOME` is set.
+- Optional extra Codex homes from a Codeg-specific environment variable.
+- Compatible provider-home layout: `<provider-home>/sessions` and `<provider-home>/archived_sessions`, when such homes are explicitly listed.
+
+Claude discovery should keep Codeg's current UI model but improve path matching resilience:
+
+- Continue scanning `~/.claude/projects` or `$CLAUDE_CONFIG_DIR/projects`.
+- Preserve current import behavior for selected folders.
+- Normalize Windows and Unix path variants consistently.
+- Keep subagent files out of the root sidebar import unless already referenced by a parent detail view.
+
+## Non-Goals
+
+- Do not merge the desktop-cc-gui application UI into Codeg.
+- Do not add desktop-cc-gui's full session catalog projection in phase one.
+- Do not read another application's private SQLite state in phase one.
+- Do not start or depend on Codex/Claude runtime processes just to list history.
+- Do not change Codeg's conversation database schema unless tests prove it is necessary.
+
+## Architecture
+
+### Codex Session Roots
+
+Add a small root-resolution layer in `src-tauri/src/parsers/codex.rs`.
+
+It should return an ordered, deduplicated list of session directories. A directory is eligible when it exists and is one of:
+
+- `<codex-home>/sessions`
+- `<codex-home>/archived_sessions`
+- A compatible provider-home session directory
+
+The first source is still `CODEX_HOME` or `~/.codex`, preserving existing behavior. Additional sources must be additive.
+
+Use `CODEG_CODEX_HOME_DIRS` as the first-phase opt-in mechanism for extra homes. It is a path-list environment variable using the platform separator (`;` on Windows, `:` on Unix). Each listed value is treated as a Codex home or provider home, and Codeg scans its `sessions` and `archived_sessions` children.
+
+Do not automatically crawl another application's private storage directory in phase one.
+
+### Codex Summary Parsing
+
+Keep the existing `parse_jsonl_summary` and `parse_conversation_detail` logic. The change is mostly root enumeration and lookup.
+
+Listing should:
+
+- Walk every resolved root.
+- Accept Codex JSONL rollout files.
+- Deduplicate by `(agent_type, conversation_id)`.
+- Prefer the newest file if the same session appears in both active and archived roots.
+- Sort newest first as today.
+
+Detail lookup should:
+
+- Search all resolved roots.
+- Prefer an exact session id match when possible.
+- Fall back to filename containment only for compatibility with the existing behavior.
+
+### External Archive Sources
+
+Update `external_transcript_sources()` so Codex archive/export includes both `sessions` and `archived_sessions`.
+
+If the existing `ExternalSource` shape cannot represent multiple Codex roots cleanly, add multiple Codex sources with distinct archive labels, or add a helper that expands agent roots before archiving. Prefer the smaller change that does not alter backup restore semantics for other agents.
+
+### Claude Path Matching
+
+Do not redesign the Claude parser in phase one. Add regression tests around Windows path normalization and project directory matching if current helpers already cover the behavior.
+
+Only change Claude code if a test proves current matching misses a real path shape from the user's environment.
+
+## UI Behavior
+
+No first-phase UI redesign.
+
+Existing Codeg surfaces continue to work:
+
+- Workspace conversation sidebar.
+- Search.
+- Import local sessions button.
+- Conversation detail viewer.
+
+If additional roots are found, imported Codex sessions simply appear through the current conversation list.
+
+## Error Handling
+
+Missing roots are skipped silently.
+
+Unreadable roots log a warning and do not fail the whole import.
+
+Malformed JSONL lines continue to be skipped as the current parser does.
+
+If all roots are missing, the parser returns an empty list, preserving current behavior.
+
+## Testing
+
+Add Rust tests for the Codex parser:
+
+- Default `sessions` root still works.
+- `archived_sessions` root is scanned.
+- Duplicate session ids across active and archived roots are deduplicated.
+- Detail lookup searches archived roots.
+- `CODEX_HOME` override still wins.
+- Root ordering is stable.
+
+Add or preserve tests for `external_transcript_sources()` to prove Codex archive/export includes archived sessions.
+
+Run at least:
+
+```powershell
+cargo test -p codeg codex
+```
+
+If package selection differs in this repository, run the nearest focused command under `src-tauri`.
+
+## Rollout
+
+Implement behind existing parser behavior with no feature flag. The change is additive and should only increase discovered sessions.
+
+If performance becomes an issue for very large histories, add a later pagination or cached index layer. Do not add it in phase one.

--- a/src-tauri/src/parsers/codex.rs
+++ b/src-tauri/src/parsers/codex.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -183,13 +184,49 @@ pub(crate) fn resolve_codex_home_dir() -> PathBuf {
 }
 
 fn resolve_codex_home_dir_from(
-    codex_home_env: Option<std::ffi::OsString>,
+    codex_home_env: Option<OsString>,
     home_dir: Option<PathBuf>,
 ) -> PathBuf {
     codex_home_env
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir.unwrap_or_default().join(".codex"))
+}
+
+pub(crate) fn resolve_codex_session_roots() -> Vec<PathBuf> {
+    resolve_codex_session_roots_from(
+        std::env::var_os("CODEX_HOME"),
+        std::env::var_os("CODEG_CODEX_HOME_DIRS"),
+        dirs::home_dir(),
+    )
+}
+
+fn resolve_codex_session_roots_from(
+    codex_home_env: Option<OsString>,
+    extra_homes_env: Option<OsString>,
+    home_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
+    let primary_home = resolve_codex_home_dir_from(codex_home_env, home_dir);
+    let mut homes = vec![primary_home];
+
+    if let Some(extra_homes) = extra_homes_env {
+        for home in std::env::split_paths(&extra_homes) {
+            if !home.as_os_str().is_empty() {
+                homes.push(home);
+            }
+        }
+    }
+
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    for home in homes {
+        for root in [home.join("sessions"), home.join("archived_sessions")] {
+            if seen.insert(root.clone()) {
+                roots.push(root);
+            }
+        }
+    }
+    roots
 }
 
 impl AgentParser for CodexParser {
@@ -2048,6 +2085,7 @@ mod tests {
     use super::merge_codex_context_window_stats;
     use super::merge_codex_total_usage_stats;
     use super::resolve_codex_home_dir_from;
+    use super::resolve_codex_session_roots_from;
     use super::should_skip_duplicate_user_message;
     use super::strip_blocked_resource_mentions;
     use super::CodexParser;
@@ -2059,6 +2097,37 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn codex_session_roots_include_sessions_and_archived_sessions() {
+        let home = PathBuf::from("/Users/default");
+        let roots = resolve_codex_session_roots_from(None, None, Some(home));
+
+        assert_eq!(
+            roots,
+            vec![
+                PathBuf::from("/Users/default/.codex/sessions"),
+                PathBuf::from("/Users/default/.codex/archived_sessions"),
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_session_roots_honor_codex_home_override() {
+        let roots = resolve_codex_session_roots_from(
+            Some(std::ffi::OsString::from("/tmp/custom-codex")),
+            None,
+            Some(PathBuf::from("/Users/default")),
+        );
+
+        assert_eq!(
+            roots,
+            vec![
+                PathBuf::from("/tmp/custom-codex/sessions"),
+                PathBuf::from("/tmp/custom-codex/archived_sessions"),
+            ]
+        );
+    }
 
     #[test]
     fn skips_agents_instructions_title_candidate() {

--- a/src-tauri/src/parsers/codex.rs
+++ b/src-tauri/src/parsers/codex.rs
@@ -291,8 +291,18 @@ impl AgentParser for CodexParser {
     }
 
     fn get_conversation(&self, conversation_id: &str) -> Result<ConversationDetail, ParseError> {
-        // Find the conversation file by walking the directory tree
-        for path in self.candidate_jsonl_files() {
+        let files = self.candidate_jsonl_files();
+
+        for path in &files {
+            if let Ok(Some(summary)) = self.parse_jsonl_summary(path) {
+                if summary.id == conversation_id {
+                    return self.parse_conversation_detail(path, conversation_id);
+                }
+            }
+        }
+
+        // Keep filename lookup as a fallback for old or partial transcripts.
+        for path in files {
             let fname = path.file_name().unwrap_or_default().to_string_lossy();
             if fname.contains(conversation_id) {
                 return self.parse_conversation_detail(&path, conversation_id);
@@ -2232,6 +2242,36 @@ mod tests {
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].id, "same-1");
         assert_eq!(summaries[0].title.as_deref(), Some("newer active prompt"));
+
+        fs::remove_dir_all(base).expect("cleanup");
+    }
+
+    #[test]
+    fn get_conversation_searches_archived_session_roots() {
+        let base = env::temp_dir().join(format!(
+            "codeg-codex-detail-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let archived = base
+            .join("archived_sessions")
+            .join("2026")
+            .join("06")
+            .join("27");
+        write_codex_rollout(
+            &archived.join("rollout-2026-06-27T00-00-00-unrelated-file-name.jsonl"),
+            "detail-1",
+            "/repo",
+            "2026-06-27T00:00:00Z",
+            "detail prompt",
+        );
+
+        let parser = CodexParser::with_session_roots(vec![
+            base.join("sessions"),
+            base.join("archived_sessions"),
+        ]);
+        let detail = parser.get_conversation("detail-1").expect("conversation");
+
+        assert_eq!(detail.id, "detail-1");
 
         fs::remove_dir_all(base).expect("cleanup");
     }

--- a/src-tauri/src/parsers/codex.rs
+++ b/src-tauri/src/parsers/codex.rs
@@ -15,7 +15,7 @@ use crate::parsers::{
 };
 
 pub struct CodexParser {
-    base_dir: PathBuf,
+    session_roots: Vec<PathBuf>,
 }
 
 impl Default for CodexParser {
@@ -26,15 +26,62 @@ impl Default for CodexParser {
 
 impl CodexParser {
     pub fn new() -> Self {
-        let base_dir = resolve_codex_home_dir().join("sessions");
-        Self { base_dir }
+        Self {
+            session_roots: resolve_codex_session_roots(),
+        }
     }
 
     /// Test-only constructor that lets callers point the parser at a fixture
     /// directory instead of `~/.codex/sessions`.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn with_base_dir(base_dir: PathBuf) -> Self {
-        Self { base_dir }
+        Self {
+            session_roots: vec![base_dir],
+        }
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn with_session_roots(session_roots: Vec<PathBuf>) -> Self {
+        Self { session_roots }
+    }
+
+    fn candidate_jsonl_files(&self) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        for root in &self.session_roots {
+            if !root.exists() {
+                continue;
+            }
+
+            for entry in WalkDir::new(root).into_iter().filter_map(|e| e.ok()) {
+                let path = entry.path().to_path_buf();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                let fname = path.file_name().unwrap_or_default().to_string_lossy();
+                if fname.starts_with("rollout-") {
+                    files.push(path);
+                }
+            }
+        }
+        files
+    }
+
+    fn dedupe_conversations(
+        conversations: Vec<ConversationSummary>,
+    ) -> Vec<ConversationSummary> {
+        let mut by_id: HashMap<String, ConversationSummary> = HashMap::new();
+        for summary in conversations {
+            match by_id.get(&summary.id) {
+                Some(existing) if existing.started_at >= summary.started_at => {}
+                _ => {
+                    by_id.insert(summary.id.clone(), summary);
+                }
+            }
+        }
+
+        let mut conversations: Vec<ConversationSummary> = by_id.into_values().collect();
+        conversations.sort_by_key(|b| std::cmp::Reverse(b.started_at));
+        conversations
     }
 
     fn parse_jsonl_summary(
@@ -233,49 +280,19 @@ impl AgentParser for CodexParser {
     fn list_conversations(&self) -> Result<Vec<ConversationSummary>, ParseError> {
         let mut conversations = Vec::new();
 
-        if !self.base_dir.exists() {
-            return Ok(conversations);
-        }
-
-        for entry in WalkDir::new(&self.base_dir)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path().to_path_buf();
-            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                continue;
-            }
-            let fname = path.file_name().unwrap_or_default().to_string_lossy();
-            if !fname.starts_with("rollout-") {
-                continue;
-            }
-
+        for path in self.candidate_jsonl_files() {
             match self.parse_jsonl_summary(&path) {
                 Ok(Some(summary)) => conversations.push(summary),
                 _ => continue,
             }
         }
 
-        conversations.sort_by_key(|b| std::cmp::Reverse(b.started_at));
-        Ok(conversations)
+        Ok(Self::dedupe_conversations(conversations))
     }
 
     fn get_conversation(&self, conversation_id: &str) -> Result<ConversationDetail, ParseError> {
-        if !self.base_dir.exists() {
-            return Err(ParseError::ConversationNotFound(
-                conversation_id.to_string(),
-            ));
-        }
-
         // Find the conversation file by walking the directory tree
-        for entry in WalkDir::new(&self.base_dir)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path().to_path_buf();
-            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                continue;
-            }
+        for path in self.candidate_jsonl_files() {
             let fname = path.file_name().unwrap_or_default().to_string_lossy();
             if fname.contains(conversation_id) {
                 return self.parse_conversation_detail(&path, conversation_id);
@@ -2092,11 +2109,29 @@ mod tests {
     use crate::models::{
         ContentBlock, MessageRole, SessionStats, TurnRole, TurnUsage, UnifiedMessage,
     };
+    use crate::parsers::AgentParser;
     use chrono::{DateTime, Duration, Utc};
     use std::env;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn write_codex_rollout(
+        path: &PathBuf,
+        id: &str,
+        cwd: &str,
+        timestamp: &str,
+        title: &str,
+    ) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        let content = format!(
+            "{{\"timestamp\":\"{timestamp}\",\"type\":\"session_meta\",\"payload\":{{\"id\":\"{id}\",\"cwd\":\"{cwd}\",\"git\":{{\"branch\":\"main\"}}}}}}\n\
+             {{\"timestamp\":\"{timestamp}\",\"type\":\"event_msg\",\"payload\":{{\"type\":\"user_message\",\"message\":\"{title}\"}}}}\n"
+        );
+        fs::write(path, content).expect("write rollout");
+    }
 
     #[test]
     fn codex_session_roots_include_sessions_and_archived_sessions() {
@@ -2127,6 +2162,78 @@ mod tests {
                 PathBuf::from("/tmp/custom-codex/archived_sessions"),
             ]
         );
+    }
+
+    #[test]
+    fn list_conversations_scans_archived_session_roots() {
+        let base = env::temp_dir().join(format!(
+            "codeg-codex-roots-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let archived = base
+            .join("archived_sessions")
+            .join("2026")
+            .join("06")
+            .join("27");
+        write_codex_rollout(
+            &archived.join("rollout-2026-06-27T00-00-00-archived.jsonl"),
+            "archived-1",
+            "/repo",
+            "2026-06-27T00:00:00Z",
+            "archived prompt",
+        );
+
+        let parser = CodexParser::with_session_roots(vec![
+            base.join("sessions"),
+            base.join("archived_sessions"),
+        ]);
+        let summaries = parser.list_conversations().expect("list conversations");
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "archived-1");
+        assert_eq!(summaries[0].title.as_deref(), Some("archived prompt"));
+
+        fs::remove_dir_all(base).expect("cleanup");
+    }
+
+    #[test]
+    fn list_conversations_dedupes_duplicate_session_ids_by_newest_timestamp() {
+        let base = env::temp_dir().join(format!(
+            "codeg-codex-dedupe-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let active = base.join("sessions").join("2026").join("06").join("27");
+        let archived = base
+            .join("archived_sessions")
+            .join("2026")
+            .join("06")
+            .join("27");
+        write_codex_rollout(
+            &archived.join("rollout-2026-06-27T00-00-00-same.jsonl"),
+            "same-1",
+            "/repo",
+            "2026-06-27T00:00:00Z",
+            "older archived prompt",
+        );
+        write_codex_rollout(
+            &active.join("rollout-2026-06-27T01-00-00-same.jsonl"),
+            "same-1",
+            "/repo",
+            "2026-06-27T01:00:00Z",
+            "newer active prompt",
+        );
+
+        let parser = CodexParser::with_session_roots(vec![
+            base.join("sessions"),
+            base.join("archived_sessions"),
+        ]);
+        let summaries = parser.list_conversations().expect("list conversations");
+
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "same-1");
+        assert_eq!(summaries[0].title.as_deref(), Some("newer active prompt"));
+
+        fs::remove_dir_all(base).expect("cleanup");
     }
 
     #[test]

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -58,9 +58,9 @@ pub fn external_transcript_sources() -> Vec<ExternalSource> {
         },
         ExternalSource {
             agent: "codex",
-            root: codex::resolve_codex_home_dir().join("sessions"),
+            root: codex::resolve_codex_home_dir(),
             is_file: false,
-            include_top: None,
+            include_top: Some(&["sessions", "archived_sessions"]),
         },
         ExternalSource {
             // Gemini's base dir mixes transcripts with credentials/config; only
@@ -124,6 +124,27 @@ pub fn external_transcript_sources() -> Vec<ExternalSource> {
         });
     }
     sources
+}
+
+#[cfg(test)]
+mod external_source_tests {
+    use super::*;
+
+    #[test]
+    fn external_sources_include_codex_active_and_archived_roots() {
+        let sources = external_transcript_sources();
+        let codex_sources: Vec<_> = sources
+            .iter()
+            .filter(|source| source.agent == "codex")
+            .collect();
+
+        assert_eq!(codex_sources.len(), 1);
+        assert_eq!(codex_sources[0].root, codex::resolve_codex_home_dir());
+        assert!(matches!(
+            codex_sources[0].include_top,
+            Some(items) if items == ["sessions", "archived_sessions"]
+        ));
+    }
 }
 
 use regex::Regex;

--- a/src/components/conversations/conversation-detail-panel-layout.test.ts
+++ b/src/components/conversations/conversation-detail-panel-layout.test.ts
@@ -125,6 +125,29 @@ describe("ConversationDetailPanel new conversation layout", () => {
   })
 })
 
+describe("ConversationDetailPanel imported native resume path", () => {
+  it("passes imported native external_id as the lifecycle sessionId", () => {
+    const externalIdStart = source.indexOf("const externalId =")
+    const lifecycleStart = source.indexOf("} = useConnectionLifecycle({")
+    const lifecycleEnd = source.indexOf("})", lifecycleStart)
+
+    expect(externalIdStart).toBeGreaterThan(-1)
+    expect(lifecycleStart).toBeGreaterThan(externalIdStart)
+    expect(lifecycleEnd).toBeGreaterThan(lifecycleStart)
+
+    const externalIdBlock = source.slice(externalIdStart, lifecycleStart)
+    expect(externalIdBlock).toContain("detail?.summary.external_id")
+    expect(externalIdBlock).toContain("runtimeSession?.externalId")
+
+    const lifecycleBlock = source.slice(lifecycleStart, lifecycleEnd)
+    expect(lifecycleBlock).toContain("sessionId:")
+    expect(lifecycleBlock).toContain("dbConversationId != null")
+    expect(lifecycleBlock).toContain('selectedAgent !== "cline"')
+    expect(lifecycleBlock).toContain("? externalId")
+    expect(lifecycleBlock).toContain("conversationId: dbConversationId ?? undefined")
+  })
+})
+
 describe("ConversationDetailPanel chat-mode send path", () => {
   // Regression guard for the "first chat message gets stuck in the queue and is
   // never sent" bug: the chat first-send must NOT enqueue-and-return, it must

--- a/src/contexts/acp-connections-context.test.tsx
+++ b/src/contexts/acp-connections-context.test.tsx
@@ -179,6 +179,34 @@ describe("AcpConnectionsProvider cross-client viewer lifecycle", () => {
     )
   })
 
+  it("passes imported native session id to acpConnect", async () => {
+    h.acpFindConnectionForConversation.mockResolvedValue(null)
+    await mountProvider()
+
+    await act(async () => {
+      await h.actions!.connect(
+        "conv-42-codex-42",
+        "codex",
+        "G:\\CTF",
+        "native-session-123",
+        42
+      )
+    })
+
+    expect(h.acpFindConnectionForConversation).toHaveBeenCalledWith(
+      42,
+      "native-session-123",
+      "codex"
+    )
+    expect(h.acpConnect).toHaveBeenCalledWith(
+      "codex",
+      "G:\\CTF",
+      "native-session-123",
+      undefined,
+      {}
+    )
+  })
+
   it("skips discovery entirely when no persisted conversationId is given", async () => {
     await mountProvider()
 


### PR DESCRIPTION
Adds multi-root Codex history scanning for active and archived sessions while preserving Codeg's existing UI.

Reverse sync behavior: imported Codex/Claude conversations continue through native resume flows by passing external_id as the native session id to Codeg's ACP connect path. Native tools remain the transcript writers. Codeg metadata stays in Codeg storage keyed by (agent_type, external_id).

Verification:
- PASS: node node_modules\\vitest\\vitest.mjs run src\\components\\conversations\\conversation-detail-panel-layout.test.ts
- PASS: node node_modules\\vitest\\vitest.mjs run src\\contexts\\acp-connections-context.test.tsx
- NOT RUN: cargo test codex (cargo is not installed or not on PATH in this environment)