### PR TITLE
feat(chat): 工具组在命令运行期间自动展开，执行结束后自动收起

### DIFF
--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps, ReactNode } from "react"
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import { useTranslations } from "next-intl"
+import { AUTO_CLOSE_DELAY_MS } from "@/lib/auto-collapse-timing"
 import {
   Collapsible,
   CollapsibleContent,
@@ -57,7 +58,6 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
   expandable?: boolean
 }
 
-const AUTO_CLOSE_DELAY = 1000
 const MS_IN_S = 1000
 
 export const Reasoning = memo(
@@ -123,7 +123,7 @@ export const Reasoning = memo(
         const timer = setTimeout(() => {
           setIsOpen(false)
           setHasAutoClosed(true)
-        }, AUTO_CLOSE_DELAY)
+        }, AUTO_CLOSE_DELAY_MS)
 
         return () => clearTimeout(timer)
       }

--- a/src/components/message/content-parts-renderer.tsx
+++ b/src/components/message/content-parts-renderer.tsx
@@ -1,5 +1,14 @@
-import { memo, useMemo, useState, type ReactNode } from "react"
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
 import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+import { AUTO_CLOSE_DELAY_MS } from "@/lib/auto-collapse-timing"
 import {
   classifyToolKind,
   TOOL_KIND_ORDER,
@@ -2234,11 +2243,22 @@ const TextPart = memo(function TextPart({
 
 const ToolCallPart = memo(function ToolCallPart({
   part,
+  onUserOpenChange,
 }: {
   part: Extract<AdaptedContentPart, { type: "tool-call" }>
+  /** Reports user-initiated card toggles so an outer tool-group can veto
+   *  its own automatic collapse while the user is reading a card. */
+  onUserOpenChange?: (toolCallId: string, open: boolean) => void
 }) {
   const t = useTranslations("Folder.chat.contentParts")
   const [manualOpen, setManualOpen] = useState(false)
+  const handleUserToggle = useCallback(
+    (next: boolean) => {
+      setManualOpen(next)
+      onUserOpenChange?.(part.toolCallId, next)
+    },
+    [part.toolCallId, onUserOpenChange]
+  )
   const normalizedToolName = useMemo(
     () => normalizeToolName(part.toolName),
     [part.toolName]
@@ -2741,10 +2761,10 @@ const ToolCallPart = memo(function ToolCallPart({
     )
   }
 
-  const open = (isRunning && (isCommandTool || hasLiveOutput)) || manualOpen
+  const open = manualOpen
 
   return (
-    <Tool open={open} onOpenChange={setManualOpen}>
+    <Tool open={open} onOpenChange={handleUserToggle}>
       <ToolHeader
         type="dynamic-tool"
         state={part.state}
@@ -2896,7 +2916,134 @@ const ToolGroupPart = memo(function ToolGroupPart({
   part: Extract<AdaptedContentPart, { type: "tool-group" }>
 }) {
   const t = useTranslations("Folder.chat.contentParts.toolGroup")
-  const [open, setOpen] = useState(false)
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null)
+  const [autoOpen, setAutoOpen] = useState(part.isStreaming)
+  const [childOpenIds, setChildOpenIds] = useState<Set<string>>(() => new Set())
+  const pendingCloseTimerRef = useRef<number | null>(null)
+  const focusCloseCleanupRef = useRef<(() => void) | null>(null)
+  const groupRef = useRef<HTMLDivElement | null>(null)
+
+  // Adjust the auto-open state during render when streaming resumes on the
+  // same mounted group. This is the React-recommended "adjust state when a
+  // prop changes" pattern and avoids a synchronous setState inside an effect.
+  if (manualOpen === null && part.isStreaming && !autoOpen) {
+    setAutoOpen(true)
+  }
+
+  const clearPendingCloseTimer = useCallback(() => {
+    if (pendingCloseTimerRef.current !== null) {
+      window.clearTimeout(pendingCloseTimerRef.current)
+      pendingCloseTimerRef.current = null
+    }
+  }, [])
+
+  const clearFocusCloseListener = useCallback(() => {
+    focusCloseCleanupRef.current?.()
+    focusCloseCleanupRef.current = null
+  }, [])
+
+  useEffect(() => {
+    if (manualOpen !== null) {
+      clearPendingCloseTimer()
+      clearFocusCloseListener()
+      return
+    }
+
+    if (part.isStreaming) {
+      clearPendingCloseTimer()
+      clearFocusCloseListener()
+      return
+    }
+
+    if (!autoOpen) return
+
+    clearPendingCloseTimer()
+    clearFocusCloseListener()
+    pendingCloseTimerRef.current = window.setTimeout(() => {
+      pendingCloseTimerRef.current = null
+
+      // The user is reading a child card. Defer the automatic collapse until
+      // every manually opened card is closed again.
+      if (childOpenIds.size > 0) return
+
+      // Don't unmount content that still owns keyboard focus.
+      const root = groupRef.current
+      if (root?.contains(document.activeElement)) {
+        const onFocusOut = (event: FocusEvent) => {
+          const next = event.relatedTarget as Node | null
+          if (next && root.contains(next)) return
+          clearFocusCloseListener()
+          setAutoOpen(false)
+        }
+        root.addEventListener("focusout", onFocusOut)
+        focusCloseCleanupRef.current = () =>
+          root.removeEventListener("focusout", onFocusOut)
+        return
+      }
+
+      setAutoOpen(false)
+    }, AUTO_CLOSE_DELAY_MS)
+
+    return () => {
+      clearPendingCloseTimer()
+      clearFocusCloseListener()
+    }
+  }, [
+    part.isStreaming,
+    autoOpen,
+    manualOpen,
+    childOpenIds,
+    clearPendingCloseTimer,
+    clearFocusCloseListener,
+  ])
+
+  // Clean up timers/listeners even when the last effect run took the
+  // `manualOpen !== null` branch (which intentionally returns no cleanup).
+  useEffect(() => {
+    return () => {
+      if (pendingCloseTimerRef.current !== null) {
+        window.clearTimeout(pendingCloseTimerRef.current)
+      }
+      focusCloseCleanupRef.current?.()
+    }
+  }, [])
+
+  const handleChildUserToggle = useCallback(
+    (toolCallId: string, nextOpen: boolean) => {
+      setChildOpenIds((prev) => {
+        const next = new Set(prev)
+        if (nextOpen) next.add(toolCallId)
+        else next.delete(toolCallId)
+        return next
+      })
+    },
+    []
+  )
+
+  const handleUserToggle = useCallback(
+    (nextOpen: boolean) => {
+      clearPendingCloseTimer()
+      clearFocusCloseListener()
+
+      // Clicking the chip of an automatically open running group pins it
+      // instead of closing it; a second click performs the normal toggle.
+      if (manualOpen === null && part.isStreaming && nextOpen === false) {
+        setManualOpen(true)
+        return
+      }
+
+      setManualOpen(nextOpen)
+      if (!nextOpen) setChildOpenIds(new Set())
+    },
+    [
+      manualOpen,
+      part.isStreaming,
+      clearPendingCloseTimer,
+      clearFocusCloseListener,
+    ]
+  )
+
+  const visibleOpen = manualOpen ?? autoOpen
 
   const { phrases, errorPhrase } = useMemo(() => {
     const counts = TOOL_KIND_ORDER.reduce(
@@ -2932,7 +3079,12 @@ const ToolGroupPart = memo(function ToolGroupPart({
   const titleText = phrases.join(joiner)
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="w-full">
+    <Collapsible
+      ref={groupRef}
+      open={visibleOpen}
+      onOpenChange={handleUserToggle}
+      className="w-full"
+    >
       <CollapsibleTrigger
         className={cn(
           "group inline-flex max-w-full items-center gap-1.5 rounded-full bg-muted/60 px-3.5 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground ws-msg-chip"
@@ -2942,7 +3094,7 @@ const ToolGroupPart = memo(function ToolGroupPart({
           aria-hidden="true"
           className={cn(
             "size-3 shrink-0 opacity-60 transition-transform",
-            open && "rotate-90"
+            visibleOpen && "rotate-90"
           )}
         />
         <span className="min-w-0 truncate">
@@ -2974,6 +3126,7 @@ const ToolGroupPart = memo(function ToolGroupPart({
             <ToolCallPart
               key={`grouped-tc-${item.toolCallId ?? idx}-${idx}`}
               part={item}
+              onUserOpenChange={handleChildUserToggle}
             />
           ))}
         </div>

--- a/src/components/message/tool-group-interaction.test.tsx
+++ b/src/components/message/tool-group-interaction.test.tsx
@@ -1,0 +1,279 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { NextIntlClientProvider } from "next-intl"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+import { AUTO_CLOSE_DELAY_MS } from "@/lib/auto-collapse-timing"
+import enMessages from "@/i18n/messages/en.json"
+
+vi.mock("@/components/ai-elements/shimmer", () => ({
+  Shimmer: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}))
+
+import { ContentPartsRenderer } from "./content-parts-renderer"
+
+type CommandState = "input-available" | "output-available"
+type ToolCallPart = Extract<AdaptedContentPart, { type: "tool-call" }>
+
+function commandPart(
+  state: CommandState,
+  output: string | null = null
+): ToolCallPart {
+  return {
+    type: "tool-call",
+    toolCallId: "call-1",
+    toolName: "bash",
+    input: "echo hi",
+    state,
+    output,
+  }
+}
+
+function groupPart(
+  isStreaming: boolean,
+  items: ToolCallPart[]
+): AdaptedContentPart {
+  return { type: "tool-group", items, isStreaming }
+}
+
+function Harness({
+  parts,
+}: {
+  parts: AdaptedContentPart | AdaptedContentPart[]
+}) {
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <ContentPartsRenderer
+        parts={Array.isArray(parts) ? parts : [parts]}
+        role="assistant"
+      />
+    </NextIntlClientProvider>
+  )
+}
+
+function renderParts(parts: AdaptedContentPart | AdaptedContentPart[]) {
+  return render(<Harness parts={parts} />)
+}
+
+function groupTrigger() {
+  return screen.getByRole("button", { name: /Ran 1 command/ })
+}
+
+function commandTrigger() {
+  return screen.getByRole("button", { name: /echo hi/ })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("tool-group auto-expand", () => {
+  it("expands a streaming group while keeping command cards collapsed", () => {
+    renderParts(groupPart(true, [commandPart("input-available")]))
+
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+    expect(commandTrigger()).toHaveAttribute("data-state", "closed")
+    expect(screen.queryByText(/\$ echo hi/)).not.toBeInTheDocument()
+  })
+
+  it("keeps a non-streaming group collapsed by default", () => {
+    renderParts(groupPart(false, [commandPart("output-available", "hi")]))
+
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+    expect(
+      screen.queryByRole("button", { name: /echo hi/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("collapses one second after the last item settles", () => {
+    const view = renderParts(groupPart(true, [commandPart("input-available")]))
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "hi")])}
+      />
+    )
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS - 1)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+    expect(
+      screen.queryByRole("button", { name: /echo hi/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("cancels the pending collapse when streaming resumes", () => {
+    const view = renderParts(groupPart(true, [commandPart("input-available")]))
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "hi")])}
+      />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS / 2)
+    })
+
+    view.rerender(
+      <Harness parts={groupPart(true, [commandPart("input-available")])} />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS * 2)
+    })
+
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+  })
+
+  it("auto transitions never pollute the manual state", () => {
+    const view = renderParts(groupPart(true, [commandPart("input-available")]))
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "hi")])}
+      />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+
+    view.rerender(
+      <Harness parts={groupPart(true, [commandPart("input-available")])} />
+    )
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+  })
+})
+
+describe("tool-group manual controls", () => {
+  it("pins on the first click and closes on the second", () => {
+    const view = renderParts(groupPart(true, [commandPart("input-available")]))
+    const trigger = groupTrigger()
+
+    fireEvent.click(trigger)
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+
+    fireEvent.click(groupTrigger())
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "hi")])}
+      />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS)
+    })
+    view.rerender(
+      <Harness parts={groupPart(true, [commandPart("input-available")])} />
+    )
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+  })
+
+  it("keeps a manually opened historical group open", () => {
+    const view = renderParts(
+      groupPart(false, [commandPart("output-available", "hi")])
+    )
+
+    fireEvent.click(groupTrigger())
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "bye")])}
+      />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+  })
+})
+
+describe("tool-group child veto and focus", () => {
+  it("defers auto-collapse while a child card is open", () => {
+    const view = renderParts(groupPart(true, [commandPart("input-available")]))
+
+    fireEvent.click(commandTrigger())
+    expect(screen.getByText(/\$ echo hi/)).toBeInTheDocument()
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "hi")])}
+      />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+
+    fireEvent.click(commandTrigger())
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+  })
+
+  it("keeps the group open while focus is inside it", () => {
+    const view = renderParts(groupPart(true, [commandPart("input-available")]))
+    const child = commandTrigger()
+    child.focus()
+
+    view.rerender(
+      <Harness
+        parts={groupPart(false, [commandPart("output-available", "hi")])}
+      />
+    )
+    act(() => {
+      vi.advanceTimersByTime(AUTO_CLOSE_DELAY_MS)
+    })
+    expect(groupTrigger()).toHaveAttribute("data-state", "open")
+
+    fireEvent.focusOut(child, { relatedTarget: document.body })
+    expect(groupTrigger()).toHaveAttribute("data-state", "closed")
+  })
+})
+
+describe("non-command cards inside a tool-group", () => {
+  it("keep read and edit cards collapsed even while running", () => {
+    const readPart: ToolCallPart = {
+      type: "tool-call",
+      toolCallId: "read-1",
+      toolName: "read",
+      input: JSON.stringify({ file_path: "a.txt" }),
+      state: "input-available",
+      output: null,
+    }
+    const editPart: ToolCallPart = {
+      type: "tool-call",
+      toolCallId: "edit-1",
+      toolName: "edit",
+      input: JSON.stringify({ file_path: "b.txt" }),
+      state: "input-available",
+      output: null,
+    }
+
+    renderParts(groupPart(true, [readPart, editPart]))
+
+    expect(screen.getByRole("button", { name: /Read a\.txt/ })).toHaveAttribute(
+      "data-state",
+      "closed"
+    )
+    expect(screen.getByRole("button", { name: /Edit b\.txt/ })).toHaveAttribute(
+      "data-state",
+      "closed"
+    )
+  })
+})

