### PR TITLE
fix(messages): hide pointer-triggered focus ring

### DIFF
--- a/src/components/message/virtualized-message-thread.test.tsx
+++ b/src/components/message/virtualized-message-thread.test.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  scrollRef: { current: null as HTMLDivElement | null },
+}))
+
+vi.mock("use-stick-to-bottom", () => ({
+  useStickToBottomContext: () => ({ scrollRef: testState.scrollRef }),
+}))
+
+vi.mock("virtua", () => ({
+  Virtualizer: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@/components/ai-elements/message-thread", () => ({
+  MessageThreadContent: ({
+    children,
+    scrollClassName,
+  }: {
+    children: ReactNode
+    scrollClassName?: string
+  }) => (
+    <div
+      ref={(element) => {
+        testState.scrollRef.current = element
+      }}
+      className={scrollClassName}
+      data-testid="viewport"
+    >
+      {children}
+    </div>
+  ),
+}))
+
+import { VirtualizedMessageThread } from "@/components/message/virtualized-message-thread"
+
+function renderThread(
+  content: ReactNode = <div data-testid="content">text</div>
+) {
+  return render(
+    <VirtualizedMessageThread
+      items={[{ id: "message-1" }]}
+      getItemKey={(item) => item.id}
+      renderItem={() => content}
+    />
+  )
+}
+
+function pointerDown(element: HTMLElement, button: number) {
+  fireEvent(element, new MouseEvent("pointerdown", { bubbles: true, button }))
+}
+
+beforeEach(() => {
+  testState.scrollRef.current = null
+})
+
+describe("VirtualizedMessageThread focus origin", () => {
+  it("marks pointer-origin focus and clears it on blur", () => {
+    renderThread()
+    const viewport = screen.getByTestId("viewport")
+
+    pointerDown(screen.getByTestId("content"), 0)
+
+    expect(document.activeElement).toBe(viewport)
+    expect(viewport).toHaveAttribute("data-focus-origin", "pointer")
+    expect(viewport.className).toContain(
+      "data-[focus-origin=pointer]:focus-visible:ring-0"
+    )
+
+    fireEvent.blur(viewport)
+    expect(viewport).not.toHaveAttribute("data-focus-origin")
+  })
+
+  it("keeps keyboard-origin focus distinguishable", () => {
+    renderThread()
+    const viewport = screen.getByTestId("viewport")
+
+    viewport.focus()
+
+    expect(document.activeElement).toBe(viewport)
+    expect(viewport).not.toHaveAttribute("data-focus-origin")
+    expect(viewport.className).toContain("focus-visible:ring-2")
+  })
+
+  it("does not mark focus when an interactive control is clicked", () => {
+    renderThread(<button data-testid="action">Action</button>)
+    const viewport = screen.getByTestId("viewport")
+
+    pointerDown(screen.getByTestId("action"), 0)
+
+    expect(viewport).not.toHaveAttribute("data-focus-origin")
+    expect(document.activeElement).not.toBe(viewport)
+  })
+
+  it("does not mark focus for a right click", () => {
+    renderThread()
+    const viewport = screen.getByTestId("viewport")
+
+    pointerDown(screen.getByTestId("content"), 2)
+
+    expect(viewport).not.toHaveAttribute("data-focus-origin")
+    expect(document.activeElement).not.toBe(viewport)
+  })
+})

--- a/src/components/message/virtualized-message-thread.test.tsx
+++ b/src/components/message/virtualized-message-thread.test.tsx
@@ -52,6 +52,10 @@ function pointerDown(element: HTMLElement, button: number) {
   fireEvent(element, new MouseEvent("pointerdown", { bubbles: true, button }))
 }
 
+function keyDown(element: HTMLElement, key: string) {
+  fireEvent.keyDown(element, { key })
+}
+
 beforeEach(() => {
   testState.scrollRef.current = null
 })
