### PR TITLE
fix(grok): send images as native ACP blocks

### DIFF
--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -2523,20 +2523,34 @@ async fn apply_and_emit_session_config_options(
     emit_session_config_options_values(state, emitter, agent_type, updated).await;
 }
 
+/// Grok's initialize still advertises `image: false` — the coding model
+/// cannot see pixels. Native ACP `image` blocks nevertheless run its
+/// image-describe sidecar (verified against grok 1.0.2). An image-mime
+/// `resource` blob does not: grok dumps it as
+/// `<file_contents type="binary">` and the model only gets a path.
+/// Advertise `image: true` so the composer sends Image blocks.
+fn effective_prompt_capabilities(
+    agent_type: AgentType,
+    capabilities: &sacp::schema::PromptCapabilities,
+) -> PromptCapabilitiesInfo {
+    PromptCapabilitiesInfo {
+        image: capabilities.image || agent_type == AgentType::Grok,
+        audio: capabilities.audio,
+        embedded_context: capabilities.embedded_context,
+    }
+}
+
 async fn emit_prompt_capabilities(
     state: &Arc<RwLock<SessionState>>,
     emitter: &EventEmitter,
     capabilities: &sacp::schema::PromptCapabilities,
+    agent_type: AgentType,
 ) {
     emit_with_state(
         state,
         emitter,
         AcpEvent::PromptCapabilities {
-            prompt_capabilities: PromptCapabilitiesInfo {
-                image: capabilities.image,
-                audio: capabilities.audio,
-                embedded_context: capabilities.embedded_context,
-            },
+            prompt_capabilities: effective_prompt_capabilities(agent_type, capabilities),
         },
     )
     .await;
@@ -3626,6 +3640,7 @@ async fn run_connection(
                 &state,
                 &emitter_clone,
                 &init_resp.agent_capabilities.prompt_capabilities,
+                agent_type,
             )
             .await;
 
@@ -5726,6 +5741,31 @@ async fn journal_turn_span(
     let _ = tokio::time::timeout(std::time::Duration::from_secs(2), ack).await;
 }
 
+/// Promote image-mime embedded resources to native Image blocks.
+///
+/// Codeg used to send Grok images as `resource` blobs because grok
+/// advertised `image:false`. That path never reaches grok's describe
+/// sidecar — see [`effective_prompt_capabilities`]. Queued drafts and
+/// work-task replays can still carry the old shape; lift them here.
+fn promote_grok_image_resources(blocks: Vec<PromptInputBlock>) -> Vec<PromptInputBlock> {
+    blocks
+        .into_iter()
+        .map(|block| match block {
+            PromptInputBlock::Resource {
+                uri,
+                mime_type: Some(mime),
+                text: None,
+                blob: Some(blob),
+            } if mime.starts_with("image/") && !blob.is_empty() => PromptInputBlock::Image {
+                data: blob,
+                mime_type: mime,
+                uri: Some(uri),
+            },
+            other => other,
+        })
+        .collect()
+}
+
 fn map_prompt_blocks(blocks: Vec<PromptInputBlock>) -> Vec<ContentBlock> {
     blocks
         .into_iter()
@@ -6518,6 +6558,14 @@ async fn run_conversation_loop<'a>(
                         .collect();
                     (crate::turn_timings::prompt_hash(&text), cursor_turn_ord)
                 });
+                // Grok: lift leftover image-mime resource blobs (queued drafts
+                // composed before we advertised image:true) into native Image
+                // blocks so its describe sidecar actually runs.
+                let blocks = if agent_type == AgentType::Grok {
+                    promote_grok_image_resources(blocks)
+                } else {
+                    blocks
+                };
                 let prompt_blocks = map_prompt_blocks(blocks);
                 if prompt_blocks.is_empty() {
                     // Defensive: the manager rejects empty prompts before the
@@ -8576,6 +8624,37 @@ fn map_grok_ext_notification(
                 images: None,
             })
         }