--- a/src/lib/auto-collapse-timing.ts
+++ b/src/lib/auto-collapse-timing.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared delay for automatically collapsing streaming content.
+ *
+ * Used by the reasoning block and the tool-group so the two surfaces stay in
+ * sync. Keep the value here rather than duplicating it in each component.
+ */
+export const AUTO_CLOSE_DELAY_MS = 1000


### PR DESCRIPTION
## 概述

本 PR 调整助手消息中工具组的默认展示方式：

- Agent 开始运行命令后，对应的工具组自动展开，用户可以直接看到
  正在执行哪些操作。
- 组内全部命令执行完成后，工具组延迟 1 秒自动收起，最终对话记录
  依然保持紧凑。
- 历史消息中的工具组仍然默认折叠，不受影响。
- 组内命令卡片继续默认折叠，用户需要查看命令详情时再点击展开。

## 动机

目前工具组默认始终是折叠的。Agent 在执行命令的过程中，界面上只能
看到一个折叠的汇总 chip，用户无法直接了解当前正在运行什么、已经
运行了多少命令，必须手动展开工具组才能看到内容。

对于较长的任务，Agent 可能会连续运行多个命令，工具组甚至会反复
创建和切换。一直保持折叠会让执行过程变成黑盒，降低用户对 Agent
工作进度的感知。

