### PR TITLE
Show archived CLI sessions in the import picker

### DIFF
--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -636,6 +636,7 @@ fn build_scan_result(
             model: summary.model,
             git_branch: summary.git_branch,
             status,
+            archived: summary.archived,
         });
     }
 
@@ -4870,6 +4871,7 @@ mod tests {
                 parent_id: None,
                 parent_tool_use_id: None,
                 delegation_call_id: None,
+                archived: false,
             },
         )
     }
@@ -4930,6 +4932,15 @@ mod tests {
         assert_eq!(by_id["gone"], ScanSessionStatus::Deleted);
         assert_eq!(result.total_sessions, 3);
         assert_eq!(result.importable_count, 1, "only New counts as importable");
+    }
+
+    #[test]
+    fn scan_preserves_cli_archived_flag() {
+        let (agent, mut summary) =
+            scan_summary("arch", AgentType::Codex, Some("/tmp/p"), at(0));
+        summary.archived = true;
+        let result = build_scan_result(vec![(agent, summary)], &HashMap::new(), &[]);
+        assert!(result.folders[0].sessions[0].archived);
     }
 
     #[test]

--- a/src-tauri/src/db/service/import_service.rs
+++ b/src-tauri/src/db/service/import_service.rs
@@ -477,6 +477,7 @@ mod tests {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         }
     }
 

--- a/src-tauri/src/models/conversation.rs
+++ b/src-tauri/src/models/conversation.rs
@@ -23,6 +23,11 @@ pub struct ConversationSummary {
     pub parent_tool_use_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delegation_call_id: Option<String>,
+    /// True when the originating CLI marked the session archived (Codex
+    /// `threads.archived`, Hermes `sessions.archived`, …). Import can hide
+    /// these behind a filter. Default false so older parsers stay live.
+    #[serde(default)]
+    pub archived: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -231,6 +236,9 @@ pub struct ScanSession {
     pub model: Option<String>,
     pub git_branch: Option<String>,
     pub status: ScanSessionStatus,
+    /// Originating CLI archived this session. Default false for old scans.
+    #[serde(default)]
+    pub archived: bool,
 }
 
 /// One folder group in the import-picker scan: all sessions sharing a

--- a/src-tauri/src/parsers/acp_native.rs
+++ b/src-tauri/src/parsers/acp_native.rs
@@ -167,6 +167,7 @@ impl AcpNativeParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         }
     }
 }

--- a/src-tauri/src/parsers/claude.rs
+++ b/src-tauri/src/parsers/claude.rs
@@ -978,6 +978,7 @@ impl ClaudeParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         }))
     }
 }
@@ -1945,6 +1946,7 @@ impl ClaudeParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         Ok(ConversationDetail {

--- a/src-tauri/src/parsers/claude.rs
+++ b/src-tauri/src/parsers/claude.rs
@@ -1005,11 +1005,37 @@ fn resolve_claude_config_dir_from(
         .unwrap_or_else(|| home_dir.unwrap_or_default().join(".claude"))
 }
 
-/// Claude Desktop stores Code sessions at
-/// `<config>/Claude/claude-code-sessions/{org}/{user}/local_{id}.json`
-/// with `"isArchived": true` when archived (anthropics/claude-code#24534).
-fn claude_desktop_sessions_root() -> Option<PathBuf> {
-    dirs::config_dir().map(|p| p.join("Claude").join("claude-code-sessions"))
+/// Claude Desktop stores Code sessions as
+/// `claude-code-sessions/{org}/{user}/local_{id}.json` with `isArchived`.
+/// Classic Electron uses `%AppData%/Claude`. The Windows Store package
+/// virtualizes that to
+/// `%LocalAppData%/Packages/Claude_*/LocalCache/Roaming/Claude`.
+fn claude_desktop_sessions_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(config) = dirs::config_dir() {
+        roots.push(config.join("Claude").join("claude-code-sessions"));
+    }
+    if let Some(local) = dirs::data_local_dir() {
+        let packages = local.join("Packages");
+        if let Ok(entries) = fs::read_dir(&packages) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if !name.starts_with("Claude_") {
+                    continue;
+                }
+                roots.push(
+                    entry
+                        .path()
+                        .join("LocalCache")
+                        .join("Roaming")
+                        .join("Claude")
+                        .join("claude-code-sessions"),
+                );
+            }
+        }
+    }
+    roots
 }
 
 fn session_id_from_desktop_filename(name: &str) -> Option<String> {
@@ -1056,6 +1082,16 @@ fn load_claude_desktop_archived_ids(root: &Path) -> HashSet<String> {
             };
             if value.get("isArchived").and_then(|v| v.as_bool()) == Some(true) {
                 ids.insert(id);
+                if let Some(session_id) = value.get("sessionId").and_then(|v| v.as_str()) {
+                    if !session_id.is_empty() {
+                        ids.insert(session_id.to_string());
+                    }
+                }
+                if let Some(cli_id) = value.get("cliSessionId").and_then(|v| v.as_str()) {
+                    if !cli_id.is_empty() {
+                        ids.insert(cli_id.to_string());
+                    }
+                }
             }
         }
     }
