### PR TITLE
feat(claude): add permission mode on the Agents settings page

### DIFF
--- a/src/components/settings/acp-agent-settings.test.tsx
+++ b/src/components/settings/acp-agent-settings.test.tsx
@@ -19,7 +19,10 @@ import {
   importantEnvKeysByAgent,
   importantFieldsFor,
   inferGrokMode,
+  applyClaudePermissionModeToConfigText,
   materializeClaudeHardeningFlags,
+  normalizeClaudePermissionMode,
+  readClaudePermissionMode,
   patchCodexConfigTomlText,
   patchEnvByImportantKey,
   patchImportantConfigText,
@@ -1292,6 +1295,74 @@ describe("materializeClaudeHardeningFlags — save-time toggle defaults", () => 
     )
     expect(configText).toBe(invalid)
     expect(envText).toBe("EXISTING=1")
+  })
+})
+
+describe("Claude permission mode — official settings.json defaultMode", () => {
+  it("maps the documented manual alias to default", () => {
+    expect(normalizeClaudePermissionMode("manual")).toBe("default")
+    expect(normalizeClaudePermissionMode("bypassPermissions")).toBe(
+      "bypassPermissions"
+    )
+    expect(normalizeClaudePermissionMode("nope")).toBe("")
+  })
+
+  it("reads permissions.defaultMode from a nested settings object", () => {
+    expect(
+      readClaudePermissionMode({
+        permissions: { defaultMode: "acceptEdits", allow: ["Bash"] },
+      })
+    ).toBe("acceptEdits")
+    expect(readClaudePermissionMode({ theme: "dark" })).toBe("")
+  })
+
+  it("sets bypass without dropping existing allow/deny rules", () => {
+    const base = JSON.stringify({
+      theme: "dark",
+      permissions: { allow: ["Bash"], deny: ["Read(./.env)"] },
+    })
+    const { configText, recoveredFromInvalid } =
+      applyClaudePermissionModeToConfigText(base, "bypassPermissions")
+    expect(recoveredFromInvalid).toBe(false)
+    const parsed = JSON.parse(configText) as {
+      theme?: string
+      skipDangerousModePermissionPrompt?: boolean
+      permissions?: { defaultMode?: string; allow?: string[]; deny?: string[] }
+    }
+    expect(parsed.theme).toBe("dark")
+    expect(parsed.permissions?.defaultMode).toBe("bypassPermissions")
+    expect(parsed.permissions?.allow).toEqual(["Bash"])
+    expect(parsed.permissions?.deny).toEqual(["Read(./.env)"])
+    expect(parsed.skipDangerousModePermissionPrompt).toBe(true)
+  })
+
+  it("clears defaultMode but keeps other permission rules", () => {
+    const base = JSON.stringify({
+      permissions: { defaultMode: "bypassPermissions", allow: ["Bash"] },
+      skipDangerousModePermissionPrompt: true,
+    })
+    const { configText } = applyClaudePermissionModeToConfigText(base, "")
+    const parsed = JSON.parse(configText) as {
+      skipDangerousModePermissionPrompt?: boolean
+      permissions?: { defaultMode?: string; allow?: string[] }
+    }
+    expect(parsed.permissions?.defaultMode).toBeUndefined()
+    expect(parsed.permissions?.allow).toEqual(["Bash"])
+    expect(parsed.skipDangerousModePermissionPrompt).toBe(true)
+  })
+
+  it("drops an empty permissions object when unsetting the only key", () => {
+    const base = JSON.stringify({
+      permissions: { defaultMode: "auto" },
+      theme: "dark",
+    })
+    const { configText } = applyClaudePermissionModeToConfigText(base, "")
+    const parsed = JSON.parse(configText) as {
+      theme?: string
+      permissions?: unknown
+    }
+    expect(parsed.theme).toBe("dark")
+    expect(parsed.permissions).toBeUndefined()
   })
 })
 

--- a/src/components/settings/acp-agent-settings.test.tsx
+++ b/src/components/settings/acp-agent-settings.test.tsx
@@ -1304,6 +1304,8 @@ describe("Claude permission mode — official settings.json defaultMode", () => 
     expect(normalizeClaudePermissionMode("bypassPermissions")).toBe(
       "bypassPermissions"
     )
+    expect(normalizeClaudePermissionMode("plan")).toBe("plan")
+    expect(normalizeClaudePermissionMode("dontAsk")).toBe("dontAsk")
     expect(normalizeClaudePermissionMode("nope")).toBe("")
   })
 
