### PR TITLE
Add phone reach without installing Tailscale on both devices

### DIFF
--- a/src-tauri/src/web/embedded_tailnet.rs
+++ b/src-tauri/src/web/embedded_tailnet.rs
@@ -1,0 +1,175 @@
+//! Userspace tailnet join plan for phone reach.
+//!
+//! The existing Web Service URL + token is the session. This module only
+//! plans a `codeg-tsnet` sidecar (auth URL or auth key). It does not install
+//! the standalone Tailscale app.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TailnetAuth {
+    AuthKey(String),
+    AuthUrl(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailnetJoinPlan {
+    pub hostname: String,
+    pub target: String,
+    pub auth: TailnetAuth,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailnetLaunch {
+    pub plan: TailnetJoinPlan,
+    pub command: Vec<String>,
+    pub binary: PathBuf,
+}
+
+pub fn join_plan(
+    target: &str,
+    hostname: Option<&str>,
+    auth_key: Option<&str>,
+    auth_url: Option<&str>,
+) -> Result<TailnetJoinPlan, String> {
+    let target = target.trim();
+    if target.is_empty() {
+        return Err("target is required (desktop web service)".into());
+    }
+    let hostname = hostname
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("codeg")
+        .to_string();
+    let key = auth_key.map(str::trim).unwrap_or("");
+    let url = auth_url.map(str::trim).unwrap_or("");
+    if !key.is_empty() && !url.is_empty() {
+        return Err("use either an auth key or an auth URL, not both".into());
+    }
+    let auth = if !key.is_empty() {
+        TailnetAuth::AuthKey(key.to_string())
+    } else if !url.is_empty() {
+        TailnetAuth::AuthUrl(url.to_string())
+    } else {
+        return Err("auth key or auth URL is required".into());
+    };
+    Ok(TailnetJoinPlan {
+        hostname,
+        target: target.to_string(),
+        auth,
+    })
+}
+
+pub fn sidecar_args(plan: &TailnetJoinPlan) -> Vec<String> {
+    let (flag, value) = match &plan.auth {
+        TailnetAuth::AuthKey(v) => ("--authkey", v.as_str()),
+        TailnetAuth::AuthUrl(v) => ("--login-server", v.as_str()),
+    };
+    vec![
+        "--hostname".into(),
+        plan.hostname.clone(),
+        "--target".into(),
+        plan.target.clone(),
+        flag.into(),
+        value.into(),
+    ]
+}
+
+pub fn resolve_sidecar_binary(search_dir: Option<&Path>) -> Option<PathBuf> {
+    let names = if cfg!(windows) {
+        ["codeg-tsnet.exe", "codeg-tsnet"]
+    } else {
+        ["codeg-tsnet", "codeg-tsnet.exe"]
+    };
+    if let Some(dir) = search_dir {
+        for name in names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+pub fn launch_sidecar(
+    plan: &TailnetJoinPlan,
+    search_dir: Option<&Path>,
+) -> Result<TailnetLaunch, String> {
+    let binary = resolve_sidecar_binary(search_dir)
+        .ok_or_else(|| "codeg-tsnet sidecar is not installed beside Codeg".to_string())?;
+    let mut command = vec![binary.display().to_string()];
+    command.extend(sidecar_args(plan));
+    Ok(TailnetLaunch {
+        plan: plan.clone(),
+        command,
+        binary,
+    })
+}
+
+/// Spawn the sidecar. Tests never call this; production callers must handle
+/// a missing binary as unavailable rather than a fake tunnel.
+pub fn spawn_sidecar(launch: &TailnetLaunch) -> Result<(), String> {
+    Command::new(&launch.binary)
+        .args(sidecar_args(&launch.plan))
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("failed to start codeg-tsnet: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_plan_is_stable_for_auth_key() {
+        let first = join_plan(
+            "http://127.0.0.1:3080",
+            Some("codeg-desk"),
+            Some("tskey-auth-example"),
+            None,
+        )
+        .unwrap();
+        let second = join_plan(
+            "http://127.0.0.1:3080",
+            Some("codeg-desk"),
+            Some("tskey-auth-example"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(first, second);
+        assert!(matches!(first.auth, TailnetAuth::AuthKey(_)));
+        assert!(sidecar_args(&first).contains(&"--authkey".into()));
+    }
+
+    #[test]
+    fn join_plan_is_stable_for_auth_url() {
+        let first = join_plan(
+            "http://127.0.0.1:3080",
+            None,
+            None,
+            Some("https://login.tailscale.com/a/example"),
+        )
+        .unwrap();
+        let second = join_plan(
+            "http://127.0.0.1:3080",
+            None,
+            None,
+            Some("https://login.tailscale.com/a/example"),
+        )
+        .unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.hostname, "codeg");
+        assert!(sidecar_args(&first).contains(&"--login-server".into()));
+    }
+
+    #[test]
+    fn missing_sidecar_is_unavailable_not_a_fake_tunnel() {
+        let plan = join_plan("http://127.0.0.1:3080", None, Some("tskey-auth-x"), None)
+            .unwrap();
+        let missing = tempfile::tempdir().unwrap();
+        let err = launch_sidecar(&plan, Some(missing.path())).unwrap_err();
+        assert!(err.contains("not installed"), "{err}");
+    }
+}

--- a/src-tauri/src/web/mod.rs
+++ b/src-tauri/src/web/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod compression;
+pub mod embedded_tailnet;
 pub mod event_bridge;
 pub mod handlers;
 pub mod port_probe;

--- a/src/components/settings/web-service-settings.tsx
+++ b/src/components/settings/web-service-settings.tsx
@@ -43,6 +43,7 @@ const DEFAULT_PORT = 3080
 import { openUrl } from "@/lib/platform"
 import { copyTextToClipboard } from "@/lib/utils"
 import { useCopiedFlag } from "@/hooks/use-copied-flag"
+import { joinPlan, sidecarCommand } from "@/lib/embedded-tailnet"
 
 // Remembers which reachable address the user last chose to display/open.
 // Keyed by host (IP) only, so the choice survives a port change.
@@ -288,6 +289,8 @@ export function WebServiceSettings() {
   const [autoStart, setAutoStart] = useState(false)
   const [configLoaded, setConfigLoaded] = useState(false)
   const [selectedAddress, setSelectedAddress] = useState<string | null>(null)
+  const [tailnetAuthKey, setTailnetAuthKey] = useState("")
+  const [tailnetAuthUrl, setTailnetAuthUrl] = useState("")
 
   const probePort = useCallback(async (portNum: number) => {
     try {
@@ -595,6 +598,56 @@ export function WebServiceSettings() {
               )}
             </div>
           )}
+
+          <div className="space-y-2 rounded-md border p-3">
+            <div className="text-sm font-medium">{t("phoneReachTitle")}</div>
+            <p className="text-xs text-muted-foreground">{t("phoneReachHint")}</p>
+            <input
+              value={tailnetAuthKey}
+              onChange={(event) => setTailnetAuthKey(event.target.value)}
+              placeholder={t("phoneReachAuthKey")}
+              spellCheck={false}
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+            />
+            <input
+              value={tailnetAuthUrl}
+              onChange={(event) => setTailnetAuthUrl(event.target.value)}
+              placeholder={t("phoneReachAuthUrl")}
+              spellCheck={false}
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+            />
+            {(() => {
+              try {
+                const plan = joinPlan({
+                  target: currentAddress ?? `http://127.0.0.1:${port}`,
+                  authKey: tailnetAuthKey || undefined,
+                  authUrl: tailnetAuthUrl || undefined,
+                })
+                const command = sidecarCommand(plan)
+                return (
+                  <div className="space-y-1">
+                    <div className="text-xs text-muted-foreground">
+                      {t("phoneReachCommand")}
+                    </div>
+                    <code className="block break-all rounded bg-muted px-2 py-1 text-[11px]">
+                      {command}
+                    </code>
+                    <button
+                      type="button"
+                      className="text-xs text-muted-foreground underline"
+                      onClick={() => {
+                        void copyTextToClipboard(command)
+                      }}
+                    >
+                      {t("phoneReachCopy")}
+                    </button>
+                  </div>
+                )
+              } catch {
+                return null
+              }
+            })()}
+          </div>
         </div>
       </div>
     </ScrollArea>

--- a/src/components/settings/web-service-settings.tsx
+++ b/src/components/settings/web-service-settings.tsx
@@ -601,7 +601,9 @@ export function WebServiceSettings() {
 
           <div className="space-y-2 rounded-md border p-3">
             <div className="text-sm font-medium">{t("phoneReachTitle")}</div>
-            <p className="text-xs text-muted-foreground">{t("phoneReachHint")}</p>
+            <p className="text-xs text-muted-foreground">
+              {t("phoneReachHint")}
+            </p>
             <input
               value={tailnetAuthKey}
               onChange={(event) => setTailnetAuthKey(event.target.value)}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "التبديل يغيّر فقط العنوان المعروض والمفتوح هنا؛ تستمع الخدمة على جميع الواجهات وتبقى قابلة للوصول من كل عنوان.",
     "sectionTitle": "خدمة الويب",
     "sectionDescription": "تفعيل للوصول إلى Codeg عن بُعد عبر المتصفح",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "Das Umschalten ändert nur die hier angezeigte und geöffnete Adresse – der Dienst lauscht auf allen Schnittstellen und bleibt unter jeder Adresse erreichbar.",
     "sectionTitle": "Webdienst",
     "sectionDescription": "Aktivieren Sie den Fernzugriff auf Codeg über den Browser",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "Switching only changes the address shown and opened here — the service listens on all interfaces and stays reachable at every address.",
     "sectionTitle": "Web Service",
     "sectionDescription": "Enable to access Codeg remotely via browser",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "Cambiar solo modifica la dirección que se muestra y se abre aquí; el servicio escucha en todas las interfaces y sigue accesible en cada dirección.",
     "sectionTitle": "Servicio Web",
     "sectionDescription": "Habilitar para acceder a Codeg de forma remota a través del navegador",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "Changer ne modifie que l'adresse affichée et ouverte ici ; le service écoute sur toutes les interfaces et reste accessible à chaque adresse.",
     "sectionTitle": "Service Web",
     "sectionDescription": "Activer pour accéder à Codeg à distance via le navigateur",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "切り替えても、ここに表示され開くアドレスが変わるだけです。サービスはすべてのインターフェースで待ち受けており、どのアドレスからもアクセスできます。",
     "sectionTitle": "Webサービス",
     "sectionDescription": "有効にするとブラウザからCodegにリモートアクセスできます",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "전환해도 여기에 표시되고 열리는 주소만 바뀝니다. 서비스는 모든 인터페이스에서 수신하며 어떤 주소로도 접속할 수 있습니다.",
     "sectionTitle": "웹 서비스",
     "sectionDescription": "활성화하면 브라우저를 통해 Codeg에 원격으로 접속할 수 있습니다",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "Alternar muda apenas o endereço mostrado e aberto aqui; o serviço escuta em todas as interfaces e continua acessível em cada endereço.",
     "sectionTitle": "Serviço Web",
     "sectionDescription": "Ativar para acessar o Codeg remotamente pelo navegador",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "切换只改变这里显示和打开的地址；服务监听所有网卡，每个地址都可访问。",
     "sectionTitle": "Web 服务",
     "sectionDescription": "启用后可通过浏览器远程访问 Codeg",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -3465,6 +3465,12 @@
     }
   },
   "WebServiceSettings": {
+    "phoneReachTitle": "Phone reach",
+    "phoneReachHint": "The iOS app uses this URL plus the token above. You do not need the standalone Tailscale app on both devices. On the same network, start the Web Service. Off-network, join a tailnet with an auth key or login URL (userspace sidecar) and keep the Codeg token.",
+    "phoneReachAuthKey": "Tailnet auth key (optional)",
+    "phoneReachAuthUrl": "Tailnet login URL (optional)",
+    "phoneReachCommand": "Sidecar command",
+    "phoneReachCopy": "Copy sidecar command",
     "addressSwitchHint": "切換只會改變這裡顯示與開啟的位址；服務會監聽所有網路介面，每個位址都可存取。",
     "sectionTitle": "Web 服務",
     "sectionDescription": "啟用後可透過瀏覽器遠端存取 Codeg",

--- a/src/lib/embedded-tailnet.test.ts
+++ b/src/lib/embedded-tailnet.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { joinPlan, sidecarCommand } from "./embedded-tailnet"
+
+describe("embedded tailnet join plan", () => {
+  it("accepts an auth key and is stable across two builds", () => {
+    const input = {
+      hostname: "codeg-desk",
+      target: "http://127.0.0.1:3080",
+      authKey: "tskey-auth-example",
+    }
+    const first = joinPlan(input)
+    const second = joinPlan(input)
+    expect(first).toEqual(second)
+    expect(first.auth).toEqual({ kind: "auth-key", value: "tskey-auth-example" })
+    expect(sidecarCommand(first)).toContain("--authkey")
+    expect(sidecarCommand(first)).toContain("http://127.0.0.1:3080")
+  })
+
+  it("accepts an auth URL and is stable across two builds", () => {
+    const input = {
+      target: "http://127.0.0.1:3080",
+      authUrl: "https://login.tailscale.com/a/example",
+    }
+    const first = joinPlan(input)
+    const second = joinPlan(input)
+    expect(first).toEqual(second)
+    expect(first.hostname).toBe("codeg")
+    expect(first.auth.kind).toBe("auth-url")
+    expect(sidecarCommand(first)).toContain("--login-server")
+  })
+
+  it("rejects missing or mixed auth", () => {
+    expect(() => joinPlan({ target: "http://127.0.0.1:3080" })).toThrow(
+      /auth key or auth URL/
+    )
+    expect(() =>
+      joinPlan({
+        target: "http://127.0.0.1:3080",
+        authKey: "k",
+        authUrl: "https://login.tailscale.com/a/x",
+      })
+    ).toThrow(/either/)
+    expect(() => joinPlan({ target: "", authKey: "k" })).toThrow(/target/)
+  })
+})

--- a/src/lib/embedded-tailnet.test.ts
+++ b/src/lib/embedded-tailnet.test.ts
@@ -11,7 +11,10 @@ describe("embedded tailnet join plan", () => {
     const first = joinPlan(input)
     const second = joinPlan(input)
     expect(first).toEqual(second)
-    expect(first.auth).toEqual({ kind: "auth-key", value: "tskey-auth-example" })
+    expect(first.auth).toEqual({
+      kind: "auth-key",
+      value: "tskey-auth-example",
+    })
     expect(sidecarCommand(first)).toContain("--authkey")
     expect(sidecarCommand(first)).toContain("http://127.0.0.1:3080")
   })

--- a/src/lib/embedded-tailnet.ts
+++ b/src/lib/embedded-tailnet.ts
@@ -39,7 +39,9 @@ export function joinPlan(input: {
   const key = input.authKey?.trim() ?? ""
   const url = input.authUrl?.trim() ?? ""
   if (key && url) {
-    throw new TailnetJoinError("use either an auth key or an auth URL, not both")
+    throw new TailnetJoinError(
+      "use either an auth key or an auth URL, not both"
+    )
   }
   if (!key && !url) {
     throw new TailnetJoinError("auth key or auth URL is required")

--- a/src/lib/embedded-tailnet.ts
+++ b/src/lib/embedded-tailnet.ts
@@ -1,0 +1,63 @@
+/**
+ * Bundled tailnet join plan for phone reach.
+ *
+ * Goal: the phone talks to desktop Codeg with the existing URL + token.
+ * A userspace tsnet sidecar can join a tailnet (auth URL or auth key)
+ * without installing the standalone Tailscale app on the computer.
+ * Funnel HTTPS then means the phone also does not need the Tailscale app.
+ */
+
+export type TailnetAuth =
+  | { kind: "auth-key"; value: string }
+  | { kind: "auth-url"; value: string }
+
+export type TailnetJoinPlan = {
+  hostname: string
+  target: string
+  auth: TailnetAuth
+  sidecarArgs: string[]
+}
+
+export class TailnetJoinError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TailnetJoinError"
+  }
+}
+
+export function joinPlan(input: {
+  hostname?: string
+  target: string
+  authKey?: string
+  authUrl?: string
+}): TailnetJoinPlan {
+  const target = input.target.trim()
+  if (!target) {
+    throw new TailnetJoinError("target is required (desktop web service)")
+  }
+  const hostname = (input.hostname ?? "codeg").trim() || "codeg"
+  const key = input.authKey?.trim() ?? ""
+  const url = input.authUrl?.trim() ?? ""
+  if (key && url) {
+    throw new TailnetJoinError("use either an auth key or an auth URL, not both")
+  }
+  if (!key && !url) {
+    throw new TailnetJoinError("auth key or auth URL is required")
+  }
+  const auth: TailnetAuth = key
+    ? { kind: "auth-key", value: key }
+    : { kind: "auth-url", value: url }
+  const sidecarArgs = [
+    "--hostname",
+    hostname,
+    "--target",
+    target,
+    auth.kind === "auth-key" ? "--authkey" : "--login-server",
+    auth.value,
+  ]
+  return { hostname, target, auth, sidecarArgs }
+}
+
+export function sidecarCommand(plan: TailnetJoinPlan): string {
+  return ["codeg-tsnet", ...plan.sidecarArgs].join(" ")
+}


### PR DESCRIPTION
Superseded as a shipping path.

A join-plan string is not a bolt-in tunnel. Phone reach without Tailscale on both devices is [#337](https://github.com/xintaofei/codeg/pull/337) (`codeg-tsnet` Funnel sidecar, proxies `http://127.0.0.1`). The secure desktop floor is loopback-by-default + constant-time token compare on `web-service-loopback-first`.

Leaving this open only as a pointer. Prefer #337 + the loopback-first PR over merging this plan-only change.