### PR TITLE
fix(grok): send native image blocks on extra Grok slots too

### DIFF
--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -3868,7 +3868,7 @@ fn effective_prompt_capabilities(
     capabilities: &sacp::schema::PromptCapabilities,
 ) -> PromptCapabilitiesInfo {
     PromptCapabilitiesInfo {
-        image: capabilities.image || agent_type == AgentType::Grok,
+        image: capabilities.image || agent_type.uses_grok_image_sidecar(),
         audio: capabilities.audio,
         embedded_context: capabilities.embedded_context,
     }
@@ -8013,7 +8013,7 @@ fn prepare_agent_bound_prompt(
     delegation_enabled: bool,
 ) -> Vec<ContentBlock> {
     append_agent_routes(&mut blocks, delegation_enabled);
-    if agent_type == AgentType::Grok {
+    if agent_type.uses_grok_image_sidecar() {
         blocks = normalize_grok_image_blocks(blocks);
     }
     map_prompt_blocks(blocks)

--- a/src-tauri/src/models/agent.rs
+++ b/src-tauri/src/models/agent.rs
@@ -68,6 +68,21 @@ impl AgentType {
         matches!(self, AgentType::Custom(_))
     }
 
+    /// Grok's initialize still advertises `image: false`. Native Image
+    /// blocks run its describe sidecar; a Resource blob does not. Built-in
+    /// Grok and extra isolated Grok slots (`custom:grok-2`, …) share that
+    /// sidecar. Other custom agents are left on the advertised bit.
+    pub fn uses_grok_image_sidecar(&self) -> bool {
+        match self {
+            AgentType::Grok => true,
+            AgentType::Custom(id) => {
+                let id = id.to_ascii_lowercase();
+                id == "grok" || id.starts_with("grok-") || id.starts_with("grok_")
+            }
+            _ => false,
+        }
+    }
+
     /// The custom agent's registry id, or `None` for a built-in.
     pub fn custom_id(&self) -> Option<&'static str> {
         match self {
@@ -281,6 +296,23 @@ mod tests {
             assert!(!agent.is_custom());
             assert_eq!(agent.custom_id(), None);
         }
+    }
+
+    #[test]
+    fn grok_image_sidecar_covers_builtin_and_extra_slots() {
+        assert!(AgentType::Grok.uses_grok_image_sidecar());
+        assert!(
+            AgentType::custom("grok-2")
+                .unwrap()
+                .uses_grok_image_sidecar()
+        );
+        assert!(
+            AgentType::custom("grok_work")
+                .unwrap()
+                .uses_grok_image_sidecar()
+        );
+        assert!(!AgentType::ClaudeCode.uses_grok_image_sidecar());
+        assert!(!AgentType::custom("goose").unwrap().uses_grok_image_sidecar());
     }
 
     #[test]

--- a/src/components/chat/composer/use-composer-attachments.ts
+++ b/src/components/chat/composer/use-composer-attachments.ts
@@ -52,6 +52,7 @@ import type { PromptCapabilitiesInfo, PromptInputBlock } from "@/lib/types"
 import type { Editor } from "@tiptap/core"
 
 import {
+  agentUsesGrokImageSidecar,
   imageAttachmentToPromptBlock,
   type ImageInputAttachment,
   type InputAttachment,
@@ -106,6 +107,8 @@ export interface ComposerAttachmentsOptions {
   disabled?: boolean
   /** Decides whether images may be attached at all, and how they are encoded. */
   promptCapabilities: Pick<PromptCapabilitiesInfo, "image" | "embedded_context">
+  /** Used to force Grok Image blocks even when initialize still says image:false. */
+  agentType?: string | null
   /** Groups uploads with the session/tab that owns them (quota + cleanup). */
   attachmentTabId?: string | null
   /** Start directory for the native picker and the server file browser. */
@@ -178,6 +181,7 @@ export function useComposerAttachments({
   containerRef,
   disabled = false,
   promptCapabilities,
+  agentType = null,
   attachmentTabId = null,
   defaultPath = null,
   logLabel = "Composer",
@@ -203,7 +207,9 @@ export function useComposerAttachments({
   // (`image`) or as an embedded resource blob (`embedded_context`, what an
   // agent that advertises `image: false` but `embeddedContext: true` takes).
   const canAttachImages =
-    promptCapabilities.image || promptCapabilities.embedded_context
+    promptCapabilities.image ||
+    promptCapabilities.embedded_context ||
+    agentUsesGrokImageSidecar(agentType)
 
   const [attachments, setAttachments] = useState<InputAttachment[]>([])
   const embeddedPayloadsRef = useRef<Map<string, PromptInputBlock>>(new Map())
@@ -1335,9 +1341,9 @@ export function useComposerAttachments({
   const imagePromptBlocks = useCallback(
     (): PromptInputBlock[] =>
       imageAttachments.map((attachment) =>
-        imageAttachmentToPromptBlock(attachment, promptCapabilities)
+        imageAttachmentToPromptBlock(attachment, promptCapabilities, agentType)
       ),
-    [imageAttachments, promptCapabilities]
+    [agentType, imageAttachments, promptCapabilities]
   )
 
   return {

--- a/src/components/chat/message-input-attachments.test.ts
+++ b/src/components/chat/message-input-attachments.test.ts
@@ -41,10 +41,20 @@ describe("imageAttachmentToPromptBlock", () => {
     expect(block).toMatchObject({ type: "image", uri: null })
   })
 
-  it("emits an embedded resource blob when the agent only accepts embedded context (Grok)", () => {
-    // Grok advertises image:false, embeddedContext:true — the image rides along
-    // as an embedded resource blob (same bytes, image mime) rather than an
-    // unsupported native image block.
+  it("still emits a native image block for Grok when initialize lies (image:false)", () => {
+    const block = imageAttachmentToPromptBlock(
+      image(),
+      { image: false, embedded_context: true },
+      "grok"
+    )
+    expect(block).toMatchObject({
+      type: "image",
+      mime_type: "image/png",
+      data: "QkFTRTY0",
+    })
+  })
+
+  it("emits an embedded resource blob when a non-Grok agent only accepts embedded context", () => {
     const block = imageAttachmentToPromptBlock(image(), {
       image: false,
       embedded_context: true,

--- a/src/components/chat/message-input-attachments.ts
+++ b/src/components/chat/message-input-attachments.ts
@@ -69,11 +69,22 @@ export type InputAttachment = ResourceInputAttachment | ImageInputAttachment
  * `clipboard://` identifier derived from its name + id, so the emitted block is
  * reproducible without a random source (and unit-testable).
  */
+/** Built-in `grok` plus extra isolated slots (`custom:grok-2`, …). */
+export function agentUsesGrokImageSidecar(
+  agentType?: string | null
+): boolean {
+  if (!agentType) return false
+  const raw = agentType.toLowerCase()
+  const id = raw.startsWith("custom:") ? raw.slice("custom:".length) : raw
+  return id === "grok" || id.startsWith("grok-") || id.startsWith("grok_")
+}
+
 export function imageAttachmentToPromptBlock(
   attachment: ImageInputAttachment,
-  caps: Pick<PromptCapabilitiesInfo, "image" | "embedded_context">
+  caps: Pick<PromptCapabilitiesInfo, "image" | "embedded_context">,
+  agentType?: string | null
 ): PromptInputBlock {
-  if (caps.image) {
+  if (caps.image || agentUsesGrokImageSidecar(agentType)) {
     return {
       type: "image",
       data: attachment.data,

--- a/src/components/chat/message-input-attachments.ts
+++ b/src/components/chat/message-input-attachments.ts
@@ -70,9 +70,7 @@ export type InputAttachment = ResourceInputAttachment | ImageInputAttachment
  * reproducible without a random source (and unit-testable).
  */
 /** Built-in `grok` plus extra isolated slots (`custom:grok-2`, …). */
-export function agentUsesGrokImageSidecar(
-  agentType?: string | null
-): boolean {
+export function agentUsesGrokImageSidecar(agentType?: string | null): boolean {
   if (!agentType) return false
   const raw = agentType.toLowerCase()
   const id = raw.startsWith("custom:") ? raw.slice("custom:".length) : raw

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -388,6 +388,7 @@ export function MessageInput({
     containerRef,
     disabled,
     promptCapabilities,
+    agentType,
     attachmentTabId,
     defaultPath,
     logLabel: "MessageInput",

--- a/src/components/tasks/task-message-composer.tsx
+++ b/src/components/tasks/task-message-composer.tsx
@@ -174,6 +174,7 @@ export function TaskMessageComposer({
     editorRef,
     containerRef,
     promptCapabilities,
+    agentType,
     defaultPath: folderPath,
     logLabel: "TaskComposer",
   })


### PR DESCRIPTION
Built-in Grok already forces `image: true` and `normalize_grok_image_blocks` on main. Extra isolated slots (`custom:grok-2`, …) are `AgentType::Custom`, so they still advertised `image: false` and sent Resource blobs. Grok dumps those as binary and invents a description.

This treats `custom:grok-*` the same as built-in Grok on both the capability bit and dispatch. The composer also emits a native Image block for those agent ids even if initialize still lies.

Does not change Claude / Codex / other custom agents. No secrets. One concern.