### PR TITLE
fix: compute completed session runtime from timestamps

### DIFF
--- a/src/components/conversations/session-details-dialog.test.tsx
+++ b/src/components/conversations/session-details-dialog.test.tsx
@@ -105,6 +105,54 @@ describe("SessionDetailsDialog", () => {
     expect(mockGet).not.toHaveBeenCalled()
   })
 
+  it("falls back to completed summary timestamps when stats duration is missing", () => {
+    const completedSummary = summary({
+      status: "completed",
+      created_at: "2026-06-10T10:00:00.000Z",
+      updated_at: "2026-06-10T10:02:30.000Z",
+    })
+    const statsWithoutDuration: SessionStats = {
+      ...fullStats,
+      total_duration_ms: 0,
+    }
+
+    const { getByText, queryByText } = renderWithIntl(
+      <SessionDetailsDialog
+        open
+        onOpenChange={() => {}}
+        summary={completedSummary}
+        stats={statsWithoutDuration}
+      />
+    )
+
+    expect(getByText("2.5m")).toBeTruthy()
+    expect(queryByText("0ms")).toBeNull()
+  })
+
+  it("does not derive an in-progress duration from timestamps", () => {
+    const liveSummary = summary({
+      status: "in_progress",
+      created_at: "2026-06-10T10:00:00.000Z",
+      updated_at: "2026-06-10T10:02:30.000Z",
+    })
+    const statsWithoutDuration: SessionStats = {
+      ...fullStats,
+      total_duration_ms: 0,
+    }
+
+    const { queryByText } = renderWithIntl(
+      <SessionDetailsDialog
+        open
+        onOpenChange={() => {}}
+        summary={liveSummary}
+        stats={statsWithoutDuration}
+      />
+    )
+
+    expect(queryByText("2.5m")).toBeNull()
+    expect(queryByText("0ms")).toBeNull()
+  })
+
   it("shows the title, agent, and status in the identity header", () => {
     const { getByText } = renderWithIntl(
       <SessionDetailsDialog

--- a/src/components/conversations/session-details-dialog.tsx
+++ b/src/components/conversations/session-details-dialog.tsx
@@ -68,6 +68,26 @@ function formatDuration(ms: number): string {
   return `${trimZero((minutes / 60).toFixed(1))}h`
 }
 
+function parseTimestampMs(value: string): number | null {
+  const ms = Date.parse(value)
+  return Number.isFinite(ms) ? ms : null
+}
+
+function resolveSessionDurationMs(
+  summary: DbConversationSummary,
+  stats: SessionStats | null
+): number {
+  const statsDuration = stats?.total_duration_ms ?? 0
+  if (statsDuration > 0) return statsDuration
+  if (summary.status !== "completed") return 0
+
+  const startedAt = parseTimestampMs(summary.created_at)
+  const endedAt = parseTimestampMs(summary.updated_at)
+  if (startedAt == null || endedAt == null || endedAt <= startedAt) return 0
+
+  return endedAt - startedAt
+}
+
 /**
  * One label-above-value cell inside a responsive `<dl>` grid. Stacking the
  * label on top keeps values left-aligned and tight against their label (no
@@ -242,7 +262,7 @@ export function SessionDetailsDialog({
     ctxUsed,
     ctxMax
   )
-  const durationMs = stats?.total_duration_ms ?? 0
+  const durationMs = resolveSessionDurationMs(summary, stats)
   // Never coerce an unknown `used` to 0 — some parsers infer the model's
   // context cap without any usage figure, so render "— / max" rather than a
   // bogus "0 / max".


### PR DESCRIPTION
## Summary

- keep using `total_duration_ms` when parsers provide a positive duration
- fall back to completed conversation timestamps when parser stats have no duration
- add regression coverage so in-progress sessions do not derive a moving duration from timestamps

Fixes #273.

## Tests

- pnpm test src/components/conversations/session-details-dialog.test.tsx
- pnpm test src/components/conversations/active-session-details.test.ts
- pnpm test src/lib/format-elapsed.test.ts
- pnpm eslint src/components/conversations/session-details-dialog.tsx src/components/conversations/session-details-dialog.test.tsx
- git diff --check