本次改动的目标是：

- 在执行期间自动显示当前活动，让用户一眼看到进度；
- 执行结束后自动收起，避免历史会话中留下大量展开的临时信息；
- 不改变用户已有的「命令细节按需查看」的使用习惯。

## 行为变化

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| 工具组内有命令正在运行 | 默认折叠，用户看不到执行内容 | 自动展开 |
| 工具组内所有命令执行完成 | 保持用户之前手动设置的状态 | 若是自动展开，则延迟 1 秒收起 |
| 历史消息中的工具组 | 默认折叠 | 默认折叠，不变 |
| 组内命令卡片 | 默认折叠，点击查看详情 | 默认折叠，点击查看详情 |
| 思考块 | 流式时展开，结束后 1 秒收起 | 不变 |

## 实现说明

- 为 `ToolGroupPart` 增加受控状态机，区分用户手动状态和自动状态：
  - `manualOpen` 记录用户主动展开或收起；
  - `autoOpen` 跟随工具组的运行状态；
  - 手动操作始终优先。
- 工具组存在未完成命令时自动展开；全部完成后通过 1000ms 定时器
  自动收起。
- 延迟收起期间如果命令重新开始运行，取消本次收起。
- 增加交互保护：
  - 运行中的自动展开工具组，第一次点击 chip 可以「钉住」它，
    第二次点击才关闭；
  - 用户正在查看某条命令卡片时，外层不会自动收起；
  - 焦点仍在工具组内时，不会自动收起，避免内容卸载造成焦点丢失。