@@ -1115,13 +1151,14 @@ impl AgentParser for ClaudeParser {
             }
         }
 
-        if let Some(root) = claude_desktop_sessions_root() {
-            let archived = load_claude_desktop_archived_ids(&root);
-            if !archived.is_empty() {
-                for conversation in &mut conversations {
-                    if archived.contains(&conversation.id) {
-                        conversation.archived = true;
-                    }
+        let mut archived = HashSet::new();
+        for root in claude_desktop_sessions_roots() {
+            archived.extend(load_claude_desktop_archived_ids(&root));
+        }
+        if !archived.is_empty() {
+            for conversation in &mut conversations {
+                if archived.contains(&conversation.id) {
+                    conversation.archived = true;
                 }
             }
         }
@@ -5213,5 +5250,21 @@ mod tests {
             session_id_from_desktop_filename("local_sess-desk.json").as_deref(),
             Some("sess-desk")
         );
+    }
+
+    #[test]
+    fn desktop_sidecar_indexes_session_id_and_cli_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("org").join("user");
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::write(
+            live.join("local_file-id.json"),
+            r#"{"isArchived":true,"sessionId":"sess-json","cliSessionId":"cli-json"}"#,
+        )
+        .unwrap();
+        let ids = load_claude_desktop_archived_ids(dir.path());
+        assert!(ids.contains("file-id"));
+        assert!(ids.contains("sess-json"));
+        assert!(ids.contains("cli-json"));
     }
 }

--- a/src-tauri/src/parsers/claude.rs
+++ b/src-tauri/src/parsers/claude.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -856,6 +857,7 @@ impl ClaudeParser {
         let mut first_timestamp: Option<DateTime<Utc>> = None;
         let mut last_timestamp: Option<DateTime<Utc>> = None;
         let mut message_count: u32 = 0;
+        let mut archived = false;
 
         for line in reader.lines() {
             let line = match line {
@@ -870,6 +872,12 @@ impl ClaudeParser {
                 Ok(v) => v,
                 Err(_) => continue,
             };
+
+            // Read before skip filters: Desktop/CLI may stamp this on a
+            // metadata record that is not a user/assistant turn.
+            if let Some(flag) = value.get("isArchived").and_then(|v| v.as_bool()) {
+                archived = flag;
+            }
 
             let msg_type = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
@@ -978,7 +986,7 @@ impl ClaudeParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
-            archived: false,
+            archived,
         }))
     }
 }
@@ -995,6 +1003,63 @@ fn resolve_claude_config_dir_from(
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir.unwrap_or_default().join(".claude"))
+}
+
+/// Claude Desktop stores Code sessions at
+/// `<config>/Claude/claude-code-sessions/{org}/{user}/local_{id}.json`
+/// with `"isArchived": true` when archived (anthropics/claude-code#24534).
+fn claude_desktop_sessions_root() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("Claude").join("claude-code-sessions"))
+}
+
+fn session_id_from_desktop_filename(name: &str) -> Option<String> {
+    let stem = name.strip_suffix(".json")?;
+    let id = stem.strip_prefix("local_")?;
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.to_string())
+    }
+}
+
+fn load_claude_desktop_archived_ids(root: &Path) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    if !root.is_dir() {
+        return ids;
+    }
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let Some(id) = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .and_then(session_id_from_desktop_filename)
+            else {
+                continue;
+            };
+            let Ok(text) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+                continue;
+            };
+            if value.get("isArchived").and_then(|v| v.as_bool()) == Some(true) {
+                ids.insert(id);
+            }
+        }
+    }
+    ids
 }
 
 impl AgentParser for ClaudeParser {
@@ -1046,6 +1111,17 @@ impl AgentParser for ClaudeParser {
                     }
                     Ok(None) => continue,
                     Err(_) => continue,
+                }
+            }
+        }
+
+        if let Some(root) = claude_desktop_sessions_root() {
+            let archived = load_claude_desktop_archived_ids(&root);
+            if !archived.is_empty() {
+                for conversation in &mut conversations {
+                    if archived.contains(&conversation.id) {
+                        conversation.archived = true;
+                    }
                 }
             }
         }
