### PR TITLE
fix(acp): kill agent process trees synchronously on quit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,17 @@ jobs:
         working-directory: src-tauri
         run: cargo test ${{ matrix.cargo_args }} ${{ (matrix.os == 'windows-latest' && matrix.mode == 'desktop') && '--no-run' || '' }}
 
+      - name: cargo test (vendored sacp-tokio)
+        # `vendor/sacp-tokio` is a path dependency, NOT a workspace member, so
+        # the cargo test above never reaches its unit tests — including the ones
+        # covering codeg's own patches to it (process-exit reporting, cwd
+        # handling). One Linux desktop cell is enough: the crate is plain
+        # tokio/futures with no system deps, and its process tests are
+        # `#[cfg(unix)]`.
+        if: matrix.os == 'ubuntu-22.04' && matrix.mode == 'desktop'
+        working-directory: src-tauri
+        run: cargo test --manifest-path vendor/sacp-tokio/Cargo.toml --lib
+
       - name: cargo clippy
         # Clippy on each (os, mode) cell — desktop covers tauri-only code
         # paths plus integration tests, server covers cfg-gated server-only

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -326,6 +326,15 @@ pub struct AgentConnection {
     /// no-op save (identical values) stays silent. Starts equal to
     /// `config_fingerprint`.
     pub last_observed_fingerprint: String,
+    /// OS process id of the spawned agent subprocess, published by the
+    /// vendored `sacp-tokio` `on_spawn` callback. `0` until the process has
+    /// launched (or if the pid was never observed). Used only as a shutdown
+    /// backstop: `disconnect_all` kills this pid's whole process tree
+    /// synchronously after the graceful-disconnect grace window, so agents
+    /// (and their own child processes, e.g. MCP servers) never leak as orphans
+    /// when the host process exits before `ChildGuard::drop` can run on the
+    /// connection driver thread.
+    pub child_pid: Arc<std::sync::atomic::AtomicU32>,
 }
 
 impl AgentConnection {
@@ -956,7 +965,18 @@ pub async fn spawn_agent_connection(
     // agree. Computed here because `working_dir` is moved into run_connection
     // below.
     let launch_cwd = resolve_working_dir(working_dir.as_deref());
-    let agent = build_agent(agent_type, &runtime_env, &launch_cwd).await?;
+    // Shared cell that receives the agent process's OS pid the instant it
+    // spawns (via `on_spawn` below). Stored on the `AgentConnection` so the
+    // shutdown path can `kill_tree` the process tree synchronously as a
+    // backstop when the connection driver thread is torn down by process exit
+    // before `ChildGuard::drop` can run. 0 = not spawned yet / unknown.
+    let child_pid = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let agent = build_agent(agent_type, &runtime_env, &launch_cwd)
+        .await?
+        .on_spawn({
+            let child_pid = Arc::clone(&child_pid);
+            move |pid| child_pid.store(pid, std::sync::atomic::Ordering::SeqCst)
+        });
 
     // Path policy for the ACP `fs/*` channel. Built HERE rather than inside
     // `run_connection` because it needs the full `runtime_env` (only the git
@@ -1012,6 +1032,7 @@ pub async fn spawn_agent_connection(
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             last_observed_fingerprint: config_fingerprint.clone(),
             config_fingerprint,
+            child_pid,
         },
     );
 

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -334,6 +334,14 @@ pub struct AgentConnection {
     /// (and their own child processes, e.g. MCP servers) never leak as orphans
     /// when the host process exits before `ChildGuard::drop` can run on the
     /// connection driver thread.
+    ///
+    /// Reset to `0` by the paired `on_exit` callback the moment the process is
+    /// *reaped* — the only moment its pid stops naming our child and becomes
+    /// reassignable. That reset is what keeps the backstop from ever aiming at
+    /// a pid the OS has since handed to an unrelated process. Notably it does
+    /// NOT fire merely because the connection ended: `ChildGuard::drop` signals
+    /// the tree without waiting, so the agent may still be alive and still
+    /// needs the backstop.
     pub child_pid: Arc<std::sync::atomic::AtomicU32>,
 }
 
@@ -976,6 +984,16 @@ pub async fn spawn_agent_connection(
         .on_spawn({
             let child_pid = Arc::clone(&child_pid);
             move |pid| child_pid.store(pid, std::sync::atomic::Ordering::SeqCst)
+        })
+        // Paired with `on_spawn`: publish 0 again once the process has been
+        // reaped, so the shutdown backstop can never `kill_tree` a pid the OS
+        // has already handed to someone else. Fires ONLY on a real reap — a
+        // connection that merely ended keeps its pid published, because the
+        // vendored `ChildGuard` signals the tree without waiting and the agent
+        // may still be running.
+        .on_exit({
+            let child_pid = Arc::clone(&child_pid);
+            move || child_pid.store(0, std::sync::atomic::Ordering::SeqCst)
         });
 
     // Path policy for the ACP `fs/*` channel. Built HERE rather than inside

--- a/src-tauri/src/acp/lifecycle.rs
+++ b/src-tauri/src/acp/lifecycle.rs
@@ -1653,6 +1653,7 @@ mod tests {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         }
     }
 

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -43,9 +43,11 @@ use crate::web::event_bridge::{emit_with_state, emit_with_state_gated, EventEmit
 const USER_PROMPT_PREVIEW_MAX_CHARS: usize = 500;
 
 /// Grace window `disconnect_all` waits after firing every `Disconnect` before
-/// hard-killing surviving agent process trees. Long enough for the graceful
-/// `ChildGuard::drop` → `kill_tree` path to win on connections that close
-/// cleanly, short enough not to stall a quit noticeably.
+/// hard-killing surviving agent process trees. Long enough for a driver thread
+/// to unwind and run its own post-loop cleanup (delegation/question/plan-approval
+/// reclaim), short enough not to stall a quit noticeably. It is NOT there to
+/// make the agent's death gentler — the graceful path ends in the same
+/// `kill_tree`.
 const DISCONNECT_ALL_GRACE: Duration = Duration::from_millis(500);
 
 /// True for ids in the parsers' turn-id namespace (`turn-<digits>`), which every
@@ -1867,13 +1869,32 @@ impl ConnectionManager {
     /// reparented and lingers until it independently notices its stdin EOF
     /// (~30s for Claude Code / node).
     ///
-    /// So: fire every `Disconnect`, give the graceful drops a short grace window
-    /// to win the race on their own, then synchronously `kill_tree` every pid we
-    /// recorded at spawn. `kill_tree` on an already-dead pid is a best-effort
-    /// no-op, so a connection that shut down cleanly within the window costs
-    /// nothing here. Only pids this manager spawned (and their descendants) are
-    /// touched — `child_pid == 0` (never spawned, or a viewer/child that owns no
-    /// process) is skipped.
+    /// So: fire every `Disconnect`, give the graceful path a short grace window,
+    /// then synchronously `kill_tree` whatever is still running.
+    ///
+    /// What the window actually buys is NOT a gentler death for the agent — the
+    /// graceful path ends in the same `kill_tree` — it is time for the driver
+    /// thread's own post-loop cleanup (delegation-token revoke, `cancel_by_parent`
+    /// for delegations / questions / plan approvals), which at quit previously
+    /// got no time at all.
+    ///
+    /// Each pid is read from its live cell as late as possible — after the
+    /// window, inside the kill loop — never from an up-front snapshot. That is
+    /// load-bearing in both directions:
+    /// - A connection whose process was reaped during the window has already
+    ///   had its cell zeroed by the `on_exit` callback, so the backstop skips it
+    ///   instead of `kill_tree`-ing a pid the OS may have recycled onto an
+    ///   unrelated process tree. A connection that merely *ended* keeps its pid
+    ///   and still gets swept — `ChildGuard::drop` signals without waiting, so
+    ///   "the driver returned" is not "the agent is gone".
+    /// - A connection whose child spawned *after* quit began (still `Connecting`
+    ///   when the map was drained) publishes its pid into the same cell, so the
+    ///   backstop still reaches it — an up-front snapshot would read `0` and
+    ///   leak exactly the orphan this exists to kill.
+    ///
+    /// Only pids this manager spawned (and their descendants) are touched;
+    /// `child_pid == 0` (never spawned, already finished, or a test/viewer entry
+    /// that owns no process) is skipped.
     pub async fn disconnect_all(&self) -> usize {
         let handles: Vec<(
             tokio::sync::mpsc::Sender<ConnectionCommand>,
@@ -1886,14 +1907,14 @@ impl ConnectionManager {
                 .collect()
         };
         let disconnected = handles.len();
-        // Snapshot the pids before consuming the senders so the backstop can
-        // still reach them after the graceful path has had its window.
-        let pids: Vec<u32> = handles
-            .iter()
-            .map(|(_, pid)| pid.load(std::sync::atomic::Ordering::SeqCst))
-            .collect();
+        // `try_send`, not `send().await`: this is the shutdown path, and the
+        // backstop below is only reachable if every send returns. A connection
+        // whose command queue is full (32 deep) would otherwise park the whole
+        // quit here — precisely the wedged connection whose tree most needs
+        // killing. A dropped `Disconnect` just means that connection skips the
+        // graceful path and gets hard-killed instead.
         for (cmd_tx, _) in &handles {
-            let _ = cmd_tx.send(ConnectionCommand::Disconnect).await;
+            let _ = cmd_tx.try_send(ConnectionCommand::Disconnect);
         }
         tracing::info!("[ACP] disconnect_all count={}", disconnected);
 
@@ -1901,26 +1922,30 @@ impl ConnectionManager {
             return 0;
         }
 
-        // Grace window: let the graceful `ChildGuard::drop` kill_tree win on its
-        // own where it can (clean stdio close, no orphaned descendants). Short
-        // enough not to stall a quit noticeably.
+        // Grace window: let the drivers unwind and run their own cleanup.
         tokio::time::sleep(DISCONNECT_ALL_GRACE).await;
 
-        // Backstop: hard-kill any pid still alive. Runs on a blocking thread so
-        // the synchronous `kill_tree` doesn't stall the async runtime while a
-        // `block_on(disconnect_all())` shutdown caller waits on it.
+        // Backstop: hard-kill whatever is still running. Runs on a blocking
+        // thread so the synchronous `kill_tree` doesn't stall the async runtime
+        // while a `block_on(disconnect_all())` shutdown caller waits on it.
+        let pid_cells: Vec<Arc<std::sync::atomic::AtomicU32>> =
+            handles.into_iter().map(|(_, pid)| pid).collect();
         let _ = tokio::task::spawn_blocking(move || {
-            for pid in pids {
+            for cell in pid_cells {
+                // Load here, not before the window — see the doc comment.
+                let pid = cell.load(std::sync::atomic::Ordering::SeqCst);
                 if pid == 0 {
                     continue;
                 }
                 match kill_tree::blocking::kill_tree(pid) {
                     Ok(_) => {
-                        tracing::info!("[ACP] disconnect_all backstop killed process tree pid={pid}");
+                        tracing::info!(
+                            "[ACP] disconnect_all backstop killed process tree pid={pid}"
+                        );
                     }
                     Err(e) => {
-                        // Already-dead pid is the common, expected case (the
-                        // graceful path won the race) — log at debug, not error.
+                        // The process can still exit between the load and the
+                        // kill; that error is expected, not a failure.
                         tracing::debug!("[ACP] disconnect_all backstop kill_tree pid={pid}: {e}");
                     }
                 }
@@ -2906,6 +2931,163 @@ mod tests {
             last_observed_fingerprint: String::new(),
             child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         }
+    }
+
+    /// Spawn a two-level process tree: `sh` (the stand-in for the agent CLI)
+    /// backgrounds a `sleep` grandchild (the stand-in for the agent's own
+    /// children — an MCP server, a forked `node`) and records its pid. The
+    /// grandchild is what the backstop assertions are about: it is the process
+    /// that gets reparented and lingers when only the direct child is killed.
+    ///
+    /// Returns the direct child — keep it alive, dropping a `Child` does NOT
+    /// kill it — and the grandchild pid.
+    #[cfg(unix)]
+    async fn spawn_process_tree(pidfile: &std::path::Path) -> (std::process::Child, i32) {
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!("sleep 30 & echo $! > '{}'; wait", pidfile.display()))
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sh");
+        for _ in 0..150 {
+            if let Ok(raw) = std::fs::read_to_string(pidfile) {
+                if let Ok(pid) = raw.trim().parse::<i32>() {
+                    return (child, pid);
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        // Bail-out path still reaps the tree, so a failing test can't leave a
+        // `sleep` behind for 30s.
+        let _ = kill_tree::blocking::kill_tree(child.id());
+        let _ = child.wait();
+        panic!("grandchild never recorded its pid");
+    }
+
+    /// True once `pid` is gone. `kill(pid, 0)` sends no signal, it only probes
+    /// existence; polling keeps the assertion from racing kernel teardown.
+    #[cfg(unix)]
+    async fn wait_until_dead(pid: i32) -> bool {
+        for _ in 0..150 {
+            // SAFETY: signal 0 only probes for existence; it sends no signal.
+            if unsafe { libc::kill(pid, 0) } != 0 {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        false
+    }
+
+    #[cfg(unix)]
+    fn is_alive(pid: i32) -> bool {
+        // SAFETY: signal 0 only probes for existence; it sends no signal.
+        unsafe { libc::kill(pid, 0) == 0 }
+    }
+
+    /// Quit has to kill the agent's whole process TREE. Killing just the direct
+    /// child leaves its children reparented and lingering — that orphan window
+    /// is the entire reason the backstop exists.
+    ///
+    /// The test connection's command receiver is dropped, so the graceful path
+    /// is unavailable and the kill can only come from the backstop.
+    /// Unix-only (relies on `sh` / `kill(2)`).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn disconnect_all_backstop_kills_the_whole_agent_process_tree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut child, gpid) = spawn_process_tree(&dir.path().join("g.pid")).await;
+
+        let mgr = ConnectionManager::new();
+        let conn = fake_connection("conn-tree", None);
+        conn.child_pid
+            .store(child.id(), std::sync::atomic::Ordering::SeqCst);
+        mgr.connections
+            .lock()
+            .await
+            .insert("conn-tree".to_string(), conn);
+
+        assert_eq!(mgr.disconnect_all().await, 1);
+        assert!(
+            wait_until_dead(gpid).await,
+            "grandchild {gpid} survived — the quit backstop did not kill the tree"
+        );
+        let _ = child.wait();
+    }
+
+    /// A connection still `Connecting` when quit begins publishes its pid AFTER
+    /// the map is drained. Reading the pids up front would see `0` there and
+    /// skip it, leaking exactly the orphan this exists to kill — so the load
+    /// has to happen after the grace window, from the live cell.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn disconnect_all_backstop_reaches_a_child_that_spawns_during_the_grace_window() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut child, gpid) = spawn_process_tree(&dir.path().join("g.pid")).await;
+
+        let mgr = ConnectionManager::new();
+        let conn = fake_connection("conn-late", None);
+        // Still 0 at drain time, exactly like a connection whose agent process
+        // hasn't launched yet.
+        let cell = Arc::clone(&conn.child_pid);
+        mgr.connections
+            .lock()
+            .await
+            .insert("conn-late".to_string(), conn);
+
+        let pid = child.id();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cell.store(pid, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        assert_eq!(mgr.disconnect_all().await, 1);
+        assert!(
+            wait_until_dead(gpid).await,
+            "grandchild {gpid} survived — a pid published during the grace window was missed"
+        );
+        let _ = child.wait();
+    }
+
+    /// The mirror image: once the agent process has been reaped, the `on_exit`
+    /// callback zeroes the cell and the backstop must leave that pid alone.
+    /// Without the clear, a quit fires `kill_tree` at a pid whose process is
+    /// already dead and reaped — and if the OS recycled that number, the victim
+    /// is an unrelated process tree.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn disconnect_all_backstop_leaves_a_cleared_pid_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut child, gpid) = spawn_process_tree(&dir.path().join("g.pid")).await;
+
+        let mgr = ConnectionManager::new();
+        let conn = fake_connection("conn-cleared", None);
+        conn.child_pid
+            .store(child.id(), std::sync::atomic::Ordering::SeqCst);
+        let cell = Arc::clone(&conn.child_pid);
+        mgr.connections
+            .lock()
+            .await
+            .insert("conn-cleared".to_string(), conn);
+
+        // Stands in for the driver unwinding mid-window: the process is gone
+        // and the guard has zeroed the cell.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cell.store(0, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        assert_eq!(mgr.disconnect_all().await, 1);
+        // Settle: a wrongly-issued SIGTERM would have landed by now.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            is_alive(gpid),
+            "backstop killed a tree whose pid the driver had already cleared"
+        );
+
+        let _ = kill_tree::blocking::kill_tree(child.id());
+        let _ = child.wait();
     }
 
     /// Build a broadcaster + subscribed receiver. Subscribing here (not lazily

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -42,6 +42,12 @@ use crate::web::event_bridge::{emit_with_state, emit_with_state_gated, EventEmit
 /// IM message, or the webhook body.
 const USER_PROMPT_PREVIEW_MAX_CHARS: usize = 500;
 
+/// Grace window `disconnect_all` waits after firing every `Disconnect` before
+/// hard-killing surviving agent process trees. Long enough for the graceful
+/// `ChildGuard::drop` → `kill_tree` path to win on connections that close
+/// cleanly, short enough not to stall a quit noticeably.
+const DISCONNECT_ALL_GRACE: Duration = Duration::from_millis(500);
+
 /// True for ids in the parsers' turn-id namespace (`turn-<digits>`), which every
 /// parser assigns via `format!("turn-{}", n)`. A broadcast `message_id` must
 /// never land here: it would collide with a persisted transcript turn id and let
@@ -339,6 +345,7 @@ impl ConnectionManager {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         };
         let mut map = self.connections.lock().await;
         map.insert(id.to_string(), conn);
@@ -381,6 +388,7 @@ impl ConnectionManager {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         };
         self.connections.lock().await.insert(id.to_string(), conn);
         rx
@@ -1845,16 +1853,81 @@ impl ConnectionManager {
         disconnected
     }
 
+    /// Disconnect every connection, then hard-kill any surviving agent process
+    /// trees as a shutdown backstop.
+    ///
+    /// The graceful path (send `Disconnect` → the connection driver thread
+    /// breaks its command loop → `run_connection` unwinds → the vendored
+    /// `sacp-tokio` `ChildGuard::drop` runs `kill_tree`) is enough on its own
+    /// *when it gets to run*. It doesn't at process exit: `run_connection` is
+    /// driven on a dedicated `std::thread` (see `spawn_agent`), and when Tauri's
+    /// `ExitRequested` handler returns the process terminates those threads
+    /// mid-flight — often before the driver reaches `ChildGuard::drop` — so the
+    /// agent CLI (and its own children, e.g. MCP servers / a forked `node`) is
+    /// reparented and lingers until it independently notices its stdin EOF
+    /// (~30s for Claude Code / node).
+    ///
+    /// So: fire every `Disconnect`, give the graceful drops a short grace window
+    /// to win the race on their own, then synchronously `kill_tree` every pid we
+    /// recorded at spawn. `kill_tree` on an already-dead pid is a best-effort
+    /// no-op, so a connection that shut down cleanly within the window costs
+    /// nothing here. Only pids this manager spawned (and their descendants) are
+    /// touched — `child_pid == 0` (never spawned, or a viewer/child that owns no
+    /// process) is skipped.
     pub async fn disconnect_all(&self) -> usize {
-        let cmd_txs: Vec<_> = {
+        let handles: Vec<(
+            tokio::sync::mpsc::Sender<ConnectionCommand>,
+            Arc<std::sync::atomic::AtomicU32>,
+        )> = {
             let mut connections = self.connections.lock().await;
-            connections.drain().map(|(_, conn)| conn.cmd_tx).collect()
+            connections
+                .drain()
+                .map(|(_, conn)| (conn.cmd_tx, conn.child_pid))
+                .collect()
         };
-        let disconnected = cmd_txs.len();
-        for cmd_tx in cmd_txs {
+        let disconnected = handles.len();
+        // Snapshot the pids before consuming the senders so the backstop can
+        // still reach them after the graceful path has had its window.
+        let pids: Vec<u32> = handles
+            .iter()
+            .map(|(_, pid)| pid.load(std::sync::atomic::Ordering::SeqCst))
+            .collect();
+        for (cmd_tx, _) in &handles {
             let _ = cmd_tx.send(ConnectionCommand::Disconnect).await;
         }
         tracing::info!("[ACP] disconnect_all count={}", disconnected);
+
+        if disconnected == 0 {
+            return 0;
+        }
+
+        // Grace window: let the graceful `ChildGuard::drop` kill_tree win on its
+        // own where it can (clean stdio close, no orphaned descendants). Short
+        // enough not to stall a quit noticeably.
+        tokio::time::sleep(DISCONNECT_ALL_GRACE).await;
+
+        // Backstop: hard-kill any pid still alive. Runs on a blocking thread so
+        // the synchronous `kill_tree` doesn't stall the async runtime while a
+        // `block_on(disconnect_all())` shutdown caller waits on it.
+        let _ = tokio::task::spawn_blocking(move || {
+            for pid in pids {
+                if pid == 0 {
+                    continue;
+                }
+                match kill_tree::blocking::kill_tree(pid) {
+                    Ok(_) => {
+                        tracing::info!("[ACP] disconnect_all backstop killed process tree pid={pid}");
+                    }
+                    Err(e) => {
+                        // Already-dead pid is the common, expected case (the
+                        // graceful path won the race) — log at debug, not error.
+                        tracing::debug!("[ACP] disconnect_all backstop kill_tree pid={pid}: {e}");
+                    }
+                }
+            }
+        })
+        .await;
+
         disconnected
     }
 
@@ -2831,6 +2904,7 @@ mod tests {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         }
     }
 
@@ -3003,6 +3077,7 @@ mod tests {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         };
         mgr.connections
             .lock()
@@ -3336,6 +3411,7 @@ mod tests {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         };
         let mgr = ConnectionManager::new();
         mgr.connections
@@ -4908,6 +4984,7 @@ mod tests {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         };
         let mgr = Arc::new(ConnectionManager::new());
         {
@@ -5281,6 +5358,7 @@ mod tests {
             prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
             config_fingerprint: String::new(),
             last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         };
         let mgr = ConnectionManager::new();
         {

--- a/src-tauri/vendor/sacp-tokio/src/acp_agent.rs
+++ b/src-tauri/vendor/sacp-tokio/src/acp_agent.rs
@@ -87,6 +87,7 @@ pub struct AcpAgent {
     debug_callback: Option<Arc<dyn Fn(&str, LineDirection) + Send + Sync + 'static>>,
     current_dir: Option<PathBuf>,
     spawn_callback: Option<Arc<dyn Fn(u32) + Send + Sync + 'static>>,
+    exit_callback: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
 }
 
 impl std::fmt::Debug for AcpAgent {
@@ -102,6 +103,7 @@ impl std::fmt::Debug for AcpAgent {
                 "spawn_callback",
                 &self.spawn_callback.as_ref().map(|_| "..."),
             )
+            .field("exit_callback", &self.exit_callback.as_ref().map(|_| "..."))
             .finish()
     }
 }
@@ -114,6 +116,7 @@ impl AcpAgent {
             debug_callback: None,
             current_dir: None,
             spawn_callback: None,
+            exit_callback: None,
         }
     }
 
@@ -212,6 +215,49 @@ impl AcpAgent {
         self
     }
 
+    /// Register a callback invoked once when the agent process has been
+    /// *reaped* — the counterpart to [`on_spawn`](Self::on_spawn), telling a
+    /// host that the pid it recorded no longer names this process.
+    ///
+    /// It deliberately does NOT fire merely because the connection ended. When
+    /// the protocol future finishes first, the internal `ChildGuard` kills the
+    /// tree on drop, but `kill_tree` only signals (SIGTERM on Unix) and does
+    /// not wait — the process can still be alive, so a host that cleared its
+    /// pid record there would disarm its own shutdown backstop.
+    ///
+    /// The callback fires only where the pid genuinely stops being ours: after
+    /// a successful `wait`, on drop of an already-reaped child, or from the
+    /// detached reaper that `drop` hands a still-running child to. That last
+    /// one is why the guard keeps owning the child instead of letting it fall
+    /// into Tokio's orphan queue — a pid reaped out of sight would go stale
+    /// while the host still believed it named this agent.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use sacp_tokio::AcpAgent;
+    /// # use std::str::FromStr;
+    /// # use std::sync::{Arc, atomic::{AtomicU32, Ordering}};
+    /// let pid_cell = Arc::new(AtomicU32::new(0));
+    /// let agent = AcpAgent::from_str("python my_agent.py")
+    ///     .unwrap()
+    ///     .on_spawn({
+    ///         let cell = pid_cell.clone();
+    ///         move |pid| cell.store(pid, Ordering::SeqCst)
+    ///     })
+    ///     .on_exit({
+    ///         let cell = pid_cell.clone();
+    ///         move || cell.store(0, Ordering::SeqCst)
+    ///     });
+    /// ```
+    pub fn on_exit<F>(mut self, callback: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.exit_callback = Some(Arc::new(callback));
+        self
+    }
+
     /// Spawn the process and get stdio streams.
     /// Used internally by the Component trait implementation.
     pub fn spawn_process(
@@ -286,20 +332,81 @@ impl AcpAgent {
 }
 
 /// A wrapper around Child that kills the process when dropped.
-struct ChildGuard(Child);
+struct ChildGuard {
+    /// `None` once the child has been handed to the detached reaper in `drop`.
+    child: Option<Child>,
+    /// Fired exactly once, at the moment the child is *reaped* — see
+    /// [`AcpAgent::on_exit`] for why that moment, and only that moment, is the
+    /// one worth reporting.
+    exit_callback: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
+}
 
 impl ChildGuard {
     async fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
-        self.0.wait().await
+        let Some(child) = self.child.as_mut() else {
+            return Err(std::io::Error::other("child already handed to the reaper"));
+        };
+        let status = child.wait().await;
+        if status.is_ok() {
+            // `wait` succeeded, so the child has been reaped and its pid is
+            // free for the OS to reassign.
+            self.notify_exit();
+        }
+        status
+    }
+
+    fn notify_exit(&mut self) {
+        if let Some(callback) = self.exit_callback.take() {
+            callback();
+        }
     }
 }
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
-        if let Some(pid) = self.0.id() {
-            let _ = kill_tree::blocking::kill_tree(pid);
-        } else {
-            let _ = self.0.start_kill();
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let Some(pid) = child.id() else {
+            // Already reaped, so the pid is free — report the exit.
+            let _ = child.start_kill();
+            self.notify_exit();
+            return;
+        };
+
+        let _ = kill_tree::blocking::kill_tree(pid);
+
+        // `kill_tree` only signals (SIGTERM on Unix) and does not wait, so the
+        // process may well outlive this call. Keep OWNING the child until it is
+        // really reaped, and report the exit from there.
+        //
+        // Simply dropping it here would hand it to Tokio's orphan queue, which
+        // reaps it out of sight: the pid would silently become reusable while a
+        // host still held it as "this agent", and a later kill could land on an
+        // unrelated process tree. Holding the child keeps the pid pinned — a
+        // zombie on Unix, an open process handle on Windows — until we ourselves
+        // observe the exit and say so.
+        let exit_callback = self.exit_callback.take();
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    // Same gate as `ChildGuard::wait`: only a successful `wait`
+                    // proves the child was reaped. Reporting an exit we failed
+                    // to observe would tell the host to stop tracking a pid
+                    // whose process may still be running.
+                    if child.wait().await.is_ok() {
+                        if let Some(callback) = exit_callback {
+                            callback();
+                        }
+                    }
+                });
+            }
+            Err(_) => {
+                // Dropped outside a runtime, so there is nothing to reap on.
+                // Fall back to the previous behaviour and deliberately stay
+                // silent about an exit we cannot observe.
+                drop(child);
+            }
         }
     }
 }
@@ -326,8 +433,12 @@ fn append_limited_utf8(output: &mut String, chunk: &str, limit: usize) -> bool {
 async fn monitor_child(
     child: Child,
     stderr_rx: tokio::sync::oneshot::Receiver<String>,
+    exit_callback: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
 ) -> Result<(), sacp::Error> {
-    let mut guard = ChildGuard(child);
+    let mut guard = ChildGuard {
+        child: Some(child),
+        exit_callback,
+    };
 
     // Wait for the child to exit
     let status = guard
@@ -419,7 +530,7 @@ impl<Counterpart: AcpAgentCounterpartRole> sacp::ConnectTo<Counterpart> for AcpA
         });
 
         // Create a future that monitors the child process for early exit
-        let child_monitor = monitor_child(child, stderr_rx);
+        let child_monitor = monitor_child(child, stderr_rx, self.exit_callback.clone());
 
         // Convert stdio to line streams with optional debug inspection
         let incoming_lines = if let Some(callback) = self.debug_callback.clone() {
@@ -543,6 +654,7 @@ impl AcpAgent {
             debug_callback: None,
             current_dir: None,
             spawn_callback: None,
+            exit_callback: None,
         })
     }
 }
@@ -588,6 +700,7 @@ impl FromStr for AcpAgent {
                 debug_callback: None,
                 current_dir: None,
                 spawn_callback: None,
+                exit_callback: None,
             });
         }
 
@@ -708,6 +821,195 @@ mod tests {
             .with_current_dir("/some/dir");
         // The directory is private; surfaced via Debug so callers can confirm.
         assert!(format!("{agent:?}").contains("/some/dir"));
+    }
+
+    /// The exit callback is a promise about ONE thing: the pid has stopped
+    /// naming this child and the OS may reassign it. These tests pin the three
+    /// moments that promise is (and isn't) true. A host records the pid at spawn
+    /// and kills that tree at shutdown, so firing early aims its kill at a
+    /// stranger, and firing late leaves an orphan alive.
+    ///
+    /// Unix-only: they need a process that can refuse a kill signal, which has
+    /// no Windows analogue (`TerminateProcess` is unconditional). The ownership
+    /// property they cover is platform-neutral though — holding the `Child`
+    /// keeps a Windows process handle open, which is exactly what stops the OS
+    /// from reusing the pid there.
+    #[cfg(unix)]
+    fn counting_callback(calls: &Arc<std::sync::atomic::AtomicUsize>) -> Arc<dyn Fn() + Send + Sync>
+    {
+        let calls = Arc::clone(calls);
+        Arc::new(move || {
+            calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        })
+    }
+
+    /// A reaped child means its pid is free for the OS to reassign, so the exit
+    /// callback has to fire — a host still holding that pid would aim its
+    /// shutdown kill at whatever inherits the number next.
+    #[cfg(unix)]
+    #[test]
+    fn exit_callback_fires_once_the_child_is_reaped() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        rt.block_on(async {
+            let child = tokio::process::Command::new("/bin/sh")
+                .args(["-c", "exit 0"])
+                .spawn()
+                .expect("spawn sh");
+            let mut guard = ChildGuard {
+                child: Some(child),
+                exit_callback: Some(counting_callback(&calls)),
+            };
+            guard.wait().await.expect("wait");
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                1,
+                "a reaped child must report its exit"
+            );
+            drop(guard);
+        });
+        // Exactly once, even though `drop` also runs its own notify path.
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Dropping the guard kills the tree but does not wait, so the exit is not
+    /// observed yet — and must not be reported yet. It has to be reported once
+    /// the child actually dies, which only works because `drop` keeps owning the
+    /// child instead of letting Tokio's orphan queue reap it out of sight.
+    ///
+    /// A current-thread runtime makes the ordering exact: the detached reaper
+    /// cannot run during the synchronous assertion right after `drop`.
+    #[cfg(unix)]
+    #[test]
+    fn dropping_the_guard_reports_the_exit_only_once_the_child_is_reaped() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        rt.block_on(async {
+            let child = tokio::process::Command::new("/bin/sh")
+                .args(["-c", "sleep 30"])
+                .spawn()
+                .expect("spawn sh");
+            let guard = ChildGuard {
+                child: Some(child),
+                exit_callback: Some(counting_callback(&calls)),
+            };
+
+            drop(guard);
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                0,
+                "the kill was only signalled — the exit has not been observed yet"
+            );
+
+            let mut reported = false;
+            for _ in 0..200 {
+                if calls.load(Ordering::SeqCst) > 0 {
+                    reported = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            assert!(
+                reported,
+                "the killed child was never reaped — its pid would stay published forever"
+            );
+        });
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// The case that makes the whole design necessary: a child that ignores the
+    /// kill signal is STILL RUNNING after `drop`. Its pid must stay published so
+    /// a host's shutdown backstop still sweeps it — reporting an exit here would
+    /// disarm that backstop and leave a real orphan behind.
+    #[cfg(unix)]
+    #[test]
+    fn a_child_that_survives_the_kill_keeps_its_pid_published() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        // The shell announces itself only AFTER installing the trap. Killing it
+        // before that point would hit the default disposition and the test would
+        // "fail" for a reason it isn't testing.
+        let ready = std::env::temp_dir().join(format!(
+            "sacp-tokio-trap-ready-{}-{:p}",
+            std::process::id(),
+            &calls
+        ));
+        let _ = std::fs::remove_file(&ready);
+
+        rt.block_on(async {
+            // Ignores SIGTERM and respawns the `sleep` that `kill_tree` reaches,
+            // so the whole tree outlives the guard's kill.
+            let child = tokio::process::Command::new("/bin/sh")
+                .args([
+                    "-c",
+                    &format!(
+                        "trap '' TERM; echo ready > '{}'; while true; do sleep 1; done",
+                        ready.display()
+                    ),
+                ])
+                .spawn()
+                .expect("spawn sh");
+            let pid = child.id().expect("child has a pid").to_string();
+            let guard = ChildGuard {
+                child: Some(child),
+                exit_callback: Some(counting_callback(&calls)),
+            };
+
+            let mut trapped = false;
+            for _ in 0..200 {
+                if ready.exists() {
+                    trapped = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            assert!(trapped, "the shell never installed its SIGTERM trap");
+
+            drop(guard);
+
+            // Well past the signal it ignored. `kill -0` probes for existence
+            // without sending anything (no `libc` dependency in this crate).
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            let alive = std::process::Command::new("kill")
+                .args(["-0", &pid])
+                .status()
+                .expect("run kill -0")
+                .success();
+            assert!(
+                alive,
+                "test setup is wrong — the child was supposed to survive SIGTERM"
+            );
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                0,
+                "a still-running child must keep its pid published"
+            );
+
+            // And once it really dies, the exit is reported — the reaper is
+            // armed the whole time, not abandoned.
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &pid])
+                .status();
+            let mut reported = false;
+            for _ in 0..200 {
+                if calls.load(Ordering::SeqCst) > 0 {
+                    reported = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            assert!(reported, "the reaper never observed the child's death");
+        });
+        let _ = std::fs::remove_file(&ready);
     }
 
     #[cfg(unix)]

--- a/src-tauri/vendor/sacp-tokio/src/acp_agent.rs
+++ b/src-tauri/vendor/sacp-tokio/src/acp_agent.rs
@@ -86,6 +86,7 @@ pub struct AcpAgent {
     server: sacp::schema::McpServer,
     debug_callback: Option<Arc<dyn Fn(&str, LineDirection) + Send + Sync + 'static>>,
     current_dir: Option<PathBuf>,
+    spawn_callback: Option<Arc<dyn Fn(u32) + Send + Sync + 'static>>,
 }
 
 impl std::fmt::Debug for AcpAgent {
@@ -97,6 +98,10 @@ impl std::fmt::Debug for AcpAgent {
                 &self.debug_callback.as_ref().map(|_| "..."),
             )
             .field("current_dir", &self.current_dir)
+            .field(
+                "spawn_callback",
+                &self.spawn_callback.as_ref().map(|_| "..."),
+            )
             .finish()
     }
 }
@@ -108,6 +113,7 @@ impl AcpAgent {
             server,
             debug_callback: None,
             current_dir: None,
+            spawn_callback: None,
         }
     }
 