- 抽取 `AUTO_CLOSE_DELAY_MS = 1000`，由思考块与工具组共用，
  保持自动收起节奏一致。
- 组内命令卡片继续由手动操作控制展开，点开后仍可看到实时终端输出。

## 边界情况

- 历史消息中的工具组保持默认折叠。
- 页面刷新或组件重挂载后，恢复到该状态应有的默认值。
- 用户手动展开或收起后，不再被自动逻辑覆盖。
- 命令执行期间工具组会保持展开，不会因为单条命令完成而提前收起。
- 编辑、读取、搜索等非命令工具卡片的行为不变。

## 测试

新增 `src/components/message/tool-group-interaction.test.tsx`，覆盖以下场景：

- 工具组运行时自动展开；
- 所有命令结束后延迟 1 秒自动收起；
- 延迟窗口内恢复运行会取消收起；
- 自动展开/收起不会污染用户手动状态；
- 手动钉住与关闭；
- 用户查看子卡片时外层不自动收起；
- 焦点在工具组内时不自动收起；
- 命令卡片保持默认折叠；
- read / edit 卡片行为回归。

验证结果：

- [x] `pnpm test`
- [x] `pnpm eslint <changed files>`
- [x] `pnpm exec tsc --noEmit`
- [x] 已通过独立数据目录的本地桌面实例进行人工预览

## 文件变更

- `src/components/message/content-parts-renderer.tsx`
- `src/components/ai-elements/reasoning.tsx`
- `src/lib/auto-collapse-timing.ts`（新增）
- `src/components/message/tool-group-interaction.test.tsx`（新增）

## 影响范围

仅前端消息渲染与交互逻辑，不涉及 Rust 后端、数据库结构、i18n
文案或事件协议。

## 关联 Issue

无。