@@ -5090,5 +5166,52 @@ mod tests {
             }
             other => panic!("expected ToolResult, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn jsonl_is_archived_marks_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let proj = dir.path().join("-tmp-demo");
+        std::fs::create_dir_all(&proj).unwrap();
+        let path = proj.join("sess-archived.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"type":"user","sessionId":"sess-archived","timestamp":"2026-07-07T03:40:00.000Z","cwd":"/tmp/demo","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+                "\n",
+                r#"{"type":"custom-title","sessionId":"sess-archived","isArchived":true}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let parser = ClaudeParser::with_base_dir(dir.path().to_path_buf());
+        let listed = parser.list_conversations().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert!(listed[0].archived);
+        assert_eq!(listed[0].id, "sess-archived");
+    }
+
+    #[test]
+    fn desktop_sidecar_is_archived_overlays_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = dir.path().join("org").join("user");
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::write(
+            live.join("local_sess-desk.json"),
+            r#"{"isArchived":true,"sessionId":"sess-desk"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            live.join("local_sess-open.json"),
+            r#"{"isArchived":false,"sessionId":"sess-open"}"#,
+        )
+        .unwrap();
+        let ids = load_claude_desktop_archived_ids(dir.path());
+        assert!(ids.contains("sess-desk"));
+        assert!(!ids.contains("sess-open"));
+        assert_eq!(
+            session_id_from_desktop_filename("local_sess-desk.json").as_deref(),
+            Some("sess-desk")
+        );
     }
 }

--- a/src-tauri/src/parsers/cline.rs
+++ b/src-tauri/src/parsers/cline.rs
@@ -193,6 +193,7 @@ impl AgentParser for ClineParser {
                 parent_id: None,
                 parent_tool_use_id: None,
                 delegation_call_id: None,
+                archived: false,
             });
         }
 
@@ -348,6 +349,7 @@ impl AgentParser for ClineParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         Ok(ConversationDetail {

--- a/src-tauri/src/parsers/codebuddy.rs
+++ b/src-tauri/src/parsers/codebuddy.rs
@@ -143,6 +143,7 @@ impl CodeBuddyParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         })
     }
 
@@ -333,6 +334,7 @@ impl CodeBuddyParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         Ok(ConversationDetail {

--- a/src-tauri/src/parsers/codex.rs
+++ b/src-tauri/src/parsers/codex.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use chrono::{DateTime, Utc};
@@ -303,6 +303,7 @@ impl CodexParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         }))
     }
 }
@@ -319,6 +320,81 @@ fn resolve_codex_home_dir_from(
         .filter(|value| !value.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| home_dir.unwrap_or_default().join(".codex"))
+}
+
+/// Codex Desktop / CLI persist `threads.archived` in `state_<n>.sqlite`.
+/// Newest schema file wins. Missing DB or column is "not archived".
+fn load_codex_archived_ids(codex_home: &Path) -> HashSet<String> {
+    let Some(db_path) = newest_codex_state_db(codex_home) else {
+        return HashSet::new();
+    };
+    let Ok(conn) = rusqlite::Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ) else {
+        return HashSet::new();
+    };
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT id FROM threads WHERE COALESCE(archived, 0) != 0",
+    ) else {
+        return HashSet::new();
+    };
+    let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(0)) else {
+        return HashSet::new();
+    };
+    rows.filter_map(Result::ok).collect()
+}
+
+fn newest_codex_state_db(codex_home: &Path) -> Option<PathBuf> {
+    let mut best: Option<(u32, PathBuf)> = None;
+    let entries = fs::read_dir(codex_home).ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let Some(rest) = name.strip_prefix("state_") else {
+            continue;
+        };
+        let Some(num) = rest.strip_suffix(".sqlite") else {
+            continue;
+        };
+        let Ok(version) = num.parse::<u32>() else {
+            continue;
+        };
+        if best.as_ref().is_none_or(|(v, _)| version >= *v) {
+            best = Some((version, entry.path()));
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+#[cfg(test)]
+mod archived_flag_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn load_codex_archived_ids_reads_newest_state_db() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("state_4.sqlite"), b"not a db").unwrap();
+        let db5 = dir.path().join("state_5.sqlite");
+        {
+            let conn = rusqlite::Connection::open(&db5).expect("create db");
+            conn.execute(
+                "CREATE TABLE threads (id TEXT PRIMARY KEY, archived INTEGER)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO threads (id, archived) VALUES ('live-1', 0), ('arch-1', 1)",
+                [],
+            )
+            .unwrap();
+        }
+        let ids = load_codex_archived_ids(dir.path());
+        assert!(ids.contains("arch-1"));
+        assert!(!ids.contains("live-1"));
+        assert_eq!(newest_codex_state_db(dir.path()), Some(db5));
+    }
 }
 
 impl AgentParser for CodexParser {
@@ -356,6 +432,15 @@ impl AgentParser for CodexParser {
                     conversations.push(summary);
                 }
                 _ => continue,
+            }
+        }
+
+        let archived = load_codex_archived_ids(
+            self.base_dir.parent().unwrap_or(self.base_dir.as_path()),
+        );
+        for conversation in &mut conversations {
+            if archived.contains(&conversation.id) {
+                conversation.archived = true;
             }
         }
 