@@ -173,6 +179,36 @@ impl AcpAgent {
     /// right place.
     pub fn with_current_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.current_dir = Some(dir.into());
+        self
+    }
+
+    /// Register a callback invoked once with the OS process id (pid) of the
+    /// spawned agent process, right after it launches.
+    ///
+    /// The child is otherwise owned entirely by [`connect_to`]'s internal
+    /// `ChildGuard`, which kills the whole process tree on drop. But that drop
+    /// only runs when the driving future completes — during a host-process
+    /// shutdown the driver may be torn down before it can, leaking the agent
+    /// (and its own child processes) as orphans. Exposing the pid lets the host
+    /// record it and force a synchronous `kill_tree` on exit as a backstop.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use sacp_tokio::AcpAgent;
+    /// # use std::str::FromStr;
+    /// # use std::sync::{Arc, atomic::{AtomicU32, Ordering}};
+    /// let pid_cell = Arc::new(AtomicU32::new(0));
+    /// let cell = pid_cell.clone();
+    /// let agent = AcpAgent::from_str("python my_agent.py")
+    ///     .unwrap()
+    ///     .on_spawn(move |pid| cell.store(pid, Ordering::SeqCst));
+    /// ```
+    pub fn on_spawn<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(u32) + Send + Sync + 'static,
+    {
+        self.spawn_callback = Some(Arc::new(callback));
         self
     }
 
