### PR TITLE
fix(i18n): translate 61 remaining English strings in French locale

### DIFF
--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -576,7 +576,7 @@
       "draftTitle": "Nouveau MCP",
       "draftDescription": "Renseignez un Server ID et une configuration pour créer un serveur MCP local.",
       "serverIdLabel": "ID du serveur",
-      "serverIdPlaceholder": "Server ID (ex. my-mcp)",
+      "serverIdPlaceholder": "ID du serveur (ex. my-mcp)",
       "typeHint": "Types pris en charge : stdio, http (alias : streamable-http, streamableHttp), sse. env n'est utilisé que par stdio ; pour les MCP distants, utilisez headers pour transporter les jetons d'authentification.",
       "envOnRemoteWarning": "env détecté sur un MCP distant. Seul stdio utilise env ; les MCP distants transportent les jetons d'authentification via headers, donc env sera ignoré à l'enregistrement."
     },
@@ -759,7 +759,7 @@
       "permissionModeLabel": "Mode d'autorisation",
       "permissionModeDefault": "Demander avant d'exécuter (par défaut)",
       "permissionModeForce": "Tout exécuter (--force)",
-      "permissionModeHint": "Run Everything lance les sessions avec --force : tous les appels d'outils sont autorisés automatiquement sauf les règles de refus, sans confirmation (une politique d'organisation peut le limiter aux règles d'autorisation). S'applique aux nouvelles sessions.",
+      "permissionModeHint": "Tout exécuter lance les sessions avec --force : tous les appels d'outils sont autorisés automatiquement sauf les règles de refus, sans confirmation (une politique d'organisation peut le limiter aux règles d'autorisation). S'applique aux nouvelles sessions.",
       "optionDefault": "Défaut (non défini)",
       "sandboxLabel": "Bac à sable",
       "sandboxEnabled": "Activé",
@@ -3117,7 +3117,7 @@
         "other": "Autre",
         "otherPlaceholder": "Saisissez votre réponse…",
         "singleSelect": "Unique",
-        "multiSelect": "Choix multiple",
+        "multiSelect": "Multiple",
         "skip": "Ignorer",
         "next": "Suivant",
         "submit": "Envoyer",