@@ -3561,6 +3646,7 @@ impl CodexParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         Ok(ConversationDetail {

--- a/src-tauri/src/parsers/cursor.rs
+++ b/src-tauri/src/parsers/cursor.rs
@@ -325,6 +325,7 @@ fn summary_from(
         parent_id: None,
         parent_tool_use_id: None,
         delegation_call_id: None,
+        archived: false,
     }
 }
 

--- a/src-tauri/src/parsers/deepseek.rs
+++ b/src-tauri/src/parsers/deepseek.rs
@@ -181,6 +181,7 @@ impl DeepSeekParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         })
     }
 
@@ -222,6 +223,7 @@ impl DeepSeekParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         ConversationDetail {

--- a/src-tauri/src/parsers/gemini.rs
+++ b/src-tauri/src/parsers/gemini.rs
@@ -454,6 +454,7 @@ impl GeminiParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         })
     }
 

--- a/src-tauri/src/parsers/grok.rs
+++ b/src-tauri/src/parsers/grok.rs
@@ -265,6 +265,7 @@ impl GrokParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         }
     }
 

--- a/src-tauri/src/parsers/hermes.rs
+++ b/src-tauri/src/parsers/hermes.rs
@@ -116,6 +116,7 @@ impl HermesParser {
                     s.started_at AS started_at,
                     s.ended_at AS ended_at,
                     s.parent_session_id AS parent_id,
+                    COALESCE(s.archived, 0) AS archived,
                     (
                         SELECT COUNT(*) FROM messages m
                         WHERE m.session_id = s.id
@@ -123,7 +124,6 @@ impl HermesParser {
                           AND m.role <> 'system'
                     ) AS message_count
                 FROM sessions s
-                WHERE COALESCE(s.archived, 0) = 0
                 ORDER BY s.started_at DESC
                 "#
                 .to_string(),
@@ -458,6 +458,7 @@ fn parse_sqlite_summary_row(row: &QueryResult) -> Result<ConversationSummary, Pa
     let title: Option<String> = row.try_get("", "title")?;
     let model: Option<String> = row.try_get("", "model")?;
     let parent_id: Option<String> = row.try_get("", "parent_id")?;
+    let archived_i64: i64 = row.try_get("", "archived").unwrap_or(0);
     let message_count_i64: i64 = row.try_get("", "message_count")?;
 
     let started_at = get_real(row, "started_at")
@@ -488,6 +489,7 @@ fn parse_sqlite_summary_row(row: &QueryResult) -> Result<ConversationSummary, Pa
         parent_id: normalize_optional_string(parent_id),
         parent_tool_use_id: None,
         delegation_call_id: None,
+        archived: archived_i64 != 0,
     })
 }
 

--- a/src-tauri/src/parsers/kimi_code.rs
+++ b/src-tauri/src/parsers/kimi_code.rs
@@ -164,6 +164,7 @@ impl KimiCodeParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         })
     }
 
@@ -216,6 +217,7 @@ impl KimiCodeParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         ConversationDetail {

--- a/src-tauri/src/parsers/openclaw.rs
+++ b/src-tauri/src/parsers/openclaw.rs
@@ -498,6 +498,7 @@ impl OpenClawParser {
                 parent_id: None,
                 parent_tool_use_id: None,
                 delegation_call_id: None,
+                archived: false,
             });
         }
 