@@ -333,6 +369,16 @@ impl<Counterpart: AcpAgentCounterpartRole> sacp::ConnectTo<Counterpart> for AcpA
         use futures::io::BufReader;
 
         let (child_stdin, child_stdout, child_stderr, child) = self.spawn_process()?;
+
+        // Publish the OS pid to the spawn callback so the host can kill the
+        // process tree deterministically at shutdown rather than relying solely
+        // on `ChildGuard::drop` (which never runs if the driving thread is torn
+        // down by process exit before the connect future unwinds).
+        if let Some(callback) = self.spawn_callback.as_ref() {
+            if let Some(pid) = child.id() {
+                callback(pid);
+            }
+        }
 
         // Create a channel to collect stderr for error reporting
         let (stderr_tx, stderr_rx) = tokio::sync::oneshot::channel::<String>();
@@ -496,6 +542,7 @@ impl AcpAgent {
             ),
             debug_callback: None,
             current_dir: None,
+            spawn_callback: None,
         })
     }
 }
@@ -540,6 +587,7 @@ impl FromStr for AcpAgent {
                 server,
                 debug_callback: None,
                 current_dir: None,
+                spawn_callback: None,
             });
         }
 


### PR DESCRIPTION
Fixes the ~30s orphan window after app quit: agent CLI subprocesses (and their own children — MCP servers, forked `node`, etc.) linger after the app closes and only self-exit when they independently notice stdin EOF.