@@ -71,6 +75,21 @@ describe("VirtualizedMessageThread focus origin", () => {
 
     fireEvent.blur(viewport)
     expect(viewport).not.toHaveAttribute("data-focus-origin")
+  })
+
+  it("clears the pointer marker on keyboard input so the ring returns", () => {
+    renderThread()
+    const viewport = screen.getByTestId("viewport")
+
+    pointerDown(screen.getByTestId("content"), 0)
+    expect(viewport).toHaveAttribute("data-focus-origin", "pointer")
+
+    // Switching to keyboard scrolling drops the marker, so the suppressing
+    // `data-[focus-origin=pointer]` selector no longer matches and the
+    // keyboard focus ring becomes visible again.
+    keyDown(viewport, "ArrowDown")
+    expect(viewport).not.toHaveAttribute("data-focus-origin")
+    expect(document.activeElement).toBe(viewport)
   })
 
   it("keeps keyboard-origin focus distinguishable", () => {

--- a/src/components/message/virtualized-message-thread.tsx
+++ b/src/components/message/virtualized-message-thread.tsx
@@ -103,6 +103,9 @@ function VirtualizedMessageThreadImpl<T>({
     const el = scrollRef.current
     if (!el) return
     el.tabIndex = 0
+    const clearPointerFocus = () => {
+      el.removeAttribute("data-focus-origin")
+    }
     const onPointerDown = (e: PointerEvent) => {
       // Ignore right-click and macOS ctrl-click (both open the context menu).
       if (e.button !== 0 || e.ctrlKey) return
@@ -117,10 +120,16 @@ function VirtualizedMessageThreadImpl<T>({
         )
       )
         return
+      el.setAttribute("data-focus-origin", "pointer")
       el.focus({ preventScroll: true })
     }
     el.addEventListener("pointerdown", onPointerDown)
-    return () => el.removeEventListener("pointerdown", onPointerDown)
+    el.addEventListener("blur", clearPointerFocus)
+    return () => {
+      el.removeEventListener("pointerdown", onPointerDown)
+      el.removeEventListener("blur", clearPointerFocus)
+      clearPointerFocus()
+    }
   }, [scrollRef])
 
   // Pre-compute the three possible padding styles so every render reuses
@@ -146,7 +155,7 @@ function VirtualizedMessageThreadImpl<T>({
     <MessageScrollProvider value={scrollContextValue}>
       <MessageThreadContent
         className={cn("mx-0 max-w-none p-0", contentClassName)}
-        scrollClassName="scrollbar-thin overscroll-contain [overflow-anchor:none] outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        scrollClassName="scrollbar-thin overscroll-contain [overflow-anchor:none] outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset data-[focus-origin=pointer]:focus-visible:ring-0"
         {...contentProps}
       >
         {items.length === 0 ? (

--- a/src/components/message/virtualized-message-thread.tsx
+++ b/src/components/message/virtualized-message-thread.tsx
@@ -125,9 +125,16 @@ function VirtualizedMessageThreadImpl<T>({
     }
     el.addEventListener("pointerdown", onPointerDown)
     el.addEventListener("blur", clearPointerFocus)
+    // Once the user drives the viewport with the keyboard (Arrow/Page/Home/End
+    // to scroll), drop the pointer-origin marker so the focus ring reappears —
+    // keeping the keyboard focus indicator visible per WCAG 2.4.7. The ring is
+    // only suppressed for the mouse click that focused the viewport, not for
+    // subsequent keyboard use.
+    el.addEventListener("keydown", clearPointerFocus)
     return () => {
       el.removeEventListener("pointerdown", onPointerDown)
       el.removeEventListener("blur", clearPointerFocus)
+      el.removeEventListener("keydown", clearPointerFocus)
       clearPointerFocus()
     }
   }, [scrollRef])


### PR DESCRIPTION
## 问题

在 Windows 桌面版或通过分享链接打开的网页端中，Agent 输出内容后，点击消息文本或正文空白处，整个消息滚动区域会出现焦点边框，边框包含右侧滚动条；点击区域外后消失。

复现步骤：

1. 打开一个已有 Agent 输出内容的对话；
2. 点击消息文本或正文空白处，不点击链接、按钮或输入框；
3. 消息滚动区域四周出现完整焦点边框。

预期行为：鼠标点击正文后不显示键盘焦点提示，但仍可使用方向键、PageUp/PageDown 等按键滚动消息。通过 Tab 键进入消息区域时，应继续显示焦点提示。

## 原因

`VirtualizedMessageThread` 为支持键盘滚动，给消息滚动视口设置了 `tabIndex=0`，并在点击非交互正文时调用 `focus()`；视口同时使用 `focus-visible:ring-2` 提供键盘焦点提示。

Chromium/WebView 会将鼠标事件中调用的程序化 `focus()` 判定为 `:focus-visible`，因此鼠标点击也触发了原本用于键盘导航的焦点环。相关行为由提交 `259989f` 引入。

## 方案选择

考虑过以下方式：

1. 删除焦点环：会同时删除 Tab 导航所需的焦点提示；
2. 删除 `tabIndex` 或点击聚焦：会破坏现有键盘滚动；
3. 仅区分本次焦点是否来自鼠标：保留现有交互，只抑制鼠标点击产生的错误焦点环。

本 PR 采用方案 3，保留原有键盘操作和无障碍设计，只修正不同输入方式下的视觉反馈。

## 改动

- 左键点击非交互正文并调用 `focus()` 前，为消息视口写入临时的鼠标焦点来源标记；
- 鼠标来源且命中 `:focus-visible` 时，通过局部样式隐藏焦点环；
- 视口失焦或组件卸载时清理标记；
- 保留现有 `tabIndex`、点击聚焦、交互元素过滤、右键处理和键盘焦点样式。

改动仅涉及 `VirtualizedMessageThread` 及对应回归测试，不修改全局 ScrollArea 或基础焦点样式。

## 影响评估

- 保留 Tab 焦点提示、键盘滚动及链接、按钮、文本选择和右键等原有交互；
- 改动仅作用于消息视口的临时 DOM 状态和局部样式，不涉及数据、文件保存、后端或其他滚动区域；桌面端和网页端共用该逻辑；
- 鼠标点击后到视口失焦前，键盘滚动也不显示焦点环；通过键盘重新聚焦后恢复。这是本方案的明确取舍。

## 验证

- 4 项定向回归测试、ESLint、完整 Vitest（182 个测试文件、2288 项测试）、Next.js 构建和 `git diff --check` 均通过；
- Windows Tauri 开发版已实机验证，原焦点边框问题未再复现；网页端人工验收待记录。