@@ -695,6 +696,7 @@ impl OpenClawParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         Ok(ConversationDetail {

--- a/src-tauri/src/parsers/opencode.rs
+++ b/src-tauri/src/parsers/opencode.rs
@@ -111,6 +111,7 @@ impl OpenCodeParser {
             parent_id: normalize_optional_string(parent_id),
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         })
     }
 

--- a/src-tauri/src/parsers/pi.rs
+++ b/src-tauri/src/parsers/pi.rs
@@ -133,6 +133,7 @@ impl PiParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         })
     }
 
@@ -169,6 +170,7 @@ impl PiParser {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         };
 
         Ok(ConversationDetail {

--- a/src-tauri/src/parsers/qoder.rs
+++ b/src-tauri/src/parsers/qoder.rs
@@ -838,6 +838,7 @@ fn parse_summary(path: &Path) -> Option<ConversationSummary> {
         parent_id: None,
         parent_tool_use_id: None,
         delegation_call_id: None,
+        archived: false,
     })
 }
 
@@ -886,6 +887,7 @@ fn parse_detail(path: &Path, conversation_id: &str) -> Result<ConversationDetail
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         },
         turns,
         session_stats,

--- a/src-tauri/src/parsers/summary_cache.rs
+++ b/src-tauri/src/parsers/summary_cache.rs
@@ -186,6 +186,7 @@ mod tests {
             parent_id: None,
             parent_tool_use_id: None,
             delegation_call_id: None,
+            archived: false,
         }
     }
 

--- a/src-tauri/tests/parsers_snapshot.rs
+++ b/src-tauri/tests/parsers_snapshot.rs
@@ -927,7 +927,7 @@ fn hermes_minimal_session_snapshot() {
             203,
         )
         .await;
-        // Archived session (excluded from list) + one message.
+        // Archived session (kept in the list, flagged) + one message.
         hermes_ins_session(
             &conn,
             "hermes-sess-archived",

--- a/src-tauri/tests/snapshots/parsers_snapshot__claude_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__claude_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": "main"
+    "git_branch": "main",
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__claude_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__claude_list.snap
@@ -13,6 +13,7 @@ expression: summaries
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": "main"
+    "git_branch": "main",
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__cline_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__cline_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": null,
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__cline_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__cline_list.snap
@@ -13,6 +13,7 @@ expression: summaries
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__codex_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__codex_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "gpt-5.1-codex",
-    "git_branch": "main"
+    "git_branch": "main",
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__codex_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__codex_list.snap
@@ -13,6 +13,7 @@ expression: summaries
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "gpt-5.1-codex",
-    "git_branch": "main"
+    "git_branch": "main",
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__gemini_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__gemini_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "gemini-2.5-pro",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__gemini_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__gemini_list.snap
@@ -13,6 +13,7 @@ expression: summaries
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "gemini-2.5-pro",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__hermes_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__hermes_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 5,
     "model": "gpt-5.5",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__hermes_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__hermes_list.snap
@@ -13,6 +13,20 @@ expression: conversations
     "ended_at": "[ts]",
     "message_count": 5,
     "model": "gpt-5.5",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
+  },
+  {
+    "id": "hermes-sess-archived",
+    "agent_type": "hermes",
+    "folder_path": "/Users/demo/arch",
+    "folder_name": "arch",
+    "title": "archived one",
+    "started_at": "[ts]",
+    "ended_at": "[ts]",
+    "message_count": 1,
+    "model": "gpt-5.5",
+    "git_branch": null,
+    "archived": true
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__kimi_code_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__kimi_code_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "kimi-k2.7-code",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__kimi_code_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__kimi_code_list.snap
@@ -13,6 +13,7 @@ expression: summaries
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "kimi-k2.7-code",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__openclaw_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__openclaw_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "gpt-5.4",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__openclaw_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__openclaw_list.snap
@@ -13,6 +13,7 @@ expression: summaries
     "ended_at": "[ts]",
     "message_count": 2,
     "model": null,
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__opencode_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__opencode_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__opencode_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__opencode_list.snap
@@ -13,6 +13,7 @@ expression: conversations
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   }
 ]