## Problem

The graceful teardown chain is correct but doesn't get to run at process exit:

- `run_connection` is driven on a dedicated `std::thread` (not a tokio task).
- The kill happens in `sacp-tokio`'s `ChildGuard::drop` → `kill_tree`, which only runs when that driver thread unwinds.
- `ConnectionManager::disconnect_all` is fire-and-forget: it sends `ConnectionCommand::Disconnect` to each connection and returns immediately.
- Tauri's `ExitRequested` handler returns right after, the process terminates, and the driver threads are killed mid-flight — usually before they reach `ChildGuard::drop`. The agent CLI is reparented and lingers (~30s for Claude Code / node until stdin EOF).

Not a permanent leak, but the window means quit-then-relaunch leaves many orphaned `node.exe` alive, and a user watching Task Manager sees processes that look stuck.

## Change

1. **`vendor/sacp-tokio`**: add `AcpAgent::on_spawn(cb)` — invokes `cb(pid)` once with the child's OS pid right after spawn. Non-breaking (new optional field defaulting to `None`; the child is still owned by `ChildGuard`).

2. **`connection.rs`**: attach `on_spawn` to store the pid in a new `AgentConnection.child_pid: Arc<AtomicU32>` (0 = not spawned / unknown).

3. **`manager.rs`**: `disconnect_all` now snapshots the pids, fires every `Disconnect`, sleeps a `DISCONNECT_ALL_GRACE` (500ms) window to let the graceful drops win the race, then `kill_tree`s any survivor on a `spawn_blocking` thread. Already-dead pids are a best-effort no-op (logged at debug), so cleanly-closed connections cost nothing.

## Notes

- Backstop only touches pids this manager spawned + their descendants.
- `kill_tree::blocking` is already used by `ChildGuard::drop`; no new deps or features.
- 500ms is a const (`DISCONNECT_ALL_GRACE`) — tune if quit feels sluggish.

## Test plan

- [ ] `cargo build --release`
- [ ] Quit app with several active agent sessions → Task Manager shows no residual `node.exe` (previously several, gone only after ~30s)
- [ ] Normal single-connection disconnect still exits cleanly within the window (backstop kill_tree is a no-op)