@@ -3209,8 +3209,8 @@
     "conversationContextBar": {
       "folderTitle": "Dossier de travail",
       "branchTitle": "Branche de travail",
-      "searchFolder": "Rechercher un dossier…",
-      "searchBranch": "Rechercher une branche…",
+      "searchFolder": "Rechercher un dossier...",
+      "searchBranch": "Rechercher une branche...",
       "noFolders": "Aucun dossier",
       "noBranches": "Aucune branche",
       "noBranch": "(aucune branche)",
@@ -3220,10 +3220,10 @@
       "merge": "Fusionner",
       "toasts": {
         "folderChanged": "Basculé vers {name}",
-        "openFolderFailed": "Échec de l’ouverture du dossier",
+        "openFolderFailed": "Échec de l'ouverture du dossier",
         "switchedToChatMode": "Basculé en mode discussion",
-        "openStashFailed": "Échec de l’ouverture de la fenêtre de remisage",
-        "openMergeFailed": "Échec de l’ouverture de la fenêtre de fusion"
+        "openStashFailed": "Échec de l'ouverture de la fenêtre de remisage",
+        "openMergeFailed": "Échec de l'ouverture de la fenêtre de fusion"
       }
     },
     "cloneDialog": {
@@ -3920,8 +3920,8 @@
     "empty": "Aucune connexion distante",
     "searchPlaceholder": "Rechercher un espace de travail distant",
     "orderFailed": "Échec de l’enregistrement de l’ordre des espaces de travail distants",
-    "dragSort": "Faire glisser pour réordonner",
-    "dragSortConnection": "Faire glisser pour réordonner {name}",
+    "dragSort": "Glisser pour trier",
+    "dragSortConnection": "Glisser pour trier {name}",
     "newConnection": "Nouvelle connexion",
     "loading": "Chargement",
     "loadingConnection": "Chargement de la connexion distante",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -475,7 +475,7 @@
     },
     "toasts": {
       "loadFailed": "Échec du chargement de la Skill",
-      "openFolderFailed": "Échec de l’ouverture du dossier",
+      "openFolderFailed": "Échec de l'ouverture du dossier",
       "noSkillDirectory": "Aucun répertoire de Skills disponible pour l’agent actuel",
       "nameRequired": "Le nom de la Skill ne peut pas être vide",
       "updated": "Skill mise à jour",
@@ -1057,7 +1057,7 @@
     "selectModelProvider": "Sélectionner un fournisseur de modèle",
     "noModelProviderAvailable": "Aucun fournisseur de modèle configuré pour cet agent. Allez dans les paramètres des fournisseurs de modèle pour en ajouter un.",
     "claude": {
-      "authMode": "Mode d'authentification",
+      "authMode": "Mode d’authentification",
       "officialSubscription": "Abonnement officiel",
       "officialSubscriptionHint": "Utiliser l'abonnement officiel Anthropic, pas de clé API requise.",
       "mainModel": "Modèle principal",
@@ -1489,7 +1489,7 @@
         "importedAndUpdated": "{imported, plural, one {# session} other {# sessions}} importée(s), {updated, plural, one {# titre} other {# titres}} mis à jour, {skipped} ignorée(s)",
         "updatedTitles": "{updated, plural, one {# titre} other {# titres}} mis à jour, {skipped} ignorée(s)",
         "noNewSessionsFound": "Aucune nouvelle session trouvée ({skipped} ignorée(s))",
-        "importFailed": "Échec de l’import : {message}",
+        "importFailed": "Échec de l'import : {message}",
         "reviewCompleted": "{count, plural, one {# session en revue} other {# sessions en revue}} marquée(s) comme terminée(s)",
         "completeReviewFailed": "Échec de la finalisation des sessions en revue : {message}",
         "folderOpened": "Dossier {name} ouvert",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -75,17 +75,17 @@
       "sectionDescription": "Choisissez une palette pour les accents, les boutons et les surlignages.",
       "current": "Couleur actuelle : {color}",
       "options": {
-        "neutral": "Neutral",
+        "neutral": "Neutre",
         "zinc": "Zinc",
-        "slate": "Slate",
-        "stone": "Stone",
-        "gray": "Gray",
-        "red": "Red",
+        "slate": "Ardoise",
+        "stone": "Pierre",
+        "gray": "Gris",
+        "red": "Rouge",
         "rose": "Rose",
         "orange": "Orange",
-        "green": "Green",
-        "blue": "Blue",
-        "yellow": "Yellow",
+        "green": "Vert",
+        "blue": "Bleu",
+        "yellow": "Jaune",
         "violet": "Violet"
       }
     },
@@ -575,7 +575,7 @@
       "configJson": "Configuration MCP (JSON)",
       "draftTitle": "Nouveau MCP",
       "draftDescription": "Renseignez un Server ID et une configuration pour créer un serveur MCP local.",
-      "serverIdLabel": "Server ID",
+      "serverIdLabel": "ID du serveur",
       "serverIdPlaceholder": "Server ID (ex. my-mcp)",
       "typeHint": "Types pris en charge : stdio, http (alias : streamable-http, streamableHttp), sse. env n'est utilisé que par stdio ; pour les MCP distants, utilisez headers pour transporter les jetons d'authentification.",
       "envOnRemoteWarning": "env détecté sur un MCP distant. Seul stdio utilise env ; les MCP distants transportent les jetons d'authentification via headers, donc env sera ignoré à l'enregistrement."
@@ -678,7 +678,7 @@
       "saveCodeBuddyConfig": "Enregistrer la configuration CodeBuddy",
       "saveKimiCodeConfig": "Enregistrer la configuration de Kimi Code",
       "customInstall": "Installation personnalisée",
-      "saveKimiCodeRawConfig": "Save config.toml",
+      "saveKimiCodeRawConfig": "Enregistrer config.toml",
       "diagnose": "Diagnostiquer"
     },
     "status": {
@@ -758,7 +758,7 @@
       "permissionsDescription": "Éditeur visuel des règles de permissions de la CLI (cli-config.json). Les règles autorisées s'exécutent sans confirmation ; les règles refusées sont toujours bloquées.",
       "permissionModeLabel": "Mode d'autorisation",
       "permissionModeDefault": "Demander avant d'exécuter (par défaut)",
-      "permissionModeForce": "Run Everything (--force)",
+      "permissionModeForce": "Tout exécuter (--force)",
       "permissionModeHint": "Run Everything lance les sessions avec --force : tous les appels d'outils sont autorisés automatiquement sauf les règles de refus, sans confirmation (une politique d'organisation peut le limiter aux règles d'autorisation). S'applique aux nouvelles sessions.",
       "optionDefault": "Défaut (non défini)",
       "sandboxLabel": "Bac à sable",
@@ -2334,8 +2334,8 @@
         "newFile": "Nouveau fichier",
         "newDirectory": "Nouveau répertoire",
         "description": "Entrez un nom pour le nouveau {kind}.",
-        "placeholderFile": "file-name.ext",
-        "placeholderDirectory": "folder-name"
+        "placeholderFile": "nom-du-fichier.ext",
+        "placeholderDirectory": "nom-du-dossier"
       },
       "renameDialog": {
         "renameDirectory": "Renommer le dossier",
@@ -2525,8 +2525,8 @@
           "connectingDescription": "Établissement de la connexion",
           "loadingSelectorsTitle": "Chargement des sélecteurs de {agent}",
           "loadingSelectorsDescription": "Récupération des options de mode et de configuration de session",
-          "initSessionTitle": "Initializing {agent} session",
-          "initSessionDescription": "Creating session and loading configuration"
+          "initSessionTitle": "Initialisation de la session {agent}",
+          "initSessionDescription": "Création de la session et chargement de la configuration"
         },
         "errors": {
           "connectionFailed": "Échec de la connexion",
@@ -2880,7 +2880,7 @@
       },
       "delegation": {
         "subAgentRunning": "Sous-agent en cours…",
-        "noDetail": "No detail available yet.",
+        "noDetail": "Aucun détail disponible pour le moment.",
         "unknownAgent": "Sous-agent",
         "openDetail": "Voir la conversation",
         "detailTitle": "Conversation du sous-agent",
@@ -3117,7 +3117,7 @@
         "other": "Autre",
         "otherPlaceholder": "Saisissez votre réponse…",
         "singleSelect": "Unique",
-        "multiSelect": "Multiple",
+        "multiSelect": "Choix multiple",
         "skip": "Ignorer",
         "next": "Suivant",
         "submit": "Envoyer",
@@ -3209,21 +3209,21 @@
     "conversationContextBar": {
       "folderTitle": "Dossier de travail",
       "branchTitle": "Branche de travail",
-      "searchFolder": "Search folder...",
-      "searchBranch": "Search branch...",
-      "noFolders": "No folders",
-      "noBranches": "No branches",
-      "noBranch": "(no branch)",
+      "searchFolder": "Rechercher un dossier…",
+      "searchBranch": "Rechercher une branche…",
+      "noFolders": "Aucun dossier",
+      "noBranches": "Aucune branche",
+      "noBranch": "(aucune branche)",
       "chatModeLabel": "Mode chat",
-      "commit": "Commit",
-      "push": "Push",
-      "merge": "Merge",
+      "commit": "Valider",
+      "push": "Pousser",
+      "merge": "Fusionner",
       "toasts": {
-        "folderChanged": "Switched to {name}",
-        "openFolderFailed": "Failed to open folder",
+        "folderChanged": "Basculé vers {name}",
+        "openFolderFailed": "Échec de l’ouverture du dossier",
         "switchedToChatMode": "Basculé en mode discussion",
-        "openStashFailed": "Failed to open stash window",
-        "openMergeFailed": "Failed to open merge window"
+        "openStashFailed": "Échec de l’ouverture de la fenêtre de remisage",
+        "openMergeFailed": "Échec de l’ouverture de la fenêtre de fusion"
       }
     },
     "cloneDialog": {
@@ -3285,7 +3285,7 @@
     "createDialog": {
       "title": "Créer un projet",
       "projectName": "Nom du projet",
-      "projectNamePlaceholder": "my-app",
+      "projectNamePlaceholder": "mon-app",
       "frameworkTemplate": "Modèle de framework",
       "packageManager": "Gestionnaire de paquets",
       "saveDirectory": "Répertoire de sauvegarde",
@@ -3617,7 +3617,7 @@
       "quality": "Qualité et tests",
       "debugging": "Débogage",
       "review": "Révision et intégration",
-      "meta": "Meta"
+      "meta": "Méta"
     },
     "states": {
       "not_linked": "Non activé",
@@ -3914,36 +3914,36 @@
     }
   },
   "RemoteWorkspace": {
-    "openRemoteWorkspace": "Open remote workspace",
-    "manage": "Manage remote workspace",
-    "manageTitle": "Remote Workspace connections",
-    "empty": "No remote connections",
-    "searchPlaceholder": "Search remote workspaces",
-    "orderFailed": "Failed to save remote workspace order",
-    "dragSort": "Drag to sort",
-    "dragSortConnection": "Drag to sort {name}",
-    "newConnection": "New connection",
-    "loading": "Loading",
-    "loadingConnection": "Loading remote connection",
-    "name": "Name",
-    "baseUrl": "Service URL",
-    "token": "Access token",
-    "save": "Save",
-    "delete": "Delete",
+    "openRemoteWorkspace": "Ouvrir l’espace de travail distant",
+    "manage": "Gérer l’espace de travail distant",
+    "manageTitle": "Connexions à l’espace de travail distant",
+    "empty": "Aucune connexion distante",
+    "searchPlaceholder": "Rechercher un espace de travail distant",
+    "orderFailed": "Échec de l’enregistrement de l’ordre des espaces de travail distants",
+    "dragSort": "Faire glisser pour réordonner",
+    "dragSortConnection": "Faire glisser pour réordonner {name}",
+    "newConnection": "Nouvelle connexion",
+    "loading": "Chargement",
+    "loadingConnection": "Chargement de la connexion distante",
+    "name": "Nom",
+    "baseUrl": "URL du service",
+    "token": "Jeton d’accès",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
     "confirmDelete": {
-      "title": "Delete remote connection?",
-      "message": "This will remove \"{name}\" from this device. This action cannot be undone.",
-      "cancel": "Cancel",
-      "confirm": "Delete"
+      "title": "Supprimer la connexion distante ?",
+      "message": "Cela retirera « {name} » de cet appareil. Cette action est irréversible.",
+      "cancel": "Annuler",
+      "confirm": "Supprimer"
     },
-    "saved": "Remote connection saved.",
-    "deleted": "Remote connection deleted.",
-    "loadFailed": "Failed to load remote connections",
-    "saveFailed": "Failed to save remote connection",
-    "deleteFailed": "Failed to delete remote connection",
-    "openFailed": "Failed to open remote workspace",
-    "connectionLoadFailed": "Failed to load remote connection: {message}",
-    "connectionExpired": "Remote connection \"{name}\" is expired. Update its token and reload this window."
+    "saved": "Connexion distante enregistrée.",
+    "deleted": "Connexion distante supprimée.",
+    "loadFailed": "Échec du chargement des connexions distantes",
+    "saveFailed": "Échec de l’enregistrement de la connexion distante",
+    "deleteFailed": "Échec de la suppression de la connexion distante",
+    "openFailed": "Échec de l’ouverture de l’espace de travail distant",
+    "connectionLoadFailed": "Échec du chargement de la connexion distante : {message}",
+    "connectionExpired": "La connexion distante « {name} » a expiré. Mettez son jeton à jour, puis rechargez cette fenêtre."
   },
   "ServerFileBrowser": {
     "title": "Sélectionner un fichier serveur",
@@ -4226,7 +4226,7 @@
     "actionLaunchSession": "Lancer une session",
     "actionEnqueueTask": "Mettre une tâche en file",
     "actionEnqueueTaskHint": "Chaque déclenchement ajoute une tâche à faire, nommée d'après cette automatisation, aux tâches à faire du dossier ; le moteur de tâches l'exécute selon les réglages du tableau.",
-    "sectionPrompt": "Prompt",
+    "sectionPrompt": "Instruction",
     "nextIn": "Prochaine dans {rel}",
     "manual": "Manuel",
     "schedEveryMinutes": "Toutes les {n} minutes",
@@ -4454,7 +4454,7 @@
     "settingsInitCommandPlaceholder": "pnpm install",
     "settingsTabGeneral": "Général",
     "settingsTabWorkflow": "Flux",
-    "settingsTabPrompts": "Prompts",
+    "settingsTabPrompts": "Instructions",
     "settingsPromptsIntro": "Chaque étape envoie déjà son propre prompt intégré : la tâche, les règles du worktree et, pour la fusion, les étapes git exactes. Ce que vous ajoutez ici est apposé à la fin comme instructions supplémentaires : cela affine ces textes intégrés, sans jamais les remplacer.",
     "settingsPromptStageAll": "Toutes les phases",
     "settingsPromptPlaceholderAll": "ex. Respecte les conventions d’AGENTS.md ; limite le résumé final à deux phrases",


### PR DESCRIPTION
## Summary

The French locale is structurally complete (4079/4079 keys, none missing), but 61 values were left in English and surface in the UI.

The largest gap is the **Remote Workspace** module: none of its 28 strings had been translated, including its dialogs and error toasts.

## Changes

- **RemoteWorkspace (28 strings)** — the entire module was untranslated
- **Conversation context bar (12)** — toasts and empty states (`No branches`, `Failed to open folder`, `Switched to {name}`, …)
- **Git vocabulary consistency (3)** — `commit`, `merge` and `push` in the context bar kept their English form, while the rest of the file already uses *Valider*, *Fusionner*, *Pousser*
- **Prompt terminology (2)** — `Automations.sectionPrompt` read "Prompt" while `Automations.prompt` already reads "Instruction"
- **Agent connection screen (2)** — `Initializing {agent} session`, `Creating session and loading configuration`
- **Theme colours (8)** and **misc (6)** — `Server ID`, `Save config.toml`, `Run Everything (--force)`, placeholders

## Deliberately left in English

Proper nouns (Git, HEAD, MCP, Stdio, Lark, shadcn), git CLI flags (`--hard`, `--soft`, `--keep`), `SKILL.md` templates (read by agents, which work in English), input placeholders (`ghp_xxx`, `pnpm install`, URLs), and words identical in French (Agent, Interface, Terminal, Configuration, …).

The project's existing glossary is preserved: **`tokens`** and **`Skill`** are kept untranslated, matching "Consommation de tokens" and "Sélectionnez une Skill" already present in the file.

## Verification

- Each key was checked against its expected English value before being edited — nothing was applied blindly
- `JSON.stringify(JSON.parse(fr.json), null, 2)` reproduces the original file byte-for-byte, so the diff carries no reformatting noise
- Key count unchanged: **4079 before, 4079 after**
- Only `src/i18n/messages/fr.json` is touched

Happy to adjust any wording if a different French term is preferred.