--- a/src-tauri/tests/snapshots/parsers_snapshot__opencode_tools_detail.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__opencode_tools_detail.snap
@@ -13,7 +13,8 @@ expression: detail
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   "turns": [
     {

--- a/src-tauri/tests/snapshots/parsers_snapshot__opencode_tools_list.snap
+++ b/src-tauri/tests/snapshots/parsers_snapshot__opencode_tools_list.snap
@@ -13,7 +13,8 @@ expression: conversations
     "ended_at": "[ts]",
     "message_count": 2,
     "model": "claude-sonnet-4-6",
-    "git_branch": null
+    "git_branch": null,
+    "archived": false
   },
   {
     "id": "oc-tools-001-child",
@@ -26,6 +27,7 @@ expression: conversations
     "message_count": 1,
     "model": null,
     "git_branch": null,
-    "parent_id": "oc-tools-001"
+    "parent_id": "oc-tools-001",
+    "archived": false
   }
 ]

--- a/src/components/import-sessions/import-sessions-rows.tsx
+++ b/src/components/import-sessions/import-sessions-rows.tsx
@@ -171,6 +171,11 @@ export const SessionRow = memo(function SessionRow({
           {t("statusDeleted")}
         </Badge>
       )}
+      {session.archived && (
+        <Badge variant="secondary" className="shrink-0 text-[10px]">
+          {t("statusArchived")}
+        </Badge>
+      )}
       <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
         {t("messageCount", { count: session.message_count })}
       </span>

--- a/src/components/import-sessions/import-sessions-window.test.tsx
+++ b/src/components/import-sessions/import-sessions-window.test.tsx
@@ -75,7 +75,8 @@ function session(
   externalId: string,
   agentType: string,
   title: string,
-  status: "new" | "imported" | "deleted"
+  status: "new" | "imported" | "deleted",
+  archived = false
 ) {
   return {
     external_id: externalId,
@@ -87,6 +88,7 @@ function session(
     model: null,
     git_branch: null,
     status,
+    archived,
   }
 }
 
@@ -103,6 +105,7 @@ function scanFixture(): ScanResult {
           session("a1", "claude_code", "Alpha one", "new"),
           session("a2", "codex", "Alpha two", "new"),
           session("a3", "codex", "Alpha old", "imported"),
+          session("a4", "codex", "Alpha archived", "new", true),
         ],
       },
       {
@@ -118,8 +121,8 @@ function scanFixture(): ScanResult {
       },
     ],
     no_folder_count: 1,
-    total_sessions: 5,
-    importable_count: 3,
+    total_sessions: 6,
+    importable_count: 4,
   } as ScanResult
 }
 
