### PR TITLE
fix(editor): preserve Windows IME composition

### DIFF
--- a/src/components/files/file-workspace-panel-ime-source.test.ts
+++ b/src/components/files/file-workspace-panel-ime-source.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const panelSource = readFileSync(
+  resolve(process.cwd(), "src/components/files/file-workspace-panel.tsx"),
+  "utf8"
+)
+
+describe("file-workspace-panel IME composition guard wiring", () => {
+  it("scopes the guard to the Monaco model and binds the mounted editor", () => {
+    expect(panelSource).toMatch(
+      /useImeSafeEditorValue\([\s\S]{0,100}renderedContent,[\s\S]{0,100}activeScope,[\s\S]{0,100}handleCompositionChange/
+    )
+    expect(panelSource).toMatch(/bindImeEditor\(editorInstance\)/)
+  })
+
+  it("keeps a creation value while withholding controlled file content during composition", () => {
+    expect(panelSource).toMatch(/defaultValue=\{renderedContent\}/)
+    expect(panelSource).toMatch(
+      /value=\{isFileTab \? imeSafeEditorValue : renderedContent\}/
+    )
+  })
+
+  it("uses a stable change callback so Monaco does not rebind it per keystroke", () => {
+    expect(panelSource).toMatch(
+      /const handleEditorChange: OnChange = useCallback/
+    )
+    expect(panelSource).toMatch(/onChange=\{handleEditorChange\}/)
+  })
+
+  it("binds content and composition state to the originating file tab", () => {
+    expect(panelSource).toMatch(
+      /updateFileTabContent\(activeScope, value \?\? ""\)/
+    )
+    expect(panelSource).toMatch(
+      /monacoRef\.current\?\.Uri\.parse\([\s\S]{0,40}editorModelPath[\s\S]{0,40}\)\.toString\(\)/
+    )
+    expect(panelSource).toMatch(/setFileTabComposing\(tabId, composing\)/)
+    expect(panelSource).toMatch(
+      /fileSaveState !== "idle" \|\|[\s\S]{0,30}isComposing/
+    )
+  })
+})

--- a/src/components/files/file-workspace-panel.tsx
+++ b/src/components/files/file-workspace-panel.tsx
@@ -8,7 +8,7 @@ import type {
   IDisposable,
   IPosition,
 } from "monaco-editor"
-import type { Monaco, OnMount } from "@monaco-editor/react"
+import type { Monaco, OnChange, OnMount } from "@monaco-editor/react"
 import { toast } from "sonner"
 import { useTranslations } from "next-intl"
 import { useAppWorkspaceStore } from "@/stores/app-workspace-store"
@@ -50,6 +50,7 @@ import {
   useMonacoThemeSync,
 } from "@/lib/monaco-themes"
 import { useZoomLevel, useEditorFont } from "@/hooks/use-appearance"
+import { useImeSafeEditorValue } from "@/hooks/use-ime-safe-editor-value"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 import "@/lib/monaco-local"
@@ -970,7 +971,8 @@ export function FileWorkspacePanel() {
     openFilePreview,
     openWorkingTreeDiff,
     saveActiveFile,
-    updateActiveFileContent,
+    setFileTabComposing,
+    updateFileTabContent,
   } = useWorkspaceActions()
   const tabs = useTabStore((s) => s.tabs)
   const activeTabId = useTabStore((s) => s.activeTabId)
@@ -994,6 +996,10 @@ export function FileWorkspacePanel() {
   // files; files outside every folder are confined to their own directory.
   const previewRoot = owningFolder?.rootPath ?? activeIo?.rootPath ?? null
   const activeScope = activeFileTab?.id ?? "__default__"
+  const editorModelPath = buildMonacoModelPath(
+    activeFileTab?.path ?? null,
+    activeScope
+  )
   const editorRef = useRef<MonacoEditorNs.IStandaloneCodeEditor | null>(null)
   const cursorListenerRef = useRef<{ dispose: () => void } | null>(null)
   const gitChangeDecorationsRef = useRef<string[]>([])
@@ -1043,11 +1049,39 @@ export function FileWorkspacePanel() {
     {}
   )
   const renderedContent = activeFileTab?.content ?? ""
+  const handleCompositionChange = useCallback(
+    (composing: boolean, tabId: string) => {
+      setFileTabComposing(tabId, composing)
+    },
+    [setFileTabComposing]
+  )
+  const {
+    value: imeSafeEditorValue,
+    isComposing,
+    bindEditor: bindImeEditor,
+  } = useImeSafeEditorValue(
+    renderedContent,
+    activeScope,
+    handleCompositionChange
+  )
   const isFileTab = activeFileTab?.kind === "file"
   const fileReadonly = isFileTab ? Boolean(activeFileTab.readonly) : true
   const fileSaveState = isFileTab ? (activeFileTab.saveState ?? "idle") : "idle"
   const fileIsDirty = isFileTab ? Boolean(activeFileTab.isDirty) : false
   const canEdit = isFileTab && !fileReadonly
+  const handleEditorChange: OnChange = useCallback(
+    (value) => {
+      if (!isFileTab) return
+      const currentModelUri = editorRef.current?.getModel()?.uri.toString()
+      const expectedModelUri =
+        monacoRef.current?.Uri.parse(editorModelPath).toString()
+      if (!currentModelUri || currentModelUri !== expectedModelUri) {
+        return
+      }
+      updateFileTabContent(activeScope, value ?? "")
+    },
+    [activeScope, editorModelPath, isFileTab, updateFileTabContent]
+  )
   // The conversation a selection attaches to: the active top-bar tab when it is
   // a conversation (mirrors aux-panel-file-tree-tab's "Attach to Current
   // Session"). Null when no conversation is focused.
@@ -1481,6 +1515,7 @@ export function FileWorkspacePanel() {
   const handleEditorMount: OnMount = useCallback(
     (editorInstance, monaco) => {
       editorRef.current = editorInstance
+      bindImeEditor(editorInstance)
       cursorListenerRef.current?.dispose()
       cursorListenerRef.current = editorInstance.onDidChangeCursorPosition(
         (event) => {
@@ -1577,6 +1612,7 @@ export function FileWorkspacePanel() {
       teardownAddToChat,
       applyGitChangeDecorations,
       applyHiddenAreas,
+      bindImeEditor,
     ]
   )
 
@@ -1690,7 +1726,9 @@ export function FileWorkspacePanel() {
       autoSaveTimerRef.current = null
     }
 
-    if (!canEdit || !fileIsDirty || fileSaveState !== "idle") return
+    if (!canEdit || !fileIsDirty || fileSaveState !== "idle" || isComposing) {
+      return
+    }
 
     autoSaveTimerRef.current = setTimeout(() => {
       const guard = autoSaveGuardRef.current
@@ -1710,7 +1748,14 @@ export function FileWorkspacePanel() {
         autoSaveTimerRef.current = null
       }
     }
-  }, [canEdit, fileIsDirty, fileSaveState, saveActiveFile, renderedContent])
+  }, [
+    canEdit,
+    fileIsDirty,
+    fileSaveState,
+    isComposing,
+    saveActiveFile,
+    renderedContent,
+  ])
 
   useEffect(() => {
     if (!isFileTab) return
@@ -2173,12 +2218,10 @@ export function FileWorkspacePanel() {
             <MonacoEditor
               beforeMount={defineMonacoThemes}
               onMount={handleEditorMount}
-              path={buildMonacoModelPath(activeFileTab.path, activeFileTab.id)}
-              value={renderedContent}
-              onChange={(value) => {
-                if (!isFileTab) return
-                updateActiveFileContent(value ?? "")
-              }}
+              path={editorModelPath}
+              defaultValue={renderedContent}
+              value={isFileTab ? imeSafeEditorValue : renderedContent}
+              onChange={handleEditorChange}
               language={activeFileTab.language}
               theme={editorTheme}
               loading={

--- a/src/contexts/workspace-context.test.tsx
+++ b/src/contexts/workspace-context.test.tsx
@@ -2209,7 +2209,9 @@ function DecoupleProbe({
     fileTabs,
     activeFileTabId,
     updateActiveFileContent,
+    updateFileTabContent,
     saveActiveFile,
+    setFileTabComposing,
     switchFileTab,
   } = useWorkspaceContext()
   onCapture({
@@ -2231,9 +2233,37 @@ function DecoupleProbe({
       <button onClick={() => updateActiveFileContent("dirty-local")}>
         edit
       </button>
+      <button
+        onClick={() =>
+          updateFileTabContent(fileTabId("/repo/a.ts"), "composing-local")
+        }
+      >
+        edit-a-by-id
+      </button>
+      <button
+        onClick={() => setFileTabComposing(fileTabId("/repo/a.ts"), true)}
+      >
+        compose-a-start
+      </button>
+      <button
+        onClick={() => setFileTabComposing(fileTabId("/repo/a.ts"), false)}
+      >
+        compose-a-end
+      </button>
       <button onClick={() => void saveActiveFile()}>save</button>
+      <button
+        onClick={() => {
+          updateActiveFileContent("deleted-content")
+          void saveActiveFile()
+        }}
+      >
+        edit-and-save-immediately
+      </button>
       <button onClick={() => switchFileTab(fileTabId("/repo2/a.ts"))}>
         switch-a-f2
+      </button>
+      <button onClick={() => switchFileTab(fileTabId("/repo/a.ts"))}>
+        switch-a-f1
       </button>
     </div>
   )
@@ -2257,6 +2287,51 @@ describe("file tabs decoupled from the active folder", () => {
         line_ending: "lf",
       })
     )
+  })
+
+  it("defers every save path during composition and flushes the original tab", async () => {
+    mockedApi.saveFileContent.mockResolvedValue({
+      path: "a.ts",
+      etag: "saved",
+      mtime_ms: 2,
+      readonly: false,
+      line_ending: "lf",
+    })
+    const snap = renderDecouple()
+
+    await act(async () => screen.getByText("open-a-f1").click())
+    await act(async () => screen.getByText("open-a-f2").click())
+    await act(async () => screen.getByText("switch-a-f1").click())
+    await act(async () => screen.getByText("compose-a-start").click())
+    await act(async () => screen.getByText("edit-a-by-id").click())
+
+    await act(async () => screen.getByText("save").click())
+    await act(async () => screen.getByText("switch-a-f2").click())
+    expect(mockedApi.saveFileContent).not.toHaveBeenCalled()
+    expect(snap().activeId).toBe(fileTabId("/repo2/a.ts"))
+
+    await act(async () => screen.getByText("compose-a-end").click())
+    expect(mockedApi.saveFileContent).toHaveBeenCalledTimes(1)
+    expect(mockedApi.saveFileContent.mock.calls[0][0]).toBe("/repo")
+    expect(mockedApi.saveFileContent.mock.calls[0][1]).toBe("a.ts")
+    expect(mockedApi.saveFileContent.mock.calls[0][2]).toBe("composing-local")
+  })
+
+  it("saves the latest edit when the shortcut follows in the same turn", async () => {
+    mockedApi.saveFileContent.mockResolvedValue({
+      path: "a.ts",
+      etag: "saved",
+      mtime_ms: 2,
+      readonly: false,
+      line_ending: "lf",
+    })
+    renderDecouple()
+
+    await act(async () => screen.getByText("open-a-f1").click())
+    await act(async () => screen.getByText("edit-and-save-immediately").click())
+
+    expect(mockedApi.saveFileContent).toHaveBeenCalledTimes(1)
+    expect(mockedApi.saveFileContent.mock.calls[0][2]).toBe("deleted-content")
   })
 
   function renderDecouple() {

--- a/src/contexts/workspace-context.tsx
+++ b/src/contexts/workspace-context.tsx
@@ -172,7 +172,9 @@ interface WorkspaceActionsValue {
     unsavedContent: string
   ) => void
   updateActiveFileContent: (content: string) => void
+  updateFileTabContent: (tabId: string, content: string) => void
   saveActiveFile: (options?: { force?: boolean }) => Promise<boolean>
+  setFileTabComposing: (tabId: string, composing: boolean) => void
   reloadActiveFile: () => Promise<void>
   toggleFileTabPreview: (tabId: string) => void
   toggleFilesMaximized: () => void
@@ -394,6 +396,13 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   // Most-recently-active tab ids, most recent first. Drives the memory
   // guardrail's least-recently-active eviction order.
   const tabRecencyRef = useRef<string[]>([])
+  const composingFileTabIdsRef = useRef<Set<string>>(new Set())
+  const deferredSaveTabsRef = useRef<Map<string, { force?: boolean }>>(
+    new Map()
+  )
+  const saveFileTabRef = useRef<
+    ((tabId: string, options?: { force?: boolean }) => Promise<boolean>) | null
+  >(null)
 
   useEffect(() => {
     fileTabsRef.current = fileTabs
@@ -1821,13 +1830,10 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
     dequeueExternalConflict()
   }, [dequeueExternalConflict])
 
-  const updateActiveFileContent = useCallback((content: string) => {
-    const activeId = activeFileTabIdRef.current
-    if (!activeId) return
-
-    setFileTabs((prev) =>
-      prev.map((tab) => {
-        if (tab.id !== activeId || tab.kind !== "file") return tab
+  const updateFileTabContent = useCallback((tabId: string, content: string) => {
+    const updateTabs = (tabs: FileWorkspaceTab[]): FileWorkspaceTab[] =>
+      tabs.map((tab) => {
+        if (tab.id !== tabId || tab.kind !== "file") return tab
         if (tab.loading || tab.readonly) return tab
         if (tab.content === content) return tab
 
@@ -1840,11 +1846,29 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
           saveError: null,
         }
       })
-    )
+
+    fileTabsRef.current = updateTabs(fileTabsRef.current)
+    setFileTabs(updateTabs)
   }, [])
+
+  const updateActiveFileContent = useCallback(
+    (content: string) => {
+      const activeId = activeFileTabIdRef.current
+      if (!activeId) return
+      updateFileTabContent(activeId, content)
+    },
+    [updateFileTabContent]
+  )
 
   const saveFileTab = useCallback(
     async (tabId: string, options?: { force?: boolean }): Promise<boolean> => {
+      if (composingFileTabIdsRef.current.has(tabId)) {
+        const deferredOptions = deferredSaveTabsRef.current.get(tabId)
+        deferredSaveTabsRef.current.set(tabId, {
+          force: Boolean(deferredOptions?.force || options?.force),
+        })
+        return false
+      }
       const tab = fileTabsRef.current.find(
         (candidate) => candidate.id === tabId
       )
@@ -1975,6 +1999,28 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
       }
     },
     [enqueueExternalConflict, recordSelfWriteEcho, t]
+  )
+
+  useEffect(() => {
+    saveFileTabRef.current = saveFileTab
+  }, [saveFileTab])
+
+  const setFileTabComposing = useCallback(
+    (tabId: string, composing: boolean) => {
+      if (composing) {
+        composingFileTabIdsRef.current.add(tabId)
+        return
+      }
+
+      composingFileTabIdsRef.current.delete(tabId)
+      const deferredOptions = deferredSaveTabsRef.current.get(tabId)
+      if (!deferredOptions) return
+      deferredSaveTabsRef.current.delete(tabId)
+      queueMicrotask(() => {
+        void saveFileTabRef.current?.(tabId, deferredOptions)
+      })
+    },
+    []
   )
 
   const saveActiveFile = useCallback(
@@ -2316,7 +2362,9 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
       openSessionFileDiff,
       openExternalConflictDiff,
       updateActiveFileContent,
+      updateFileTabContent,
       saveActiveFile,
+      setFileTabComposing,
       reloadActiveFile,
       toggleFileTabPreview,
       toggleFilesMaximized,
@@ -2342,7 +2390,9 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
       openSessionFileDiff,
       openExternalConflictDiff,
       updateActiveFileContent,
+      updateFileTabContent,
       saveActiveFile,
+      setFileTabComposing,
       reloadActiveFile,
       toggleFileTabPreview,
       toggleFilesMaximized,

--- a/src/hooks/use-ime-safe-editor-value.test.tsx
+++ b/src/hooks/use-ime-safe-editor-value.test.tsx
@@ -1,0 +1,229 @@
+import { StrictMode, type ReactNode } from "react"
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useImeSafeEditorValue } from "@/hooks/use-ime-safe-editor-value"
+
+type Listener = () => void
+
+class FakeCompositionEditor {
+  private startListeners = new Set<Listener>()
+  private endListeners = new Set<Listener>()
+  private modelListeners = new Set<Listener>()
+  private disposeListeners = new Set<Listener>()
+
+  onDidCompositionStart(listener: Listener) {
+    this.startListeners.add(listener)
+    return { dispose: () => this.startListeners.delete(listener) }
+  }
+
+  onDidCompositionEnd(listener: Listener) {
+    this.endListeners.add(listener)
+    return { dispose: () => this.endListeners.delete(listener) }
+  }
+
+  onDidChangeModel(listener: Listener) {
+    this.modelListeners.add(listener)
+    return { dispose: () => this.modelListeners.delete(listener) }
+  }
+
+  onDidDispose(listener: Listener) {
+    this.disposeListeners.add(listener)
+    return { dispose: () => this.disposeListeners.delete(listener) }
+  }
+
+  startComposition() {
+    this.startListeners.forEach((listener) => listener())
+  }
+
+  endComposition() {
+    this.endListeners.forEach((listener) => listener())
+  }
+
+  changeModel() {
+    this.modelListeners.forEach((listener) => listener())
+  }
+
+  dispose() {
+    this.disposeListeners.forEach((listener) => listener())
+    this.disposeListeners.clear()
+  }
+}
+
+let nextFrameId = 1
+let frameCallbacks = new Map<number, FrameRequestCallback>()
+
+function flushAnimationFrames() {
+  const pending = [...frameCallbacks.values()]
+  frameCallbacks.clear()
+  pending.forEach((callback) => callback(0))
+}
+
+beforeEach(() => {
+  nextFrameId = 1
+  frameCallbacks = new Map()
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const id = nextFrameId++
+    frameCallbacks.set(id, callback)
+    return id
+  })
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    frameCallbacks.delete(id)
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("useImeSafeEditorValue", () => {
+  it("reports composition active until the controlled value can safely resume", () => {
+    const editor = new FakeCompositionEditor()
+    const onCompositionChange = vi.fn()
+    const { result } = renderHook(() =>
+      useImeSafeEditorValue("content", "file:///notes.md", onCompositionChange)
+    )
+    act(() => result.current.bindEditor(editor))
+
+    act(() => editor.startComposition())
+    expect(onCompositionChange).toHaveBeenLastCalledWith(
+      true,
+      "file:///notes.md"
+    )
+    expect(result.current.isComposing).toBe(true)
+
+    act(() => editor.endComposition())
+    expect(onCompositionChange).toHaveBeenCalledTimes(1)
+    act(flushAnimationFrames)
+    expect(onCompositionChange).toHaveBeenLastCalledWith(
+      false,
+      "file:///notes.md"
+    )
+    expect(result.current.isComposing).toBe(false)
+  })
+
+  it("withholds the controlled value throughout composition and restores the latest value next frame", () => {
+    const editor = new FakeCompositionEditor()
+    const { result, rerender } = renderHook(
+      ({ value, modelKey }) => useImeSafeEditorValue(value, modelKey),
+      { initialProps: { value: "before", modelKey: "file:///notes.md" } }
+    )
+
+    act(() => result.current.bindEditor(editor))
+    expect(result.current.value).toBe("before")
+
+    act(() => editor.startComposition())
+    expect(result.current.value).toBeUndefined()
+
+    rerender({ value: "beforemo", modelKey: "file:///notes.md" })
+    rerender({ value: "before魔魂", modelKey: "file:///notes.md" })
+    expect(result.current.value).toBeUndefined()
+
+    act(() => editor.endComposition())
+    expect(result.current.value).toBeUndefined()
+
+    act(flushAnimationFrames)
+    expect(result.current.value).toBe("before魔魂")
+  })
+
+  it("keeps ordinary input controlled when no composition is active", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useImeSafeEditorValue(value, "file:///notes.md"),
+      { initialProps: { value: "a" } }
+    )
+
+    rerender({ value: "ab" })
+    expect(result.current.value).toBe("ab")
+  })
+
+  it("cancels a pending resume when a new composition starts", () => {
+    const editor = new FakeCompositionEditor()
+    const { result } = renderHook(() =>
+      useImeSafeEditorValue("content", "file:///notes.md")
+    )
+    act(() => result.current.bindEditor(editor))
+
+    act(() => editor.startComposition())
+    act(() => editor.endComposition())
+    expect(frameCallbacks).toHaveLength(1)
+
+    act(() => editor.startComposition())
+    expect(frameCallbacks).toHaveLength(0)
+    act(flushAnimationFrames)
+    expect(result.current.value).toBeUndefined()
+  })
+
+  it("resets the guard and cancels resume work when the model changes", () => {
+    const editor = new FakeCompositionEditor()
+    const { result, rerender } = renderHook(
+      ({ value, modelKey }) => useImeSafeEditorValue(value, modelKey),
+      { initialProps: { value: "a", modelKey: "file:///a.md" } }
+    )
+    act(() => result.current.bindEditor(editor))
+
+    act(() => editor.startComposition())
+    act(() => editor.endComposition())
+    expect(frameCallbacks).toHaveLength(1)
+
+    rerender({ value: "b", modelKey: "file:///b.md" })
+    act(() => editor.changeModel())
+    expect(frameCallbacks).toHaveLength(0)
+    expect(result.current.value).toBe("b")
+
+    rerender({ value: "a", modelKey: "file:///a.md" })
+    expect(result.current.value).toBe("a")
+  })
+
+  it("disposes listeners and pending resume work with the editor", () => {
+    const editor = new FakeCompositionEditor()
+    const { result } = renderHook(() =>
+      useImeSafeEditorValue("content", "file:///notes.md")
+    )
+    act(() => result.current.bindEditor(editor))
+
+    act(() => editor.startComposition())
+    act(() => editor.endComposition())
+    expect(frameCallbacks).toHaveLength(1)
+
+    act(() => editor.dispose())
+    expect(frameCallbacks).toHaveLength(0)
+    expect(result.current.value).toBe("content")
+
+    act(() => editor.startComposition())
+    expect(result.current.value).toBe("content")
+  })
+
+  it("cancels pending resume work when the hook unmounts", () => {
+    const editor = new FakeCompositionEditor()
+    const onCompositionChange = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useImeSafeEditorValue("content", "file:///notes.md", onCompositionChange)
+    )
+    act(() => result.current.bindEditor(editor))
+    act(() => editor.startComposition())
+    act(() => editor.endComposition())
+    expect(frameCallbacks).toHaveLength(1)
+
+    unmount()
+    expect(frameCallbacks).toHaveLength(0)
+    expect(onCompositionChange).toHaveBeenLastCalledWith(
+      false,
+      "file:///notes.md"
+    )
+  })
+
+  it("remains active after the Strict Mode effect replay", () => {
+    const editor = new FakeCompositionEditor()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <StrictMode>{children}</StrictMode>
+    )
+    const { result } = renderHook(
+      () => useImeSafeEditorValue("content", "file:///notes.md"),
+      { wrapper }
+    )
+    act(() => result.current.bindEditor(editor))
+
+    act(() => editor.startComposition())
+    expect(result.current.value).toBeUndefined()
+  })
+})

--- a/src/hooks/use-ime-safe-editor-value.ts
+++ b/src/hooks/use-ime-safe-editor-value.ts
@@ -38,6 +38,10 @@ export function useImeSafeEditorValue<T>(
   const resumeFrameRef = useRef<number | null>(null)
   const unbindRef = useRef<(() => void) | null>(null)
   const mountedRef = useRef(true)
+  // Keep the latest callback in a ref so editor listeners bound once at mount
+  // never call a stale closure — the hook must not require callers to memoize
+  // `onCompositionChange`.
+  const onCompositionChangeRef = useRef(onCompositionChange)
 
   const cancelResume = useCallback(() => {
     if (resumeFrameRef.current === null) return
@@ -45,16 +49,13 @@ export function useImeSafeEditorValue<T>(
     resumeFrameRef.current = null
   }, [])
 
-  const finishComposition = useCallback(
-    (expectedModelKey?: string) => {
-      const current = composingModelKeyRef.current
-      if (!current || (expectedModelKey && current !== expectedModelKey)) return
-      composingModelKeyRef.current = null
-      if (mountedRef.current) setComposingModelKey(null)
-      onCompositionChange?.(false, current)
-    },
-    [onCompositionChange]
-  )
+  const finishComposition = useCallback((expectedModelKey?: string) => {
+    const current = composingModelKeyRef.current
+    if (!current || (expectedModelKey && current !== expectedModelKey)) return
+    composingModelKeyRef.current = null
+    if (mountedRef.current) setComposingModelKey(null)
+    onCompositionChangeRef.current?.(false, current)
+  }, [])
 
   const bindEditor = useCallback(
     (editor: ImeCompositionEditor | null) => {
@@ -88,7 +89,7 @@ export function useImeSafeEditorValue<T>(
         const startingModelKey = modelKeyRef.current
         composingModelKeyRef.current = startingModelKey
         setComposingModelKey(startingModelKey)
-        onCompositionChange?.(true, startingModelKey)
+        onCompositionChangeRef.current?.(true, startingModelKey)
       })
       endDisposable = editor.onDidCompositionEnd(() => {
         cancelResume()
@@ -108,7 +109,7 @@ export function useImeSafeEditorValue<T>(
       unbind = () => release(true)
       unbindRef.current = unbind
     },
-    [cancelResume, finishComposition, onCompositionChange]
+    [cancelResume, finishComposition]
   )
 
   useEffect(() => {
@@ -126,6 +127,10 @@ export function useImeSafeEditorValue<T>(
     modelKeyRef.current = modelKey
     cancelResume()
   }, [cancelResume, modelKey])
+
+  useEffect(() => {
+    onCompositionChangeRef.current = onCompositionChange
+  }, [onCompositionChange])
 
   return {
     value: composingModelKey === modelKey ? undefined : value,

--- a/src/hooks/use-ime-safe-editor-value.ts
+++ b/src/hooks/use-ime-safe-editor-value.ts
@@ -1,0 +1,135 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+interface Disposable {
+  dispose: () => void
+}
+
+export interface ImeCompositionEditor {
+  onDidCompositionStart: (listener: () => void) => Disposable
+  onDidCompositionEnd: (listener: () => void) => Disposable
+  onDidChangeModel: (listener: () => void) => Disposable
+  onDidDispose: (listener: () => void) => Disposable
+}
+
+interface ImeSafeEditorValue<T> {
+  value: T | undefined
+  isComposing: boolean
+  bindEditor: (editor: ImeCompositionEditor | null) => void
+}
+
+/**
+ * Prevents a controlled Monaco value from replacing the model while an IME
+ * composition is active. The wrapper treats `undefined` as uncontrolled, so
+ * intermediate composition text remains owned by Monaco until the next frame
+ * after composition ends.
+ */
+export function useImeSafeEditorValue<T>(
+  value: T,
+  modelKey: string,
+  onCompositionChange?: (composing: boolean, modelKey: string) => void
+): ImeSafeEditorValue<T> {
+  const modelKeyRef = useRef(modelKey)
+  const [composingModelKey, setComposingModelKey] = useState<string | null>(
+    null
+  )
+  const composingModelKeyRef = useRef<string | null>(null)
+  const resumeFrameRef = useRef<number | null>(null)
+  const unbindRef = useRef<(() => void) | null>(null)
+  const mountedRef = useRef(true)
+
+  const cancelResume = useCallback(() => {
+    if (resumeFrameRef.current === null) return
+    cancelAnimationFrame(resumeFrameRef.current)
+    resumeFrameRef.current = null
+  }, [])
+
+  const finishComposition = useCallback(
+    (expectedModelKey?: string) => {
+      const current = composingModelKeyRef.current
+      if (!current || (expectedModelKey && current !== expectedModelKey)) return
+      composingModelKeyRef.current = null
+      if (mountedRef.current) setComposingModelKey(null)
+      onCompositionChange?.(false, current)
+    },
+    [onCompositionChange]
+  )
+
+  const bindEditor = useCallback(
+    (editor: ImeCompositionEditor | null) => {
+      unbindRef.current?.()
+      unbindRef.current = null
+      cancelResume()
+      if (mountedRef.current) setComposingModelKey(null)
+      if (!editor) return
+
+      let released = false
+      let startDisposable: Disposable | null = null
+      let endDisposable: Disposable | null = null
+      let modelDisposable: Disposable | null = null
+      let editorDisposable: Disposable | null = null
+      let unbind: (() => void) | null = null
+
+      const release = (resetState: boolean) => {
+        if (released) return
+        released = true
+        startDisposable?.dispose()
+        endDisposable?.dispose()
+        modelDisposable?.dispose()
+        editorDisposable?.dispose()
+        cancelResume()
+        if (unbindRef.current === unbind) unbindRef.current = null
+        if (resetState) finishComposition()
+      }
+
+      startDisposable = editor.onDidCompositionStart(() => {
+        cancelResume()
+        const startingModelKey = modelKeyRef.current
+        composingModelKeyRef.current = startingModelKey
+        setComposingModelKey(startingModelKey)
+        onCompositionChange?.(true, startingModelKey)
+      })
+      endDisposable = editor.onDidCompositionEnd(() => {
+        cancelResume()
+        const endingModelKey = modelKeyRef.current
+        resumeFrameRef.current = requestAnimationFrame(() => {
+          resumeFrameRef.current = null
+          if (mountedRef.current && modelKeyRef.current === endingModelKey) {
+            finishComposition(endingModelKey)
+          }
+        })
+      })
+      modelDisposable = editor.onDidChangeModel(() => {
+        cancelResume()
+        finishComposition()
+      })
+      editorDisposable = editor.onDidDispose(() => release(true))
+      unbind = () => release(true)
+      unbindRef.current = unbind
+    },
+    [cancelResume, finishComposition, onCompositionChange]
+  )
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      const unbind = unbindRef.current
+      unbindRef.current = null
+      unbind?.()
+      cancelResume()
+    }
+  }, [cancelResume])
+
+  useEffect(() => {
+    modelKeyRef.current = modelKey
+    cancelResume()
+  }, [cancelResume, modelKey])
+
+  return {
+    value: composingModelKey === modelKey ? undefined : value,
+    isComposing: composingModelKey === modelKey,
+    bindEditor,
+  }
+}

--- a/src/lib/monaco-model-path.test.ts
+++ b/src/lib/monaco-model-path.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { URI } from "monaco-editor/esm/vs/base/common/uri.js"
 import { buildMonacoModelPath } from "@/lib/monaco-model-path"
 
 describe("buildMonacoModelPath", () => {
@@ -26,5 +27,12 @@ describe("buildMonacoModelPath", () => {
     expect(buildMonacoModelPath("/repo/a b#c.ts", "x")).toBe(
       "file:///repo/a%20b%23c.ts"
     )
+  })
+
+  it("is compared after Monaco normalizes Windows drive letters", () => {
+    const path = buildMonacoModelPath("D:\\repo\\notes.md", "x")
+
+    expect(path).toBe("file:///D%3A/repo/notes.md")
+    expect(URI.parse(path).toString()).toBe("file:///d%3A/repo/notes.md")
   })
 })

--- a/src/types/monaco-editor-internal.d.ts
+++ b/src/types/monaco-editor-internal.d.ts
@@ -1,0 +1,8 @@
+// `monaco-editor/esm/vs/base/common/uri.js` is a leaf module that ships no type
+// declarations, so importing it directly (tests use it to exercise Monaco's URI
+// normalization without loading the full DOM-bound editor) would otherwise be an
+// implicit `any` (TS7016). It re-exports the same class as Monaco's public
+// `Uri`, so borrow that type.
+declare module "monaco-editor/esm/vs/base/common/uri.js" {
+  export const URI: typeof import("monaco-editor").Uri
+}


### PR DESCRIPTION
## Summary

- suspend controlled Monaco value updates while IME composition is active
- defer all file saves during composition and flush explicit saves for the originating tab
- bind editor changes to the normalized Monaco model URI to avoid stale cross-tab writes on Windows
- add regression coverage for composition lifecycle, deferred saves, immediate saves, and Windows drive normalization

## Behavior

Pressing Ctrl+S during an unfinished composition keeps the dirty marker until composition ends. This intentionally prevents intermediate pinyin from being written to disk.

## Validation

- changed-file ESLint
- targeted Vitest: 4 files, 80 tests
- full `pnpm test`
- `pnpm build`
- Windows 11 + Microsoft Pinyin + Tauri manual verification

Fixes #330