+        // A prompt image was accepted on the wire but dropped before the
+        // describe sidecar (too small, oversize, decode failure). Surface it
+        // so the user isn't left wondering why Grok "can't see" the shot.
+        "image_dropped" => {
+            let detail = update
+                .get("notes")
+                .and_then(|v| v.as_array())
+                .map(|notes| {
+                    notes
+                        .iter()
+                        .filter_map(|n| n.as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ")
+                })
+                .filter(|s| !s.is_empty())
+                .or_else(|| {
+                    update
+                        .get("reason")
+                        .or_else(|| update.get("message"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                })
+                .unwrap_or_else(|| "image was dropped before send".to_string());
+            Some(AcpEvent::Error {
+                message: format!("Image dropped: {detail}"),
+                agent_type: agent_type.to_string(),
+                code: None,
+                details: None,
+                terminal: false,
+            })
+        }
         // Compaction itself blew up (e.g. the summarizer model call failed) while
         // the turn still ended cleanly — surface a non-terminal error so the
         // result isn't a silent blank.
@@ -10498,6 +10577,85 @@ mod tests {
         assert!(matches!(
             map_grok_ext_notification(&raw, AgentType::Grok),
             Some(AcpEvent::ToolCall { .. })
+        ));
+    }
+
+    #[test]
+    fn map_grok_ext_notification_image_dropped_surfaces_error() {
+        let raw = UntypedMessage::new(
+            "_x.ai/session_notification",
+            serde_json::json!({
+                "sessionId": "s",
+                "update": {
+                    "sessionUpdate": "image_dropped",
+                    "notes": [
+                        "Image 1 was dropped before send: too small (1×1); images must be at least 8×8 pixels."
+                    ]
+                }
+            }),
+        )
+        .unwrap();
+        match map_grok_ext_notification(&raw, AgentType::Grok) {
+            Some(AcpEvent::Error {
+                message, terminal, ..
+            }) => {
+                assert!(
+                    message.contains("too small"),
+                    "error should carry grok's drop reason; got: {message}"
+                );
+                assert!(!terminal, "a dropped image must not kill the connection");
+            }
+            other => panic!("expected non-terminal Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn promote_grok_image_resources_lifts_image_blobs_only() {
+        let blocks = vec![
+            PromptInputBlock::Text {
+                text: "see this".into(),
+            },
+            PromptInputBlock::Resource {
+                uri: "clipboard://shot.png-abc".into(),
+                mime_type: Some("image/png".into()),
+                text: None,
+                blob: Some("aGk=".into()),
+            },
+            PromptInputBlock::Resource {
+                uri: "clipboard://notes.md".into(),
+                mime_type: Some("text/markdown".into()),
+                text: Some("hi".into()),
+                blob: None,
+            },
+            PromptInputBlock::Image {
+                data: "already".into(),
+                mime_type: "image/jpeg".into(),
+                uri: None,
+            },
+        ];
+        let out = promote_grok_image_resources(blocks);
+        assert!(matches!(&out[0], PromptInputBlock::Text { text } if text == "see this"));
+        assert!(
+            matches!(
+                &out[1],
+                PromptInputBlock::Image { data, mime_type, uri: Some(u) }
+                    if data == "aGk="
+                        && mime_type == "image/png"
+                        && u == "clipboard://shot.png-abc"
+            ),
+            "{:?}",
+            out[1]
+        );
+        assert!(matches!(
+            &out[2],
+            PromptInputBlock::Resource {
+                mime_type: Some(m),
+                ..
+            } if m == "text/markdown"
+        ));
+        assert!(matches!(
+            &out[3],
+            PromptInputBlock::Image { data, .. } if data == "already"
         ));
     }
 

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -2525,10 +2525,20 @@ async fn apply_and_emit_session_config_options(
 
 /// Grok's initialize still advertises `image: false` — the coding model
 /// cannot see pixels. Native ACP `image` blocks nevertheless run its
-/// image-describe sidecar (verified against grok 1.0.2). An image-mime
-/// `resource` blob does not: grok dumps it as
-/// `<file_contents type="binary">` and the model only gets a path.
+/// image-describe sidecar. An image-mime `resource` blob does not: grok dumps
+/// it as `<file_contents type="binary">` and the model only gets a path.
 /// Advertise `image: true` so the composer sends Image blocks.
+///
+/// Measured live against grok 1.0.0 (the version `registry.rs` pins) and 0.2.112:
+/// both accept a native `image` block and answer correctly about the pixels,
+/// while the same bytes as a resource blob make the model invent an answer. The
+/// advertisement has simply been wrong for as long as codeg has supported grok,
+/// so this is deliberately NOT version-gated, and it stays correct if grok ever
+/// starts advertising the truth (`image` is already true then).
+///
+/// This bit says only that grok takes image blocks AT ALL — it decodes just some
+/// formats, which is a per-mime question a single capability cannot answer, so
+/// [`normalize_grok_image_blocks`] settles that separately at dispatch.
 fn effective_prompt_capabilities(
     agent_type: AgentType,
     capabilities: &sacp::schema::PromptCapabilities,
@@ -4047,9 +4057,19 @@ async fn run_connection(
                                     .otherwise(async |dispatch| {
                                         // Historical replay: throwaway state,
                                         // mirroring the sibling closure above.
+                                        // An ext notification that raises an
+                                        // ALERT is skipped, though — a
+                                        // compaction failure or a dropped image
+                                        // recorded in a past session is not
+                                        // happening now, and that path also
+                                        // fires an OS notification. The typed
+                                        // closure above draws the same line by
+                                        // forwarding only AvailableCommands.
                                         let mut replay_cb_state =
                                             CodeBuddyLiveState::default();
-                                        maybe_emit_ext_notification(&st, &h, agent_type, dispatch, &mut replay_cb_state).await;
+                                        if !grok_ext_notification_is_alert(&dispatch, agent_type) {
+                                            maybe_emit_ext_notification(&st, &h, agent_type, dispatch, &mut replay_cb_state).await;
+                                        }
                                         Ok(())
                                     })
                                     .await;
@@ -5741,26 +5761,80 @@ async fn journal_turn_span(
     let _ = tokio::time::timeout(std::time::Duration::from_secs(2), ack).await;
 }
 
-/// Promote image-mime embedded resources to native Image blocks.
+/// The image mime types grok's normalizer actually decodes — verbatim the set
+/// its own clipboard reader accepts (`xai-grok-shared/src/clipboard.rs`), and
+/// the boundary between the two carriages in [`normalize_grok_image_blocks`].
 ///
-/// Codeg used to send Grok images as `resource` blobs because grok
-/// advertised `image:false`. That path never reaches grok's describe
-/// sidecar — see [`effective_prompt_capabilities`]. Queued drafts and
-/// work-task replays can still carry the old shape; lift them here.
-fn promote_grok_image_resources(blocks: Vec<PromptInputBlock>) -> Vec<PromptInputBlock> {
+/// Measured against grok 1.0.0: png / webp / bmp / tiff round-trip through the
+/// describe sidecar (jpeg is one of the two formats grok itself re-encodes to,
+/// gif rides the same table). `image/svg+xml` does NOT — its validator answers
+/// `unsupported or unrecognised image format` and the image never reaches the
+/// model. Deliberately an allow-list, not a `image/*` prefix test: a mime we
+/// have no evidence for keeps the resource carriage, which is where it already
+/// was, so a wrong guess here can never be a regression.
+fn grok_decodes_image_mime(mime: &str) -> bool {
+    matches!(
+        mime.trim().to_ascii_lowercase().as_str(),
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/bmp" | "image/tiff"
+    )
+}
+
+/// Whether a mime names an image at all — the outer guard on the demotion, so a
+/// malformed `Image` block carrying something else entirely is left untouched.
+/// Normalized exactly like [`grok_decodes_image_mime`]: if the two guards
+/// disagreed about the same string (`IMAGE/SVG+XML` reads as "not an image" to a
+/// case-sensitive test), an undecodable format would slip through as native.
+fn is_image_mime(mime: &str) -> bool {
+    mime.trim().to_ascii_lowercase().starts_with("image/")
+}
+
+/// Put every attached image on the carriage grok can actually read.
+///
+/// Two encodings carry the same bytes and grok treats them very differently:
+///
+/// * A native `Image` block runs its describe sidecar — the ONLY path where the
+///   model sees pixels (see [`effective_prompt_capabilities`]). But grok
+///   validates the format first and DROPS anything it cannot decode.
+/// * A `Resource` blob is saved into the session's `assets/` and announced to
+///   the model as a file path. No pixels, but for a text-shaped image (svg) the
+///   model can just read the source — measurably better than a drop.
+///
+/// So decodable images are promoted (queued drafts and work-task prompts
+/// composed before codeg advertised `image:true` still carry the old shape),
+/// and undecodable ones are demoted back — the composer only sees the single
+/// `image` capability bit and cannot make this call per mime.
+fn normalize_grok_image_blocks(blocks: Vec<PromptInputBlock>) -> Vec<PromptInputBlock> {
     blocks
         .into_iter()
-        .map(|block| match block {
+        .enumerate()
+        .map(|(index, block)| match block {
             PromptInputBlock::Resource {
                 uri,
                 mime_type: Some(mime),
                 text: None,
                 blob: Some(blob),
-            } if mime.starts_with("image/") && !blob.is_empty() => PromptInputBlock::Image {
+            } if grok_decodes_image_mime(&mime) && !blob.is_empty() => PromptInputBlock::Image {
                 data: blob,
                 mime_type: mime,
                 uri: Some(uri),
             },
+            PromptInputBlock::Image {
+                data,
+                mime_type,
+                uri,
+            } if is_image_mime(&mime_type)
+                && !grok_decodes_image_mime(&mime_type)
+                && !data.is_empty() =>
+            {
+                PromptInputBlock::Resource {
+                    // A pasted image has no path; its position in this prompt is
+                    // the stable identifier, same as the work-task engine's.
+                    uri: uri.unwrap_or_else(|| format!("clipboard://grok-image-{index}")),
+                    mime_type: Some(mime_type),
+                    text: None,
+                    blob: Some(data),
+                }
+            }
             other => other,
         })
         .collect()
@@ -6558,11 +6632,13 @@ async fn run_conversation_loop<'a>(
                         .collect();
                     (crate::turn_timings::prompt_hash(&text), cursor_turn_ord)
                 });
-                // Grok: lift leftover image-mime resource blobs (queued drafts
-                // composed before we advertised image:true) into native Image
-                // blocks so its describe sidecar actually runs.
+                // Grok: settle each image onto the carriage grok can read —
+                // decodable ones as native Image blocks (so its describe
+                // sidecar runs), the rest back as resource blobs. The last
+                // point that sees the blocks, so every producer (composer,
+                // queued draft, work task, delegation) is covered at once.
                 let blocks = if agent_type == AgentType::Grok {
-                    promote_grok_image_resources(blocks)
+                    normalize_grok_image_blocks(blocks)
                 } else {
                     blocks
                 };
@@ -8573,9 +8649,11 @@ fn grok_ext_event_id(params: &serde_json::Value) -> String {
         .unwrap_or_else(|| format!("grok-ext-{}", uuid::Uuid::new_v4().simple()))
 }
 
-/// Map grok's private context-compaction ext notifications into `AcpEvent`s.
+/// Map grok's private ext notifications — context compaction and dropped
+/// prompt images — into `AcpEvent`s.
 ///
-/// grok reports `/compact` (and auto-compaction) results on
+/// grok reports `/compact` (and auto-compaction) results, and the fate of an
+/// image it refused to send, on
 /// `_x.ai/session_notification` / `_x.ai/session/update` rather than as normal
 /// `agent_message_chunk`s. Those methods never match the typed `session/update`
 /// pipeline, so without this the whole turn is blank and `/compact` looks like
@@ -8628,15 +8706,23 @@ fn map_grok_ext_notification(
         // describe sidecar (too small, oversize, decode failure). Surface it
         // so the user isn't left wondering why Grok "can't see" the shot.
         "image_dropped" => {
-            let detail = update
+            // `notes` is grok's own user-facing sentence, one per dropped image
+            // ("Image 1 was dropped before send: too small (1×1); images must be
+            // at least 8×8 pixels."). It already names the subject, so it is
+            // shown verbatim — prefixing it would read "Image dropped: Image 1
+            // was dropped before send: …". Only the shapeless fallbacks get a
+            // prefix, because on their own they say nothing about images.
+            let message = update
                 .get("notes")
                 .and_then(|v| v.as_array())
                 .map(|notes| {
                     notes
                         .iter()
                         .filter_map(|n| n.as_str())
+                        .map(str::trim)
+                        .filter(|n| !n.is_empty())
                         .collect::<Vec<_>>()
-                        .join("; ")
+                        .join(" ")
                 })
                 .filter(|s| !s.is_empty())
                 .or_else(|| {
@@ -8644,11 +8730,15 @@ fn map_grok_ext_notification(
                         .get("reason")
                         .or_else(|| update.get("message"))
                         .and_then(|v| v.as_str())
-                        .map(str::to_string)
+                        .map(str::trim)
+                        // A blank reason would render as a bare "Image dropped: "
+                        // — worse than the generic sentence below.
+                        .filter(|d| !d.is_empty())
+                        .map(|d| format!("Image dropped: {d}"))
                 })
-                .unwrap_or_else(|| "image was dropped before send".to_string());
+                .unwrap_or_else(|| "An image was dropped before send.".to_string());
             Some(AcpEvent::Error {
-                message: format!("Image dropped: {detail}"),
+                message,
                 agent_type: agent_type.to_string(),
                 code: None,
                 details: None,
@@ -8959,18 +9049,40 @@ fn grok_subagent_meta(
 }
 
 /// Whether a dispatch is a grok ext notification that
-/// `map_grok_ext_notification` renders as visible turn output (a compaction card
-/// or a compaction error). The active-turn loop consults this BEFORE the typed
+/// `map_grok_ext_notification` renders as visible turn output (a compaction
+/// card, a compaction error, or a dropped-image error). The active-turn loop
+/// consults this BEFORE the typed
 /// pipeline to mark the turn as non-empty: a `/compact` turn emits only these
 /// ext notifications and no standard `agent_message_chunk`, so without this its
 /// `end_turn` is reclassified as `"empty"` and re-surfaced as a spurious error —
 /// the exact symptom this change removes. Reuses `map_grok_ext_notification` so
-/// the handled-variant set can never drift from what actually emits.
+/// the handled-variant set can never drift from what actually emits. A turn
+/// whose only output was a dropped image therefore reports THAT, rather than
+/// the generic empty-turn failure it used to.
 fn grok_ext_notification_is_turn_output(dispatch: &Dispatch, agent_type: AgentType) -> bool {
     match dispatch {
         Dispatch::Notification(notification) => {
             map_grok_ext_notification(notification, agent_type).is_some()
         }
+        _ => false,
+    }
+}
+
+/// Whether a grok ext notification would raise a user-facing ALERT (status-bar
+/// entry + OS notification), as opposed to rendering a card in the turn.
+///
+/// Only the historical `session/load` replay asks: those notifications describe
+/// a PAST session, so re-raising their alerts would report a compaction failure
+/// or a dropped image as if it were happening now, for a session the user is
+/// merely opening. Reuses the mapper for the same reason
+/// [`grok_ext_notification_is_turn_output`] does — the alerting set cannot drift
+/// away from what actually emits.
+fn grok_ext_notification_is_alert(dispatch: &Dispatch, agent_type: AgentType) -> bool {
+    match dispatch {
+        Dispatch::Notification(notification) => matches!(
+            map_grok_ext_notification(notification, agent_type),
+            Some(AcpEvent::Error { .. })
+        ),
         _ => false,
     }
 }
@@ -10603,14 +10715,58 @@ mod tests {
                     message.contains("too small"),
                     "error should carry grok's drop reason; got: {message}"
                 );
+                // grok's note already opens with "Image 1 was dropped before
+                // send"; a prefix here would stutter it back at the user.
+                assert!(
+                    message.starts_with("Image 1 was dropped"),
+                    "grok's own sentence must be shown verbatim; got: {message}"
+                );
                 assert!(!terminal, "a dropped image must not kill the connection");
             }
             other => panic!("expected non-terminal Error, got {other:?}"),
         }
     }
 
+    /// Without `notes` there is no sentence to show, so the fallback has to
+    /// supply the subject itself.
     #[test]
-    fn promote_grok_image_resources_lifts_image_blobs_only() {
+    fn map_grok_ext_notification_image_dropped_without_notes_still_names_the_subject() {
+        let raw = UntypedMessage::new(
+            "_x.ai/session_notification",
+            serde_json::json!({
+                "sessionId": "s",
+                "update": { "sessionUpdate": "image_dropped", "reason": "decode failed" }
+            }),
+        )
+        .unwrap();
+        match map_grok_ext_notification(&raw, AgentType::Grok) {
+            Some(AcpEvent::Error { message, .. }) => {
+                assert_eq!(message, "Image dropped: decode failed");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        let bare = UntypedMessage::new(
+            "_x.ai/session_notification",
+            serde_json::json!({
+                "sessionId": "s",
+                "update": { "sessionUpdate": "image_dropped", "notes": [] }
+            }),
+        )
+        .unwrap();
+        match map_grok_ext_notification(&bare, AgentType::Grok) {
+            Some(AcpEvent::Error { message, .. }) => {
+                assert!(
+                    message.to_lowercase().contains("image"),
+                    "a note-less drop must still say what happened; got: {message}"
+                );
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn normalize_grok_image_blocks_lifts_decodable_image_blobs_only() {
         let blocks = vec![
             PromptInputBlock::Text {
                 text: "see this".into(),
@@ -10633,7 +10789,7 @@ mod tests {
                 uri: None,
             },
         ];
-        let out = promote_grok_image_resources(blocks);
+        let out = normalize_grok_image_blocks(blocks);
         assert!(matches!(&out[0], PromptInputBlock::Text { text } if text == "see this"));
         assert!(
             matches!(
@@ -10657,6 +10813,98 @@ mod tests {
             &out[3],
             PromptInputBlock::Image { data, .. } if data == "already"
         ));
+    }
+
+    /// grok's validator rejects `image/svg+xml` outright ("unsupported or
+    /// unrecognised image format") and the model then sees nothing at all. As a
+    /// resource blob the same file lands in the session's assets, where the
+    /// model can read the source — so an undecodable mime must NOT ride the
+    /// native carriage, whichever producer built the block.
+    #[test]
+    fn normalize_grok_image_blocks_demotes_mimes_grok_cannot_decode() {
+        let blocks = vec![
+            PromptInputBlock::Image {
+                data: "PHN2Zy8+".into(),
+                mime_type: "image/svg+xml".into(),
+                uri: Some("file:///tmp/diagram.svg".into()),
+            },
+            // Path-less (pasted): the demotion has to invent a stable uri.
+            // Upper-cased on purpose — the "is it an image at all" guard and the
+            // allow-list must read the same string the same way, or an
+            // undecodable format sails through as native.
+            PromptInputBlock::Image {
+                data: "PHN2Zy8+".into(),
+                mime_type: "IMAGE/SVG+XML".into(),
+                uri: None,
+            },
+            // Already on the resource carriage and undecodable — left alone,
+            // never promoted.
+            PromptInputBlock::Resource {
+                uri: "clipboard://icon.svg".into(),
+                mime_type: Some("image/svg+xml".into()),
+                text: None,
+                blob: Some("PHN2Zy8+".into()),
+            },
+        ];
+        let out = normalize_grok_image_blocks(blocks);
+        assert!(
+            matches!(
+                &out[0],
+                PromptInputBlock::Resource { uri, mime_type: Some(m), text: None, blob: Some(b) }
+                    if uri == "file:///tmp/diagram.svg"
+                        && m == "image/svg+xml"
+                        && b == "PHN2Zy8+"
+            ),
+            "{:?}",
+            out[0]
+        );
+        assert!(
+            matches!(
+                &out[1],
+                PromptInputBlock::Resource { uri, blob: Some(b), .. }
+                    if uri == "clipboard://grok-image-1" && b == "PHN2Zy8+"
+            ),
+            "{:?}",
+            out[1]
+        );
+        assert!(
+            matches!(
+                &out[2],
+                PromptInputBlock::Resource { mime_type: Some(m), .. } if m == "image/svg+xml"
+            ),
+            "{:?}",
+            out[2]
+        );
+    }
+
+    /// The allow-list is the boundary between the two carriages, so pin it:
+    /// grok's own raster set in, everything else out.
+    #[test]
+    fn grok_decodes_image_mime_covers_groks_raster_set_only() {
+        for mime in [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "image/bmp",
+            "image/tiff",
+            "IMAGE/PNG",
+        ] {
+            assert!(grok_decodes_image_mime(mime), "{mime} should be decodable");
+        }
+        for mime in [
+            "image/svg+xml",
+            "image/avif",
+            "image/heic",
+            "image/x-icon",
+            "text/markdown",
+            "",
+        ] {
+            assert!(
+                !grok_decodes_image_mime(mime),
+                "{mime} must keep the resource carriage"
+            );
+        }
     }
 
     #[test]
@@ -11052,6 +11300,54 @@ mod tests {
         // Never fires for a non-grok agent.
         assert!(!grok_ext_notification_is_turn_output(
             &notif("auto_compact_completed"),
+            AgentType::Codex
+        ));
+    }
+
+    /// The `session/load` replay drains a PAST session, so anything that would
+    /// raise an alert (status-bar entry + OS notification) has to be recognised
+    /// and skipped there — otherwise opening an old conversation reports its
+    /// historical failures as if they were happening now.
+    #[test]
+    fn grok_ext_notification_is_alert_matches_only_the_error_outcomes() {
+        let notif = |variant: &str| {
+            Dispatch::Notification(
+                UntypedMessage::new(
+                    "_x.ai/session_notification",
+                    serde_json::json!({
+                        "sessionId": "s",
+                        "update": {
+                            "sessionUpdate": variant,
+                            "tokens_before": 9, "tokens_after": 8, "reason": "x",
+                            "notes": ["Image 1 was dropped before send: too small."]
+                        }
+                    }),
+                )
+                .unwrap(),
+            )
+        };
+        // Both map to a non-terminal Error, so both alert.
+        assert!(grok_ext_notification_is_alert(
+            &notif("image_dropped"),
+            AgentType::Grok
+        ));
+        assert!(grok_ext_notification_is_alert(
+            &notif("auto_compact_failed"),
+            AgentType::Grok
+        ));
+        // A successful compaction renders a CARD, not an alert — it stays
+        // replayable, so the loaded transcript still shows what happened.
+        assert!(!grok_ext_notification_is_alert(
+            &notif("auto_compact_completed"),
+            AgentType::Grok
+        ));
+        // Unmapped variants and non-grok agents never alert.
+        assert!(!grok_ext_notification_is_alert(
+            &notif("turn_completed"),
+            AgentType::Grok
+        ));
+        assert!(!grok_ext_notification_is_alert(
+            &notif("image_dropped"),
             AgentType::Codex
         ));
     }

--- a/src-tauri/src/acp/types.rs
+++ b/src-tauri/src/acp/types.rs
@@ -472,9 +472,9 @@ pub enum ConfigStaleKind {
 /// [`PromptInputBlock`]: only what a viewer needs to render the user turn.
 /// Non-image `Resource` / `ResourceLink` prompt blocks are folded into `Text`
 /// markdown links by [`user_blocks_from_prompt`]; an image-mime embedded
-/// `Resource` (how an `image:false` / `embedded_context:true` agent like Grok
-/// carries a pasted image) is promoted to `Image` so the viewer renders a
-/// thumbnail, not a link.
+/// `Resource` (how an `image:false` / `embedded_context:true` agent carries a
+/// pasted image — and still how a format the agent cannot decode travels) is
+/// promoted to `Image` so the viewer renders a thumbnail, not a link.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum UserMessageBlock {
@@ -484,10 +484,12 @@ pub enum UserMessageBlock {
 
 /// Project the wire `PromptInputBlock`s the sender submitted into the lean
 /// [`UserMessageBlock`]s broadcast to viewers: text and images pass through; an
-/// image-mime embedded resource (Grok's pasted-image encoding) is promoted to an
-/// `Image`; other resources/resource-links collapse to a `[label](uri)` markdown
-/// line so a viewer still sees what was attached without shipping blob bytes
-/// twice.
+/// image-mime embedded resource is promoted to an `Image`; other
+/// resources/resource-links collapse to a `[label](uri)` markdown line so a
+/// viewer still sees what was attached without shipping blob bytes twice.
+///
+/// Both image carriages therefore render identically, which is what keeps the
+/// user turn stable no matter which one the prompt ends up taking.
 pub fn user_blocks_from_prompt(blocks: &[PromptInputBlock]) -> Vec<UserMessageBlock> {
     blocks
         .iter()
@@ -500,9 +502,10 @@ pub fn user_blocks_from_prompt(blocks: &[PromptInputBlock]) -> Vec<UserMessageBl
                 mime_type: mime_type.clone(),
             },
             // An image-mime embedded resource carries a pasted image for agents
-            // that reject native image blocks (Grok: `image:false` +
-            // `embedded_context:true`). Promote it to `Image` so viewers render
-            // the thumbnail; non-image resources still collapse to a link.
+            // that reject native image blocks (an `image:false` +
+            // `embedded_context:true` agent), and for a format the agent cannot
+            // decode. Promote it to `Image` so viewers render the thumbnail;
+            // non-image resources still collapse to a link.
             PromptInputBlock::Resource {
                 uri,
                 mime_type,

--- a/src-tauri/src/parsers/grok.rs
+++ b/src-tauri/src/parsers/grok.rs
@@ -1010,15 +1010,14 @@ fn update_text(update: &Value) -> String {
 
 /// Classify a `user_message_chunk`'s `content` into a display block.
 ///
-/// Grok sends prose as `{type:"text"}` and a pasted image as an embedded
-/// `{type:"resource", resource:{blob, mimeType, uri}}` — it advertises
-/// `image:false`, so images ride as embedded resources. An image-mime resource
-/// is promoted to [`ContentBlock::Image`] (bytes: `blob → data`) so it renders
-/// as a thumbnail, matching the live path and every other agent's images; a
-/// non-image embedded resource folds to a `[uri](uri)` link (same as the live
-/// [`crate::acp::user_blocks_from_prompt`]) so the attachment is still visible
-/// instead of a blank turn. Anything else falls back to a (possibly empty) text
-/// block, preserving prior behavior for plain prompts.
+/// Grok sends prose as `{type:"text"}`. Current codeg prompts send a native
+/// `{type:"image"}` chunk (so grok's describe sidecar runs). Older transcripts
+/// still carry the embedded `{type:"resource", resource:{blob, mimeType, uri}}`
+/// shape from when we followed grok's `image:false` advertisement. Both
+/// image-mime forms become [`ContentBlock::Image`] so they render as a
+/// thumbnail; a non-image embedded resource folds to a `[uri](uri)` link
+/// (same as the live [`crate::acp::user_blocks_from_prompt`]). Anything else
+/// falls back to a (possibly empty) text block.
 fn user_chunk_to_block(update: &Value) -> Option<ContentBlock> {
     let content = update.get("content")?;
     match content.get("type").and_then(Value::as_str).unwrap_or("") {
@@ -1045,8 +1044,7 @@ fn user_chunk_to_block(update: &Value) -> Option<ContentBlock> {
                 }
             }
         }
-        // Defensive: native ACP image content. Grok uses the `resource` shape
-        // above, but stay robust to a future/native image chunk.
+        // Native ACP image content — the live send path as of grok 1.0.2.
         "image" => {
             let data = content.get("data").and_then(Value::as_str)?;
             Some(ContentBlock::Image {
@@ -2074,12 +2072,42 @@ mod tests {
     }
 
     #[test]
+    fn merges_prompt_text_and_native_image_into_one_user_turn() {
+        // Live grok 1.0.2 echoes a native ACP image as its own
+        // `user_message_chunk` (same `promptIndex` as the prose). Same merge
+        // rule as the legacy resource-blob shape below.
+        let updates = concat!(
+            r#"{"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"这是什么"},"_meta":{"modelId":"grok-4.6","promptIndex":0}}},"timestamp":1783584019}"#, "\n",
+            r#"{"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"image","data":"QUJD","mimeType":"image/png"},"_meta":{"promptIndex":0}}},"timestamp":1783584019}"#, "\n",
+            r#"{"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"一张截图"}}},"timestamp":1783584024}"#, "\n",
+            r#"{"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"turn_completed","stop_reason":"end_turn"}},"timestamp":1783584024}"#, "\n",
+        );
+        let (_tmp, sessions) = fixture(SUMMARY, updates);
+        let parser = GrokParser::with_base_dir(sessions);
+        let detail = parser
+            .get_conversation("019f45e3-e1ef-7690-a29f-fe2554382b49")
+            .unwrap();
+        let turns = &detail.turns;
+        assert_eq!(turns.len(), 2);
+        assert!(matches!(turns[0].role, TurnRole::User));
+        assert_eq!(turns[0].blocks.len(), 2);
+        assert!(
+            matches!(&turns[0].blocks[0], ContentBlock::Text { text } if text == "这是什么")
+        );
+        assert!(matches!(
+            &turns[0].blocks[1],
+            ContentBlock::Image { data, mime_type, .. }
+                if data == "QUJD" && mime_type == "image/png"
+        ));
+        assert!(matches!(turns[1].role, TurnRole::Assistant));
+    }
+
+    #[test]
     fn merges_prompt_text_and_image_resource_into_one_user_turn() {
-        // Grok (`image:false` + `embedded_context:true`) sends a pasted image as
-        // a separate `user_message_chunk` carrying an embedded resource blob,
-        // right after the prose chunk of the SAME prompt (same `promptIndex`).
-        // Both must land in ONE user turn as [Text, Image] — not a text turn
-        // plus a trailing empty/image-only turn (the bug this fixes).
+        // Older transcripts: Grok echoed a pasted image as an embedded
+        // resource blob (`user_message_chunk` after the prose, same
+        // `promptIndex`). Both must still land in ONE user turn as
+        // [Text, Image] — not a text turn plus a trailing image-only turn.
         let updates = concat!(
             r#"{"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"这是什么"},"_meta":{"modelId":"grok-4.5","promptIndex":0}}},"timestamp":1783584019}"#, "\n",
             r#"{"method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"user_message_chunk","content":{"type":"resource","resource":{"blob":"QUJD","mimeType":"image/png","uri":"clipboard://image.png-abc"}},"_meta":{"promptIndex":0}}},"timestamp":1783584019}"#, "\n",

--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -3264,10 +3264,14 @@ fn carries_image(block: &PromptInputBlock) -> bool {
 /// Swap every attached image into the shape the connected agent advertised.
 ///
 /// Two wire encodings carry the same bytes: a native `Image` block, and a
-/// `Resource` whose `blob` holds them under an image mime type (what agents
-/// that reject image content but accept embedded context — e.g. Grok — take).
-/// The composer picks one at compose time from a probe; this picks again at
-/// dispatch, when the session has actually said what it accepts.
+/// `Resource` whose `blob` holds them under an image mime type (what an agent
+/// that rejects image content but accepts embedded context takes). The composer
+/// picks one at compose time from a probe; this picks again at dispatch, when
+/// the session has actually said what it accepts.
+///
+/// Grok needs neither swap — it advertises both bits — but its images still get
+/// sorted per mime further downstream, in `acp::connection`, which is the last
+/// point that sees the blocks.
 ///
 /// Only image-carrying blocks are touched, and only to move between those two
 /// encodings — never to invent or drop content. An agent that advertises

--- a/src/components/chat/composer/from-prompt-blocks.ts
+++ b/src/components/chat/composer/from-prompt-blocks.ts
@@ -74,9 +74,10 @@ export function blocksToRestoredDraft(
       }
       case "resource": {
         // An embedded image blob (how an `image: false` / `embedded_context:
-        // true` agent like Grok carries a pasted image) restores as a thumbnail
-        // image attachment, matching how it was displayed when composed — not as
-        // an inline resource badge. Non-image / text embedded resources keep the
+        // true` agent carries a pasted image, and how any image the agent
+        // cannot decode natively travels) restores as a thumbnail image
+        // attachment, matching how it was displayed when composed — not as an
+        // inline resource badge. Non-image / text embedded resources keep the
         // badge form.
         if (block.mime_type?.startsWith("image/") && block.blob) {
           // A synthetic `clipboard://` uri (path-less pasted image) is not a

--- a/src/components/chat/composer/use-composer-attachments.ts
+++ b/src/components/chat/composer/use-composer-attachments.ts
@@ -200,8 +200,8 @@ export function useComposerAttachments({
 
   // Route pasted / dropped / picked images to the thumbnail strip whenever the
   // agent can receive them in ANY form — either as a native ACP image block
-  // (`image`) or as an embedded resource blob (`embedded_context`, e.g. Grok,
-  // which advertises `image: false` but `embeddedContext: true`).
+  // (`image`) or as an embedded resource blob (`embedded_context`, what an
+  // agent that advertises `image: false` but `embeddedContext: true` takes).
   const canAttachImages =
     promptCapabilities.image || promptCapabilities.embedded_context
 
@@ -1331,7 +1331,7 @@ export function useComposerAttachments({
   // `attachments` holds only images — files live inline as editor badges. The
   // wire encoding is capability-driven (native `image` block vs embedded
   // `resource` blob) so an agent that advertises `image: false` but
-  // `embedded_context: true` (e.g. Grok) still receives the bytes it accepts.
+  // `embedded_context: true` still receives the bytes it accepts.
   const imagePromptBlocks = useCallback(
     (): PromptInputBlock[] =>
       imageAttachments.map((attachment) =>

--- a/src/components/chat/message-input-attachments.ts
+++ b/src/components/chat/message-input-attachments.ts
@@ -53,15 +53,17 @@ export type InputAttachment = ResourceInputAttachment | ImageInputAttachment
  * Serialize an image attachment into its outgoing prompt block, choosing the
  * wire encoding by the connected agent's declared capabilities:
  *
- * - Agents that accept native ACP image content (`caps.image` — e.g. Claude,
- *   Codex) → an `image` block.
+ * - Agents that accept native ACP image content (`caps.image` — Claude, Codex,
+ *   and Grok, whose `image: false` the backend overrides because it is simply
+ *   untrue) → an `image` block.
  * - Agents that reject image content but accept embedded context
- *   (`caps.embedded_context` — e.g. Grok, which advertises `image: false` +
- *   `embeddedContext: true`) → an embedded `resource` blob carrying the same
- *   base64 bytes and image mime type. This is exactly what those agents already
- *   received before; the only change is that the composer now shows the image
- *   as a thumbnail instead of an inline file badge (see `canAttachImages` in
- *   `message-input.tsx`), so the sent payload is unchanged for them.
+ *   (`caps.embedded_context`) → an embedded `resource` blob carrying the same
+ *   base64 bytes and image mime type.
+ *
+ * The capability is a single bit, so this cannot vary the encoding per mime
+ * type. An agent that takes native images but decodes only some formats is
+ * sorted out at dispatch instead, where the whole prompt is in view — see
+ * `normalize_grok_image_blocks` in `acp/connection.rs`.
  *
  * Pure and deterministic: a path-less pasted image (no `uri`) is given a stable
  * `clipboard://` identifier derived from its name + id, so the emitted block is

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -1078,8 +1078,8 @@ export function MessageInput({
     // `attachments` holds only images now — files live inline as badges above.
     // The wire encoding is capability-driven inside the hook (native `image`
     // block vs embedded `resource` blob), so an agent that advertises
-    // `image: false` but `embedded_context: true` (e.g. Grok) still receives
-    // the bytes it accepts.
+    // `image: false` but `embedded_context: true` still receives the bytes it
+    // accepts.
     blocks.push(...imagePromptBlocks())
 
     const displayText =

--- a/src/lib/prompt-draft.ts
+++ b/src/lib/prompt-draft.ts
@@ -26,9 +26,10 @@ function isImageBlock(
 /**
  * An embedded `resource` block that actually carries image bytes — an `image/*`
  * mime + a `blob`. This is how an agent with `image:false` but
- * `embedded_context:true` (e.g. Grok) encodes a pasted image (see
- * `imageAttachmentToPromptBlock`). It must render as a thumbnail like a native
- * image, not as a content-less resource chip.
+ * `embedded_context:true` encodes a pasted image (see
+ * `imageAttachmentToPromptBlock`), and how an image in a format the agent
+ * cannot decode travels. It must render as a thumbnail like a native image, not
+ * as a content-less resource chip.
  */
 function isImageResourceBlock(block: PromptInputBlock): block is Extract<
   PromptInputBlock,


### PR DESCRIPTION
## What changed

- Override Grok's advertised prompt image capability so pasted and attached images are sent as native ACP `image` blocks.
- Promote legacy queued image resources to native image blocks before sending them to Grok.
- Surface Grok's `image_dropped` notifications as non-terminal errors.
- Parse native Grok image chunks in history while preserving compatibility with the older resource-blob transcript shape.

## Why

Grok 1.0.2 still advertises `image: false`, so Codeg encoded images as embedded resources. Grok treats that shape as a binary file attachment and does not invoke its image-description sidecar, leaving the model unable to inspect the pixels. Native ACP image blocks do invoke the sidecar.

## Impact

Grok can now inspect pasted or attached images in Codeg. Existing queued drafts and older transcripts remain compatible, and users receive a visible warning when Grok rejects an image before sending it to the model.

## Validation

- `cargo test --features test-utils promote_grok_image_resources_lifts_image_blobs_only`
- `cargo test --features test-utils map_grok_ext_notification_image_dropped_surfaces_error`
- `cargo test --features test-utils merges_prompt_text_and_native_image_into_one_user_turn`
- `cargo test --features test-utils merges_prompt_text_and_image_resource_into_one_user_turn`
- `git diff --check`

All targeted tests passed.