@@ -165,9 +168,9 @@ describe("ImportSessionsWindow", () => {
 
     expect(await screen.findByText("alpha")).toBeVisible()
     expect(screen.getByText("beta")).toBeVisible()
-    // All five sessions render as rows under their folders.
     expect(screen.getByText("Alpha one")).toBeVisible()
     expect(screen.getByText("Beta gone")).toBeVisible()
+    expect(screen.queryByText("Alpha archived")).toBeNull()
     // The not-in-codeg folder carries the "New" badge; the existing one not.
     const alphaHeader = screen
       .getByText("alpha")
@@ -176,7 +179,7 @@ describe("ImportSessionsWindow", () => {
     expect(alphaHeader.textContent).toContain("New")
     // Summary footer counts come from the scan payload.
     expect(
-      screen.getByText("5 sessions · 3 importable · 2 folders")
+      screen.getByText("6 sessions · 4 importable · 2 folders")
     ).toBeVisible()
     expect(screen.getByText("1 without a project folder skipped")).toBeVisible()
   })
@@ -253,11 +256,25 @@ describe("ImportSessionsWindow", () => {
     renderWindow()
     await screen.findByText("alpha")
 
-    fireEvent.click(screen.getByRole("switch"))
+    const switches = screen.getAllByRole("switch")
+    fireEvent.click(switches[0])
     expect(screen.queryByText("Alpha old")).toBeNull()
     expect(screen.queryByText("Beta gone")).toBeNull()
     expect(screen.getByText("Alpha one")).toBeVisible()
     expect(screen.getByText("Beta new")).toBeVisible()
+  })
+
+  it("hides archived sessions by default and shows them when the filter is off", async () => {
+    renderWindow()
+    await screen.findByText("alpha")
+
+    expect(screen.queryByText("Alpha archived")).toBeNull()
+    expect(screen.getByText("Alpha one")).toBeVisible()
+
+    const switches = screen.getAllByRole("switch")
+    fireEvent.click(switches[1])
+    expect(screen.getByText("Alpha archived")).toBeVisible()
+    expect(screen.getByText("Archived")).toBeVisible()
   })
 
   it("imports exactly the selected keys and shows the summary", async () => {

--- a/src/components/import-sessions/import-sessions-window.test.tsx
+++ b/src/components/import-sessions/import-sessions-window.test.tsx
@@ -106,6 +106,7 @@ function scanFixture(): ScanResult {
           session("a2", "codex", "Alpha two", "new"),
           session("a3", "codex", "Alpha old", "imported"),
           session("a4", "codex", "Alpha archived", "new", true),
+          session("a5", "claude_code", "Alpha archived claude", "new", true),
         ],
       },
       {
@@ -121,8 +122,8 @@ function scanFixture(): ScanResult {
       },
     ],
     no_folder_count: 1,
-    total_sessions: 6,
-    importable_count: 4,
+    total_sessions: 7,
+    importable_count: 5,
   } as ScanResult
 }
 
@@ -171,6 +172,7 @@ describe("ImportSessionsWindow", () => {
     expect(screen.getByText("Alpha one")).toBeVisible()
     expect(screen.getByText("Beta gone")).toBeVisible()
     expect(screen.queryByText("Alpha archived")).toBeNull()
+    expect(screen.queryByText("Alpha archived claude")).toBeNull()
     // The not-in-codeg folder carries the "New" badge; the existing one not.
     const alphaHeader = screen
       .getByText("alpha")
@@ -179,7 +181,7 @@ describe("ImportSessionsWindow", () => {
     expect(alphaHeader.textContent).toContain("New")
     // Summary footer counts come from the scan payload.
     expect(
-      screen.getByText("6 sessions · 4 importable · 2 folders")
+      screen.getByText("7 sessions · 5 importable · 2 folders")
     ).toBeVisible()
     expect(screen.getByText("1 without a project folder skipped")).toBeVisible()
   })
@@ -269,12 +271,14 @@ describe("ImportSessionsWindow", () => {
     await screen.findByText("alpha")
 
     expect(screen.queryByText("Alpha archived")).toBeNull()
+    expect(screen.queryByText("Alpha archived claude")).toBeNull()
     expect(screen.getByText("Alpha one")).toBeVisible()
 
     const switches = screen.getAllByRole("switch")
     fireEvent.click(switches[1])
     expect(screen.getByText("Alpha archived")).toBeVisible()
-    expect(screen.getByText("Archived")).toBeVisible()
+    expect(screen.getByText("Alpha archived claude")).toBeVisible()
+    expect(screen.getAllByText("Archived").length).toBeGreaterThanOrEqual(2)
   })
 
   it("imports exactly the selected keys and shows the summary", async () => {

--- a/src/components/import-sessions/import-sessions-window.tsx
+++ b/src/components/import-sessions/import-sessions-window.tsx
@@ -92,6 +92,7 @@ export function ImportSessionsWindow({
   const [search, setSearch] = useState("")
   const [agentFilter, setAgentFilter] = useState<AgentType | "all">("all")
   const [onlyImportable, setOnlyImportable] = useState(false)
+  const [hideArchived, setHideArchived] = useState(true)
   const [importResult, setImportResult] = useState<ImportSelectedResult | null>(
     null
   )
@@ -224,6 +225,9 @@ export function ImportSessionsWindow({
       if (onlyImportable) {
         sessions = sessions.filter((s) => s.status === "new")
       }
+      if (hideArchived) {
+        sessions = sessions.filter((s) => !s.archived)
+      }
       if (query) {
         const folderMatches =
           folder.path.toLowerCase().includes(query) ||
@@ -237,7 +241,7 @@ export function ImportSessionsWindow({
       if (sessions.length > 0) entries.push({ folder, sessions })
     }
     return entries
-  }, [scan, search, agentFilter, onlyImportable])
+  }, [scan, search, agentFilter, onlyImportable, hideArchived])
 
   const rows = useMemo(() => {
     const out: Row[] = []
@@ -530,6 +534,14 @@ export function ImportSessionsWindow({
             disabled={busy}
           />
           {t("onlyImportable")}
+        </label>
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Switch
+            checked={hideArchived}
+            onCheckedChange={setHideArchived}
+            disabled={busy}
+          />
+          {t("hideArchived")}
         </label>
         <div className="flex-1" />
         <Button

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "ابحث في العنوان أو المسار…",
     "allAgents": "جميع الوكلاء",
     "onlyImportable": "القابلة للاستيراد فقط",
+    "hideArchived": "إخفاء المؤرشفة",
+    "statusArchived": "مؤرشفة",
     "selectAll": "تحديد الكل",
     "clearSelection": "مسح",
     "expandAll": "توسيع الكل",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "Titel oder Pfad suchen…",
     "allAgents": "Alle Agenten",
     "onlyImportable": "Nur importierbare",
+    "hideArchived": "Archivierte ausblenden",
+    "statusArchived": "Archiviert",
     "selectAll": "Alle auswählen",
     "clearSelection": "Leeren",
     "expandAll": "Alle ausklappen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "Search title or path…",
     "allAgents": "All agents",
     "onlyImportable": "Importable only",
+    "hideArchived": "Hide archived",
+    "statusArchived": "Archived",
     "selectAll": "Select all",
     "clearSelection": "Clear",
     "expandAll": "Expand all",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "Buscar título o ruta…",
     "allAgents": "Todos los agentes",
     "onlyImportable": "Solo importables",
+    "hideArchived": "Ocultar archivadas",
+    "statusArchived": "Archivada",
     "selectAll": "Seleccionar todo",
     "clearSelection": "Limpiar",
     "expandAll": "Expandir todo",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "Rechercher un titre ou un chemin…",
     "allAgents": "Tous les agents",
     "onlyImportable": "Importables uniquement",
+    "hideArchived": "Masquer les archivées",
+    "statusArchived": "Archivée",
     "selectAll": "Tout sélectionner",
     "clearSelection": "Effacer",
     "expandAll": "Tout développer",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "タイトルまたはパスを検索…",
     "allAgents": "すべてのエージェント",
     "onlyImportable": "インポート可能のみ",
+    "hideArchived": "アーカイブを隠す",
+    "statusArchived": "アーカイブ",
     "selectAll": "すべて選択",
     "clearSelection": "クリア",
     "expandAll": "すべて展開",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "제목 또는 경로 검색…",
     "allAgents": "모든 에이전트",
     "onlyImportable": "가져오기 가능만",
+    "hideArchived": "보관됨 숨기기",
+    "statusArchived": "보관됨",
     "selectAll": "모두 선택",
     "clearSelection": "지우기",
     "expandAll": "모두 펼치기",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "Pesquisar título ou caminho…",
     "allAgents": "Todos os agentes",
     "onlyImportable": "Somente importáveis",
+    "hideArchived": "Ocultar arquivadas",
+    "statusArchived": "Arquivada",
     "selectAll": "Selecionar tudo",
     "clearSelection": "Limpar",
     "expandAll": "Expandir tudo",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "搜索标题或路径…",
     "allAgents": "全部智能体",
     "onlyImportable": "仅显示可导入",
+    "hideArchived": "隐藏已归档",
+    "statusArchived": "已归档",
     "selectAll": "全选",
     "clearSelection": "清空",
     "expandAll": "全部展开",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1521,6 +1521,8 @@
     "searchPlaceholder": "搜尋標題或路徑…",
     "allAgents": "全部智慧代理",
     "onlyImportable": "僅顯示可匯入",
+    "hideArchived": "隱藏已封存",
+    "statusArchived": "已封存",
     "selectAll": "全選",
     "clearSelection": "清空",
     "expandAll": "全部展開",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -513,6 +513,8 @@ export interface ScanSession {
   model: string | null
   git_branch: string | null
   status: ScanSessionStatus
+  /** Originating CLI archived this session. Missing on old servers = false. */
+  archived?: boolean
 }
 
 /** Mirrors Rust `ScanFolder`: sessions sharing a normalize-matched cwd, plus


### PR DESCRIPTION
Import now keeps sessions the originating CLI marked archived, instead of dropping them.

- **Codex** archived flags come from `state_*.sqlite` `threads.archived`.
- **Hermes** already stored `sessions.archived` but hid those rows.
- **Claude**: local Claude Code JSONL has no archive field. Claude Desktop Code sessions persist `isArchived` in `%AppData%/Claude/claude-code-sessions/**/local_{id}.json` (anthropics/claude-code#24534). Import reads that field from JSONL when present and overlays Desktop sidecar ids.

The picker badges them and hides them behind a Hide archived filter that is on by default.

Includes a scan-path test and an import-window filter test (Codex + Claude rows).