@@ -1333,7 +1335,19 @@ describe("Claude permission mode — official settings.json defaultMode", () => 
     expect(parsed.permissions?.defaultMode).toBe("bypassPermissions")
     expect(parsed.permissions?.allow).toEqual(["Bash"])
     expect(parsed.permissions?.deny).toEqual(["Read(./.env)"])
-    expect(parsed.skipDangerousModePermissionPrompt).toBe(true)
+    expect(parsed.skipDangerousModePermissionPrompt).toBeUndefined()
+  })
+
+  it("round-trips plan without turning it into unset", () => {
+    const { configText } = applyClaudePermissionModeToConfigText(
+      JSON.stringify({ permissions: { defaultMode: "plan", allow: ["Bash"] } }),
+      "plan"
+    )
+    const parsed = JSON.parse(configText) as {
+      permissions?: { defaultMode?: string; allow?: string[] }
+    }
+    expect(parsed.permissions?.defaultMode).toBe("plan")
+    expect(parsed.permissions?.allow).toEqual(["Bash"])
   })
 
   it("clears defaultMode but keeps other permission rules", () => {

--- a/src/components/settings/acp-agent-settings.tsx
+++ b/src/components/settings/acp-agent-settings.tsx
@@ -230,6 +230,10 @@ interface AgentDraft {
   claudeCustomModelOption: string
   claudeCustomModelOptionName: string
   claudeCustomModelOptionDescription: string
+  // Claude Code `permissions.defaultMode` in ~/.claude/settings.json. Empty
+  // string = unset (Claude's own default). Distinct from the per-chat
+  // composer dropdown: this is the session start default.
+  claudePermissionMode: ClaudePermissionMode
   // Claude Code hardening toggles (native config `env`). `claudeSendAttributionHeader`
   // → CLAUDE_CODE_ATTRIBUTION_HEADER (on="1"/off="0"), default off (don't send).
   // `claudeDisableNonessentialTraffic` → CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC,
@@ -632,6 +636,92 @@ const CLAUDE_ENV_FLAG_OFF = "0"
 const CLAUDE_SEND_ATTRIBUTION_HEADER_DEFAULT = false
 const CLAUDE_DISABLE_NONESSENTIAL_TRAFFIC_DEFAULT = true
 
+// Official Claude Code permission modes written to
+// `permissions.defaultMode` in ~/.claude/settings.json. Empty string means
+// the key is unset (Claude picks its own start mode). `manual` is the
+// documented alias of `default` (Ask every time).
+type ClaudePermissionMode =
+  | ""
+  | "default"
+  | "acceptEdits"
+  | "auto"
+  | "bypassPermissions"
+
+const CLAUDE_PERMISSION_UNSET = "__codeg_claude_perm_unset__"
+
+const CLAUDE_PERMISSION_MODE_VALUES: ReadonlyArray<
+  Exclude<ClaudePermissionMode, "">
+> = ["default", "acceptEdits", "auto", "bypassPermissions"]
+
+export function normalizeClaudePermissionMode(
+  value: unknown
+): ClaudePermissionMode {
+  if (typeof value !== "string") return ""
+  const normalized = value.trim()
+  if (normalized === "manual") return "default"
+  if (
+    normalized === "default" ||
+    normalized === "acceptEdits" ||
+    normalized === "auto" ||
+    normalized === "bypassPermissions"
+  ) {
+    return normalized
+  }
+  return ""
+}
+
+export function readClaudePermissionMode(
+  config: Record<string, unknown>
+): ClaudePermissionMode {
+  const perms = config.permissions
+  if (!perms || typeof perms !== "object" || Array.isArray(perms)) return ""
+  return normalizeClaudePermissionMode(
+    (perms as Record<string, unknown>).defaultMode
+  )
+}
+
+/**
+ * Write or clear `permissions.defaultMode` in Claude's native settings.json
+ * text, preserving other permission rules (allow/deny/ask). Setting
+ * `bypassPermissions` also stamps `skipDangerousModePermissionPrompt` so
+ * Claude does not pop the extra "are you sure" dialog. Clearing the mode
+ * leaves that skip flag alone. Pure — shared by the settings handler and tests.
+ */
+export function applyClaudePermissionModeToConfigText(
+  configText: string,
+  mode: ClaudePermissionMode
+): { configText: string; recoveredFromInvalid: boolean } {
+  const parseResult = parseConfigJsonText(configText)
+  const config: Record<string, unknown> = parseResult.error
+    ? {}
+    : { ...parseResult.config }
+  const existingPerms =
+    config.permissions &&
+    typeof config.permissions === "object" &&
+    !Array.isArray(config.permissions)
+      ? { ...(config.permissions as Record<string, unknown>) }
+      : {}
+  if (mode) {
+    existingPerms.defaultMode = mode
+    config.permissions = existingPerms
+    if (mode === "bypassPermissions") {
+      config.skipDangerousModePermissionPrompt = true
+    }
+  } else {
+    delete existingPerms.defaultMode
+    if (Object.keys(existingPerms).length === 0) {
+      delete config.permissions
+    } else {
+      config.permissions = existingPerms
+    }
+  }
+  return {
+    configText:
+      Object.keys(config).length === 0 ? "" : JSON.stringify(config, null, 2),
+    recoveredFromInvalid: Boolean(parseResult.error),
+  }
+}
+
 const GEMINI_AUTH_MODES = [
   "custom",
   "login_google",
@@ -979,6 +1069,7 @@ function extractImportantConfigValues(
   claudeCustomModelOption: string
   claudeCustomModelOptionName: string
   claudeCustomModelOptionDescription: string
+  claudePermissionMode: ClaudePermissionMode
   claudeSendAttributionHeader: boolean
   claudeDisableNonessentialTraffic: boolean
   configError: string | null
@@ -1024,6 +1115,9 @@ function extractImportantConfigValues(
     CLAUDE_MODEL_ENV_KEYS.claudeCustomModelOptionDescription,
   ])
 
+  const claudePermissionMode: ClaudePermissionMode =
+    agentType === "claude_code" ? readClaudePermissionMode(config) : ""
+
   // Present in env → on iff value is "1"; absent → the toggle's default.
   const attributionRaw = findEnvValue(mergedEnv, [
     CLAUDE_ATTRIBUTION_HEADER_ENV_KEY,
@@ -1063,6 +1157,7 @@ function extractImportantConfigValues(
       agentType === "claude_code" ? claudeCustomModelOptionName : "",
     claudeCustomModelOptionDescription:
       agentType === "claude_code" ? claudeCustomModelOptionDescription : "",
+    claudePermissionMode,
     claudeSendAttributionHeader,
     claudeDisableNonessentialTraffic,
     configError: parseResult.error,
@@ -3722,6 +3817,7 @@ function buildAgentDraft(agent: AcpAgentInfo): AgentDraft {
     claudeCustomModelOptionName: important.claudeCustomModelOptionName,
     claudeCustomModelOptionDescription:
       important.claudeCustomModelOptionDescription,
+    claudePermissionMode: important.claudePermissionMode,
     claudeSendAttributionHeader: important.claudeSendAttributionHeader,
     claudeDisableNonessentialTraffic:
       important.claudeDisableNonessentialTraffic,
@@ -5729,6 +5825,7 @@ export function AcpAgentSettings() {
         claudeCustomModelOptionName: important.claudeCustomModelOptionName,
         claudeCustomModelOptionDescription:
           important.claudeCustomModelOptionDescription,
+        claudePermissionMode: important.claudePermissionMode,
         claudeSendAttributionHeader: important.claudeSendAttributionHeader,
         claudeDisableNonessentialTraffic:
           important.claudeDisableNonessentialTraffic,
@@ -5766,6 +5863,34 @@ export function AcpAgentSettings() {
           configText: nextJson.configText,
         }
       })
+    },
+    [selectedAgent, selectedDraft, t, updateSelectedDraft]
+  )
+
+  const handleClaudePermissionModeChange = useCallback(
+    (nextValue: ClaudePermissionMode) => {
+      if (
+        !selectedAgent ||
+        !selectedDraft ||
+        selectedAgent.agent_type !== "claude_code"
+      )
+        return
+      const next = applyClaudePermissionModeToConfigText(
+        selectedDraft.configText,
+        nextValue
+      )
+      if (next.recoveredFromInvalid) {
+        toast.warning(t("warnings.nativeJsonRecoveredStructured"))
+      }
+      setConfigErrors((prev) => ({
+        ...prev,
+        [selectedAgent.agent_type]: null,
+      }))
+      updateSelectedDraft((current) => ({
+        ...current,
+        claudePermissionMode: nextValue,
+        configText: next.configText,
+      }))
     },
     [selectedAgent, selectedDraft, t, updateSelectedDraft]
   )
@@ -11687,6 +11812,46 @@ supports_websockets = true`}
                           </div>
                           <p className="text-2xs text-muted-foreground">
                             {t("claude.customModelOptionHint")}
+                          </p>
+                        </div>
+                        <div className="space-y-1.5">
+                          <label className="text-2xs text-muted-foreground">
+                            {t("claude.permissionModeLabel")}
+                          </label>
+                          <Select
+                            value={
+                              selectedDraft.claudePermissionMode ||
+                              CLAUDE_PERMISSION_UNSET
+                            }
+                            onValueChange={(nextValue) => {
+                              handleClaudePermissionModeChange(
+                                nextValue === CLAUDE_PERMISSION_UNSET
+                                  ? ""
+                                  : (nextValue as ClaudePermissionMode)
+                              )
+                            }}
+                          >
+                            <SelectTrigger
+                              className="w-full"
+                              aria-label={t("claude.permissionModeAria")}
+                            >
+                              <SelectValue
+                                placeholder={t("claude.permissionUnset")}
+                              />
+                            </SelectTrigger>
+                            <SelectContent align="start">
+                              <SelectItem value={CLAUDE_PERMISSION_UNSET}>
+                                {t("claude.permissionUnset")}
+                              </SelectItem>
+                              {CLAUDE_PERMISSION_MODE_VALUES.map((value) => (
+                                <SelectItem key={value} value={value}>
+                                  {t(`claude.permission_${value}`)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <p className="text-2xs text-muted-foreground">
+                            {t("claude.permissionModeHint")}
                           </p>
                         </div>
                         <div className="space-y-1.5">

--- a/src/components/settings/acp-agent-settings.tsx
+++ b/src/components/settings/acp-agent-settings.tsx
@@ -37,6 +37,7 @@ import {
 } from "lucide-react"
 import { parse as parseTomlDocument } from "smol-toml"
 import { isDesktop, openUrl } from "@/lib/platform"
+import { saveModeIdPreference } from "@/lib/selector-prefs-storage"
 import { getActiveRemoteConnectionId } from "@/lib/transport"
 import { toast } from "sonner"
 import {
@@ -231,8 +232,9 @@ interface AgentDraft {
   claudeCustomModelOptionName: string
   claudeCustomModelOptionDescription: string
   // Claude Code `permissions.defaultMode` in ~/.claude/settings.json. Empty
-  // string = unset (Claude's own default). Distinct from the per-chat
-  // composer dropdown: this is the session start default.
+  // string = unset (leave the CLI default and CodeG's composer last-used).
+  // A chosen value is also written to `codeg:selector-prefs` on save so a
+  // stickier composer pick cannot silently win on connect.
   claudePermissionMode: ClaudePermissionMode
   // Claude Code hardening toggles (native config `env`). `claudeSendAttributionHeader`
   // → CLAUDE_CODE_ATTRIBUTION_HEADER (on="1"/off="0"), default off (don't send).
@@ -639,19 +641,29 @@ const CLAUDE_DISABLE_NONESSENTIAL_TRAFFIC_DEFAULT = true
 // Official Claude Code permission modes written to
 // `permissions.defaultMode` in ~/.claude/settings.json. Empty string means
 // the key is unset (Claude picks its own start mode). `manual` is the
-// documented alias of `default` (Ask every time).
+// documented alias of `default`. `plan` and `dontAsk` are valid disk values
+// we do not offer as options; they must round-trip so the control cannot
+// silently replace them with unset.
 type ClaudePermissionMode =
   | ""
   | "default"
   | "acceptEdits"
   | "auto"
   | "bypassPermissions"
+  | "plan"
+  | "dontAsk"
 
 const CLAUDE_PERMISSION_UNSET = "__codeg_claude_perm_unset__"
 
 const CLAUDE_PERMISSION_MODE_VALUES: ReadonlyArray<
-  Exclude<ClaudePermissionMode, "">
+  "default" | "acceptEdits" | "auto" | "bypassPermissions"
 > = ["default", "acceptEdits", "auto", "bypassPermissions"]
+
+function isOfferedClaudePermissionMode(
+  mode: ClaudePermissionMode
+): mode is (typeof CLAUDE_PERMISSION_MODE_VALUES)[number] {
+  return (CLAUDE_PERMISSION_MODE_VALUES as readonly string[]).includes(mode)
+}
 
 export function normalizeClaudePermissionMode(
   value: unknown
@@ -663,7 +675,9 @@ export function normalizeClaudePermissionMode(
     normalized === "default" ||
     normalized === "acceptEdits" ||
     normalized === "auto" ||
-    normalized === "bypassPermissions"
+    normalized === "bypassPermissions" ||
+    normalized === "plan" ||
+    normalized === "dontAsk"
   ) {
     return normalized
   }
@@ -682,10 +696,12 @@ export function readClaudePermissionMode(
 
 /**
  * Write or clear `permissions.defaultMode` in Claude's native settings.json
- * text, preserving other permission rules (allow/deny/ask). Setting
- * `bypassPermissions` also stamps `skipDangerousModePermissionPrompt` so
- * Claude does not pop the extra "are you sure" dialog. Clearing the mode
- * leaves that skip flag alone. Pure — shared by the settings handler and tests.
+ * text, preserving other permission rules (allow/deny/ask). Never writes
+ * `skipDangerousModePermissionPrompt`: that flag is a record of the user
+ * accepting Claude Code's own bypass dialog, not a behavior switch, and
+ * forging it from this dropdown would suppress a safety interlock outside
+ * codeg. Clearing the mode also leaves any existing skip flag alone.
+ * Pure, shared by the settings handler and tests.
  */
 export function applyClaudePermissionModeToConfigText(
   configText: string,
@@ -704,9 +720,6 @@ export function applyClaudePermissionModeToConfigText(
   if (mode) {
     existingPerms.defaultMode = mode
     config.permissions = existingPerms
-    if (mode === "bypassPermissions") {
-      config.skipDangerousModePermissionPrompt = true
-    }
   } else {
     delete existingPerms.defaultMode
     if (Object.keys(existingPerms).length === 0) {
@@ -11848,6 +11861,16 @@ supports_websockets = true`}
                                   {t(`claude.permission_${value}`)}
                                 </SelectItem>
                               ))}
+                              {selectedDraft.claudePermissionMode &&
+                              !isOfferedClaudePermissionMode(
+                                selectedDraft.claudePermissionMode
+                              ) ? (
+                                <SelectItem
+                                  value={selectedDraft.claudePermissionMode}
+                                >
+                                  {selectedDraft.claudePermissionMode}
+                                </SelectItem>
+                              ) : null}
                             </SelectContent>
                           </Select>
                           <p className="text-2xs text-muted-foreground">
@@ -12005,6 +12028,21 @@ supports_websockets = true`}
                               )
                             )
                             .then(() => {
+                              // A chosen Claude default must also become CodeG's
+                              // new-chat composer default. Connect applies
+                              // selector-prefs after the adapter reads
+                              // settings.json, so without this write-through a
+                              // stickier last-used mode silently wins. Unset
+                              // leaves the composer last-used alone.
+                              if (
+                                selectedAgent.agent_type === "claude_code" &&
+                                selectedDraft.claudePermissionMode
+                              ) {
+                                saveModeIdPreference(
+                                  "claude_code",
+                                  selectedDraft.claudePermissionMode
+                                )
+                              }
                               // Reflect the provider-authoritative rewrite AND the
                               // materialized hardening flags in the editors so the
                               // textareas don't show stale values until reload —

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "إرسال معرّف الإسناد/الفوترة إلى الواجهة",
       "sendAttributionHeaderAria": "إرسال معرّف الإسناد/الفوترة الخاص بـ Claude Code إلى الواجهة",
       "disableNonessentialTraffic": "تعطيل القياس عن بُعد أو طلبات الشبكة غير الضرورية",
-      "disableNonessentialTrafficAria": "تعطيل القياس عن بُعد أو طلبات الشبكة غير الضرورية في Claude Code"
+      "disableNonessentialTrafficAria": "تعطيل القياس عن بُعد أو طلبات الشبكة غير الضرورية في Claude Code",
+      "permissionModeLabel": "وضع الأذونات",
+      "permissionModeHint": "تبدأ محادثات Claude الجديدة بهذا الوضع. تُحفظ كـ permissions.defaultMode في ~/.claude/settings.json.",
+      "permissionModeAria": "وضع أذونات Claude Code",
+      "permissionUnset": "استخدام الافتراضي",
+      "permission_default": "السؤال في كل مرة",
+      "permission_acceptEdits": "الموافقة التلقائية على التعديلات",
+      "permission_auto": "موافقة تلقائية ذكية",
+      "permission_bypassPermissions": "السماح دائماً"
     },
     "dialogs": {
       "confirmDeleteProvider": "حذف المزود {providerId}؟",

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "تعطيل القياس عن بُعد أو طلبات الشبكة غير الضرورية",
       "disableNonessentialTrafficAria": "تعطيل القياس عن بُعد أو طلبات الشبكة غير الضرورية في Claude Code",
       "permissionModeLabel": "وضع الأذونات",
-      "permissionModeHint": "تبدأ محادثات Claude الجديدة بهذا الوضع. تُحفظ كـ permissions.defaultMode في ~/.claude/settings.json.",
+      "permissionModeHint": "يكتب permissions.defaultMode لجلسات CLI الجديدة. الوضع المختار يُحفظ أيضاً كافتراضي composer في CodeG حتى لا يفوز اختيار دردشة سابق بصمت عند الاتصال. استخدام الافتراضي يُبقي آخر قيمة في composer كما هي.",
       "permissionModeAria": "وضع أذونات Claude Code",
       "permissionUnset": "استخدام الافتراضي",
-      "permission_default": "السؤال في كل مرة",
-      "permission_acceptEdits": "الموافقة التلقائية على التعديلات",
-      "permission_auto": "موافقة تلقائية ذكية",
-      "permission_bypassPermissions": "السماح دائماً"
+      "permission_default": "يدوي",
+      "permission_acceptEdits": "قبول التعديلات",
+      "permission_auto": "تلقائي",
+      "permission_bypassPermissions": "تجاوز الأذونات"
     },
     "dialogs": {
       "confirmDeleteProvider": "حذف المزود {providerId}؟",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "Telemetrie oder überflüssige Netzwerkanfragen deaktivieren",
       "disableNonessentialTrafficAria": "Telemetrie oder überflüssige Netzwerkanfragen von Claude Code deaktivieren",
       "permissionModeLabel": "Berechtigungsmodus",
-      "permissionModeHint": "Neue Claude-Chats starten in diesem Modus. Wird als permissions.defaultMode in ~/.claude/settings.json gespeichert.",
+      "permissionModeHint": "Schreibt permissions.defaultMode für neue CLI-Sitzungen. Ein gewählter Modus wird auch als CodeG-Composer-Standard gespeichert, damit eine frühere Chat-Wahl beim Verbinden nicht still gewinnt. Standard verwenden lässt den zuletzt genutzten Composer-Wert unverändert.",
       "permissionModeAria": "Claude-Code-Berechtigungsmodus",
       "permissionUnset": "Standard verwenden",
-      "permission_default": "Jedes Mal fragen",
-      "permission_acceptEdits": "Bearbeitungen automatisch genehmigen",
-      "permission_auto": "Intelligente automatische Genehmigung",
-      "permission_bypassPermissions": "Immer zulassen"
+      "permission_default": "Manuell",
+      "permission_acceptEdits": "Änderungen akzeptieren",
+      "permission_auto": "Auto",
+      "permission_bypassPermissions": "Berechtigungen umgehen"
     },
     "dialogs": {
       "confirmDeleteProvider": "Provider {providerId} löschen?",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "Attributions-/Abrechnungskennung an die API senden",
       "sendAttributionHeaderAria": "Attributions-/Abrechnungskennung von Claude Code an die API senden",
       "disableNonessentialTraffic": "Telemetrie oder überflüssige Netzwerkanfragen deaktivieren",
-      "disableNonessentialTrafficAria": "Telemetrie oder überflüssige Netzwerkanfragen von Claude Code deaktivieren"
+      "disableNonessentialTrafficAria": "Telemetrie oder überflüssige Netzwerkanfragen von Claude Code deaktivieren",
+      "permissionModeLabel": "Berechtigungsmodus",
+      "permissionModeHint": "Neue Claude-Chats starten in diesem Modus. Wird als permissions.defaultMode in ~/.claude/settings.json gespeichert.",
+      "permissionModeAria": "Claude-Code-Berechtigungsmodus",
+      "permissionUnset": "Standard verwenden",
+      "permission_default": "Jedes Mal fragen",
+      "permission_acceptEdits": "Bearbeitungen automatisch genehmigen",
+      "permission_auto": "Intelligente automatische Genehmigung",
+      "permission_bypassPermissions": "Immer zulassen"
     },
     "dialogs": {
       "confirmDeleteProvider": "Provider {providerId} löschen?",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "Disable telemetry or redundant network requests",
       "disableNonessentialTrafficAria": "Disable Claude Code telemetry or redundant network requests",
       "permissionModeLabel": "Permission mode",
-      "permissionModeHint": "New Claude chats start in this mode. Saved as permissions.defaultMode in ~/.claude/settings.json.",
+      "permissionModeHint": "Writes permissions.defaultMode for new CLI sessions. A chosen mode is also saved as CodeG's composer default so a previous chat pick cannot silently win. Use default leaves the composer last-used as-is.",
       "permissionModeAria": "Claude Code permission mode",
       "permissionUnset": "Use default",
-      "permission_default": "Ask every time",
-      "permission_acceptEdits": "Auto-approve edits",
-      "permission_auto": "Smart auto-approve",
-      "permission_bypassPermissions": "Always approve"
+      "permission_default": "Manual",
+      "permission_acceptEdits": "Accept Edits",
+      "permission_auto": "Auto",
+      "permission_bypassPermissions": "Bypass Permissions"
     },
     "dialogs": {
       "confirmDeleteProvider": "Delete Provider {providerId}?",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "Send attribution/billing identifier to the API",
       "sendAttributionHeaderAria": "Send Claude Code attribution/billing identifier to the API",
       "disableNonessentialTraffic": "Disable telemetry or redundant network requests",
-      "disableNonessentialTrafficAria": "Disable Claude Code telemetry or redundant network requests"
+      "disableNonessentialTrafficAria": "Disable Claude Code telemetry or redundant network requests",
+      "permissionModeLabel": "Permission mode",
+      "permissionModeHint": "New Claude chats start in this mode. Saved as permissions.defaultMode in ~/.claude/settings.json.",
+      "permissionModeAria": "Claude Code permission mode",
+      "permissionUnset": "Use default",
+      "permission_default": "Ask every time",
+      "permission_acceptEdits": "Auto-approve edits",
+      "permission_auto": "Smart auto-approve",
+      "permission_bypassPermissions": "Always approve"
     },
     "dialogs": {
       "confirmDeleteProvider": "Delete Provider {providerId}?",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "Desactivar la telemetría o las solicitudes de red innecesarias",
       "disableNonessentialTrafficAria": "Desactivar la telemetría o las solicitudes de red innecesarias de Claude Code",
       "permissionModeLabel": "Modo de permisos",
-      "permissionModeHint": "Los chats nuevos de Claude empiezan en este modo. Se guarda como permissions.defaultMode en ~/.claude/settings.json.",
+      "permissionModeHint": "Escribe permissions.defaultMode para las sesiones nuevas de la CLI. El modo elegido también queda como valor predeterminado del composer de CodeG, para que una elección anterior no gane en silencio al conectar. Usar el predeterminado deja el último valor del composer como está.",
       "permissionModeAria": "Modo de permisos de Claude Code",
       "permissionUnset": "Usar el predeterminado",
-      "permission_default": "Preguntar cada vez",
-      "permission_acceptEdits": "Aprobar ediciones automáticamente",
-      "permission_auto": "Aprobación automática inteligente",
-      "permission_bypassPermissions": "Aprobar siempre"
+      "permission_default": "Manual",
+      "permission_acceptEdits": "Aceptar ediciones",
+      "permission_auto": "Auto",
+      "permission_bypassPermissions": "Omitir permisos"
     },
     "dialogs": {
       "confirmDeleteProvider": "¿Eliminar proveedor {providerId}?",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "Enviar identificador de atribución/facturación a la API",
       "sendAttributionHeaderAria": "Enviar el identificador de atribución/facturación de Claude Code a la API",
       "disableNonessentialTraffic": "Desactivar la telemetría o las solicitudes de red innecesarias",
-      "disableNonessentialTrafficAria": "Desactivar la telemetría o las solicitudes de red innecesarias de Claude Code"
+      "disableNonessentialTrafficAria": "Desactivar la telemetría o las solicitudes de red innecesarias de Claude Code",
+      "permissionModeLabel": "Modo de permisos",
+      "permissionModeHint": "Los chats nuevos de Claude empiezan en este modo. Se guarda como permissions.defaultMode en ~/.claude/settings.json.",
+      "permissionModeAria": "Modo de permisos de Claude Code",
+      "permissionUnset": "Usar el predeterminado",
+      "permission_default": "Preguntar cada vez",
+      "permission_acceptEdits": "Aprobar ediciones automáticamente",
+      "permission_auto": "Aprobación automática inteligente",
+      "permission_bypassPermissions": "Aprobar siempre"
     },
     "dialogs": {
       "confirmDeleteProvider": "¿Eliminar proveedor {providerId}?",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "Envoyer l'identifiant d'attribution/facturation à l'API",
       "sendAttributionHeaderAria": "Envoyer l'identifiant d'attribution/facturation de Claude Code à l'API",
       "disableNonessentialTraffic": "Désactiver la télémétrie ou les requêtes réseau superflues",
-      "disableNonessentialTrafficAria": "Désactiver la télémétrie ou les requêtes réseau superflues de Claude Code"
+      "disableNonessentialTrafficAria": "Désactiver la télémétrie ou les requêtes réseau superflues de Claude Code",
+      "permissionModeLabel": "Mode d'autorisation",
+      "permissionModeHint": "Les nouveaux chats Claude démarrent dans ce mode. Enregistré comme permissions.defaultMode dans ~/.claude/settings.json.",
+      "permissionModeAria": "Mode d'autorisation de Claude Code",
+      "permissionUnset": "Utiliser la valeur par défaut",
+      "permission_default": "Demander à chaque fois",
+      "permission_acceptEdits": "Approuver automatiquement les modifications",
+      "permission_auto": "Approbation automatique intelligente",
+      "permission_bypassPermissions": "Toujours autoriser"
     },
     "dialogs": {
       "confirmDeleteProvider": "Supprimer le provider {providerId} ?",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "Désactiver la télémétrie ou les requêtes réseau superflues",
       "disableNonessentialTrafficAria": "Désactiver la télémétrie ou les requêtes réseau superflues de Claude Code",
       "permissionModeLabel": "Mode d'autorisation",
-      "permissionModeHint": "Les nouveaux chats Claude démarrent dans ce mode. Enregistré comme permissions.defaultMode dans ~/.claude/settings.json.",
+      "permissionModeHint": "Écrit permissions.defaultMode pour les nouvelles sessions CLI. Le mode choisi devient aussi le défaut du composer CodeG, pour qu'un choix de chat précédent ne l'emporte pas en silence à la connexion. Utiliser la valeur par défaut laisse le dernier choix du composer inchangé.",
       "permissionModeAria": "Mode d'autorisation de Claude Code",
       "permissionUnset": "Utiliser la valeur par défaut",
-      "permission_default": "Demander à chaque fois",
-      "permission_acceptEdits": "Approuver automatiquement les modifications",
-      "permission_auto": "Approbation automatique intelligente",
-      "permission_bypassPermissions": "Toujours autoriser"
+      "permission_default": "Manuel",
+      "permission_acceptEdits": "Accepter les modifications",
+      "permission_auto": "Auto",
+      "permission_bypassPermissions": "Ignorer les autorisations"
     },
     "dialogs": {
       "confirmDeleteProvider": "Supprimer le provider {providerId} ?",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "テレメトリや不要なネットワークリクエストを無効化",
       "disableNonessentialTrafficAria": "Claude Code のテレメトリや不要なネットワークリクエストを無効化",
       "permissionModeLabel": "権限モード",
-      "permissionModeHint": "新しい Claude チャットはこのモードで始まります。~/.claude/settings.json の permissions.defaultMode に保存されます。",
+      "permissionModeHint": "CLI の新規セッション向けに permissions.defaultMode を書き込みます。選んだモードは CodeG の composer 既定値にもなり、以前のチャットで選んだモードが接続時に黙って勝つことはありません。「デフォルトを使用」は composer の前回値をそのままにします。",
       "permissionModeAria": "Claude Code の権限モード",
       "permissionUnset": "デフォルトを使用",
-      "permission_default": "毎回確認",
-      "permission_acceptEdits": "編集を自動承認",
-      "permission_auto": "スマート自動承認",
-      "permission_bypassPermissions": "常に許可"
+      "permission_default": "手動",
+      "permission_acceptEdits": "編集を許可",
+      "permission_auto": "自動",
+      "permission_bypassPermissions": "権限をバイパス"
     },
     "dialogs": {
       "confirmDeleteProvider": "Provider {providerId} を削除しますか？",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "API に帰属/課金識別子を送信",
       "sendAttributionHeaderAria": "API に Claude Code の帰属/課金識別子を送信",
       "disableNonessentialTraffic": "テレメトリや不要なネットワークリクエストを無効化",
-      "disableNonessentialTrafficAria": "Claude Code のテレメトリや不要なネットワークリクエストを無効化"
+      "disableNonessentialTrafficAria": "Claude Code のテレメトリや不要なネットワークリクエストを無効化",
+      "permissionModeLabel": "権限モード",
+      "permissionModeHint": "新しい Claude チャットはこのモードで始まります。~/.claude/settings.json の permissions.defaultMode に保存されます。",
+      "permissionModeAria": "Claude Code の権限モード",
+      "permissionUnset": "デフォルトを使用",
+      "permission_default": "毎回確認",
+      "permission_acceptEdits": "編集を自動承認",
+      "permission_auto": "スマート自動承認",
+      "permission_bypassPermissions": "常に許可"
     },
     "dialogs": {
       "confirmDeleteProvider": "Provider {providerId} を削除しますか？",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "API에 속성/청구 식별자 전송",
       "sendAttributionHeaderAria": "API에 Claude Code 속성/청구 식별자 전송",
       "disableNonessentialTraffic": "텔레메트리 또는 불필요한 네트워크 요청 비활성화",
-      "disableNonessentialTrafficAria": "Claude Code 텔레메트리 또는 불필요한 네트워크 요청 비활성화"
+      "disableNonessentialTrafficAria": "Claude Code 텔레메트리 또는 불필요한 네트워크 요청 비활성화",
+      "permissionModeLabel": "권한 모드",
+      "permissionModeHint": "새 Claude 채팅이 이 모드로 시작됩니다. ~/.claude/settings.json 의 permissions.defaultMode 에 저장됩니다.",
+      "permissionModeAria": "Claude Code 권한 모드",
+      "permissionUnset": "기본값 사용",
+      "permission_default": "매번 묻기",
+      "permission_acceptEdits": "편집 자동 승인",
+      "permission_auto": "스마트 자동 승인",
+      "permission_bypassPermissions": "항상 허용"
     },
     "dialogs": {
       "confirmDeleteProvider": "Provider {providerId}를 삭제하시겠습니까?",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "텔레메트리 또는 불필요한 네트워크 요청 비활성화",
       "disableNonessentialTrafficAria": "Claude Code 텔레메트리 또는 불필요한 네트워크 요청 비활성화",
       "permissionModeLabel": "권한 모드",
-      "permissionModeHint": "새 Claude 채팅이 이 모드로 시작됩니다. ~/.claude/settings.json 의 permissions.defaultMode 에 저장됩니다.",
+      "permissionModeHint": "CLI 새 세션의 permissions.defaultMode 를 기록합니다. 고른 모드는 CodeG composer 기본값에도 반영되어, 이전 채팅에서 고른 모드가 연결 시 조용히 이기지 않습니다. 기본값 사용은 composer 마지막 값을 그대로 둡니다.",
       "permissionModeAria": "Claude Code 권한 모드",
       "permissionUnset": "기본값 사용",
-      "permission_default": "매번 묻기",
-      "permission_acceptEdits": "편집 자동 승인",
-      "permission_auto": "스마트 자동 승인",
-      "permission_bypassPermissions": "항상 허용"
+      "permission_default": "수동",
+      "permission_acceptEdits": "편집 수락",
+      "permission_auto": "자동",
+      "permission_bypassPermissions": "권한 우회"
     },
     "dialogs": {
       "confirmDeleteProvider": "Provider {providerId}를 삭제하시겠습니까?",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "Desativar a telemetria ou solicitações de rede desnecessárias",
       "disableNonessentialTrafficAria": "Desativar a telemetria ou solicitações de rede desnecessárias do Claude Code",
       "permissionModeLabel": "Modo de permissão",
-      "permissionModeHint": "Novos chats do Claude começam neste modo. Gravado como permissions.defaultMode em ~/.claude/settings.json.",
+      "permissionModeHint": "Grava permissions.defaultMode para novas sessões da CLI. O modo escolhido também vira o padrão do composer do CodeG, para que uma escolha anterior de chat não vença em silêncio na conexão. Usar o padrão deixa o último valor do composer como está.",
       "permissionModeAria": "Modo de permissão do Claude Code",
       "permissionUnset": "Usar o padrão",
-      "permission_default": "Perguntar sempre",
-      "permission_acceptEdits": "Aprovar edições automaticamente",
-      "permission_auto": "Aprovação automática inteligente",
-      "permission_bypassPermissions": "Sempre aprovar"
+      "permission_default": "Manual",
+      "permission_acceptEdits": "Aceitar edições",
+      "permission_auto": "Auto",
+      "permission_bypassPermissions": "Ignorar permissões"
     },
     "dialogs": {
       "confirmDeleteProvider": "Excluir o provedor {providerId}?",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "Enviar identificador de atribuição/cobrança para a API",
       "sendAttributionHeaderAria": "Enviar o identificador de atribuição/cobrança do Claude Code para a API",
       "disableNonessentialTraffic": "Desativar a telemetria ou solicitações de rede desnecessárias",
-      "disableNonessentialTrafficAria": "Desativar a telemetria ou solicitações de rede desnecessárias do Claude Code"
+      "disableNonessentialTrafficAria": "Desativar a telemetria ou solicitações de rede desnecessárias do Claude Code",
+      "permissionModeLabel": "Modo de permissão",
+      "permissionModeHint": "Novos chats do Claude começam neste modo. Gravado como permissions.defaultMode em ~/.claude/settings.json.",
+      "permissionModeAria": "Modo de permissão do Claude Code",
+      "permissionUnset": "Usar o padrão",
+      "permission_default": "Perguntar sempre",
+      "permission_acceptEdits": "Aprovar edições automaticamente",
+      "permission_auto": "Aprovação automática inteligente",
+      "permission_bypassPermissions": "Sempre aprovar"
     },
     "dialogs": {
       "confirmDeleteProvider": "Excluir o provedor {providerId}?",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "禁用遥测或多余的网络请求",
       "disableNonessentialTrafficAria": "禁用 Claude Code 遥测或多余的网络请求",
       "permissionModeLabel": "权限模式",
-      "permissionModeHint": "新的 Claude 会话以此模式启动。写入 ~/.claude/settings.json 的 permissions.defaultMode。",
+      "permissionModeHint": "写入 CLI 新会话的 permissions.defaultMode。选定的模式同时会成为 CodeG 的 composer 默认值，避免之前聊天里选过的模式在连接时悄悄覆盖。使用默认则不改动 composer 上次使用的值。",
       "permissionModeAria": "Claude Code 权限模式",
       "permissionUnset": "使用默认",
-      "permission_default": "每次询问",
-      "permission_acceptEdits": "自动批准编辑",
-      "permission_auto": "智能自动批准",
-      "permission_bypassPermissions": "始终允许"
+      "permission_default": "手动",
+      "permission_acceptEdits": "接受编辑",
+      "permission_auto": "自动",
+      "permission_bypassPermissions": "绕过权限"
     },
     "dialogs": {
       "confirmDeleteProvider": "确认删除 Provider {providerId}？",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "向接口发送归属/计费标识",
       "sendAttributionHeaderAria": "向接口发送 Claude Code 归属/计费标识",
       "disableNonessentialTraffic": "禁用遥测或多余的网络请求",
-      "disableNonessentialTrafficAria": "禁用 Claude Code 遥测或多余的网络请求"
+      "disableNonessentialTrafficAria": "禁用 Claude Code 遥测或多余的网络请求",
+      "permissionModeLabel": "权限模式",
+      "permissionModeHint": "新的 Claude 会话以此模式启动。写入 ~/.claude/settings.json 的 permissions.defaultMode。",
+      "permissionModeAria": "Claude Code 权限模式",
+      "permissionUnset": "使用默认",
+      "permission_default": "每次询问",
+      "permission_acceptEdits": "自动批准编辑",
+      "permission_auto": "智能自动批准",
+      "permission_bypassPermissions": "始终允许"
     },
     "dialogs": {
       "confirmDeleteProvider": "确认删除 Provider {providerId}？",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1287,7 +1287,15 @@
       "sendAttributionHeader": "向介面傳送歸屬/計費識別碼",
       "sendAttributionHeaderAria": "向介面傳送 Claude Code 歸屬/計費識別碼",
       "disableNonessentialTraffic": "停用遙測或多餘的網路請求",
-      "disableNonessentialTrafficAria": "停用 Claude Code 遙測或多餘的網路請求"
+      "disableNonessentialTrafficAria": "停用 Claude Code 遙測或多餘的網路請求",
+      "permissionModeLabel": "權限模式",
+      "permissionModeHint": "新的 Claude 工作階段以此模式啟動。寫入 ~/.claude/settings.json 的 permissions.defaultMode。",
+      "permissionModeAria": "Claude Code 權限模式",
+      "permissionUnset": "使用預設",
+      "permission_default": "每次詢問",
+      "permission_acceptEdits": "自動核准編輯",
+      "permission_auto": "智慧自動核准",
+      "permission_bypassPermissions": "永遠允許"
     },
     "dialogs": {
       "confirmDeleteProvider": "確認刪除 Provider {providerId}？",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1289,13 +1289,13 @@
       "disableNonessentialTraffic": "停用遙測或多餘的網路請求",
       "disableNonessentialTrafficAria": "停用 Claude Code 遙測或多餘的網路請求",
       "permissionModeLabel": "權限模式",
-      "permissionModeHint": "新的 Claude 工作階段以此模式啟動。寫入 ~/.claude/settings.json 的 permissions.defaultMode。",
+      "permissionModeHint": "寫入 CLI 新工作階段的 permissions.defaultMode。選定的模式同時會成為 CodeG 的 composer 預設值，避免先前聊天選過的模式在連線時悄悄覆蓋。使用預設則不改動 composer 上次使用的值。",
       "permissionModeAria": "Claude Code 權限模式",
       "permissionUnset": "使用預設",
-      "permission_default": "每次詢問",
-      "permission_acceptEdits": "自動核准編輯",
-      "permission_auto": "智慧自動核准",
-      "permission_bypassPermissions": "永遠允許"
+      "permission_default": "手動",
+      "permission_acceptEdits": "接受編輯",
+      "permission_auto": "自動",
+      "permission_bypassPermissions": "略過權限"
     },
     "dialogs": {
       "confirmDeleteProvider": "確認刪除 Provider {providerId}？",

--- a/src/lib/selector-prefs-storage.test.ts
+++ b/src/lib/selector-prefs-storage.test.ts
@@ -4,6 +4,7 @@ import {
   getSavedModeId,
   getSavedPrefsForConnect,
   saveConfigPreference,
+  saveModeIdPreference,
   saveModePreference,
 } from "./selector-prefs-storage"
 
@@ -148,5 +149,36 @@ describe("selector-prefs-storage", () => {
     expect(getSavedPrefsForConnect("other-cursor").configValues).toEqual({
       model: "claude-opus-5",
     })
+  })
+})
+
+describe("saveModeIdPreference", () => {
+  beforeEach(() => localStorage.clear())
+
+  it("overwrites a stickier last-used mode so Settings=default wins over saved bypass", () => {
+    saveModeIdPreference("claude_code", "bypassPermissions")
+    expect(getSavedModeId("claude_code")).toBe("bypassPermissions")
+    saveModeIdPreference("claude_code", "default")
+    expect(getSavedModeId("claude_code")).toBe("default")
+  })
+
+  it("overwrites the inverse: Settings=bypass wins over saved default", () => {
+    saveModeIdPreference("claude_code", "default")
+    saveModeIdPreference("claude_code", "bypassPermissions")
+    expect(getSavedModeId("claude_code")).toBe("bypassPermissions")
+  })
+
+  it("ignores empty so Use default does not wipe the composer last-used", () => {
+    saveModeIdPreference("claude_code", "acceptEdits")
+    saveModeIdPreference("claude_code", "   ")
+    expect(getSavedModeId("claude_code")).toBe("acceptEdits")
+  })
+
+  it("is the same store saveModePreference writes", () => {
+    saveModePreference("claude_code", {
+      current_mode_id: "auto",
+      available_modes: [],
+    })
+    expect(getSavedModeId("claude_code")).toBe("auto")
   })
 })

--- a/src/lib/selector-prefs-storage.ts
+++ b/src/lib/selector-prefs-storage.ts
@@ -164,9 +164,20 @@ export function saveModePreference(
   agentType: string,
   modes: SessionModeStateInfo
 ) {
+  saveModeIdPreference(agentType, modes.current_mode_id)
+}
+
+/**
+ * Write a mode id as the agent's sticky new-chat default without needing a
+ * live `SessionModeStateInfo`. Empty / whitespace is ignored: callers that
+ * mean "leave the composer last-used alone" simply skip this.
+ */
+export function saveModeIdPreference(agentType: string, modeId: string) {
+  const id = modeId.trim()
+  if (!id) return
   updatePrefs(agentType, (prefs) => ({
     ...prefs,
-    modeId: modes.current_mode_id,
+    modeId: id,
   }))
 }
 


### PR DESCRIPTION
Grok and Cursor already have a permission-mode control on Settings -> Agents. This adds the same kind of dropdown for Claude Code.

It writes the official `permissions.defaultMode` key and keeps existing allow/deny rules. It does not write `skipDangerousModePermissionPrompt`. That flag is Claude Code's own bypass-dialog consent, not a CodeG switch.

On save, a chosen mode is also written to CodeG's composer default (`codeg:selector-prefs`) so connect cannot keep a stickier last-used mode. Leaving Use default does not touch the composer last-used.

Labels match the composer: Manual / Accept Edits / Auto / Bypass Permissions. `plan` and `dontAsk` already on disk stay as-is instead of being shown as Use default.

New chats only. Extra custom Claude slots still use their isolated settings.json because they do not get this panel.