### PR TITLE
Show the pinned session mode on the delegation card

### DIFF
--- a/src-tauri/src/acp/delegation/broker.rs
+++ b/src-tauri/src/acp/delegation/broker.rs
@@ -2463,11 +2463,15 @@ impl DelegationBroker {
         // Pull per-agent overrides from the broker config (defaults to empty).
         // Cloning is cheap — `AgentDelegationDefaults` is at most one Option<String>
         // and a small BTreeMap, and the spawner consumes both fields by value.
-        let (preferred_mode_id, preferred_config_values) = cfg
+        let (configured_mode_id, preferred_config_values) = cfg
             .agent_defaults
             .get(&req.agent_type)
             .map(|d: &AgentDelegationDefaults| (d.mode_id.clone(), d.config_values.clone()))
             .unwrap_or((None, BTreeMap::new()));
+        // A per-call `permission_mode` wins over the settings default; when the
+        // LLM omits it the configured default is used unchanged, so existing
+        // callers and non-delegated sessions see no behaviour change.
+        let preferred_mode_id = req.permission_mode.clone().or(configured_mode_id);
         // Checkpoint #1 (opportunistic): if a parent cancel already landed
         // during the claim/depth phase, bail before spawning a child the parent
         // has abandoned. No child exists yet, so there's nothing to tear down.
@@ -4656,6 +4660,7 @@ mod tests {
             task: "do x".into(),
             working_dir: None,
             requested_working_dir: None,
+            permission_mode: None,
             external_handle: None,
         }
     }
@@ -5334,6 +5339,106 @@ mod tests {
             DelegationOutcome::Err { code, .. } => assert_eq!(code, "spawn_failed"),
             other => panic!("expected Err, got {other:?}"),
         }
+    }
+
+    /// A per-call `permission_mode` overrides the configured per-agent default
+    /// for that delegation only. This is the whole point of the parameter: a
+    /// parent can bound one child without changing global settings.
+    #[tokio::test]
+    async fn per_call_permission_mode_overrides_agent_default() {
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+
+        let mut agent_defaults = BTreeMap::new();
+        agent_defaults.insert(
+            AgentType::ClaudeCode,
+            AgentDelegationDefaults {
+                mode_id: Some("auto".into()),
+                config_values: BTreeMap::new(),
+            },
+        );
+        broker
+            .set_config(DelegationConfig {
+                enabled: true,
+                depth_limit: 8,
+                agent_defaults,
+                ..DelegationConfig::default()
+            })
+            .await;
+
+        let mut req = request(1, "pt-1");
+        req.permission_mode = Some("plan".into());
+        let _ = broker.handle_request(req).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("plan"));
+    }
+
+    /// Omitting `permission_mode` must leave the configured default untouched,
+    /// so existing callers see no behaviour change.
+    #[tokio::test]
+    async fn omitted_permission_mode_keeps_configured_default() {
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+
+        let mut agent_defaults = BTreeMap::new();
+        agent_defaults.insert(
+            AgentType::ClaudeCode,
+            AgentDelegationDefaults {
+                mode_id: Some("auto".into()),
+                config_values: BTreeMap::new(),
+            },
+        );
+        broker
+            .set_config(DelegationConfig {
+                enabled: true,
+                depth_limit: 8,
+                agent_defaults,
+                ..DelegationConfig::default()
+            })
+            .await;
+
+        // `request()` leaves permission_mode as None.
+        let _ = broker.handle_request(request(1, "pt-1")).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("auto"));
+    }
+
+    /// With no configured default and no per-call value, nothing is forced.
+    #[tokio::test]
+    async fn per_call_permission_mode_works_without_any_agent_default() {
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+        broker
+            .set_config(DelegationConfig {
+                enabled: true,
+                depth_limit: 8,
+                ..DelegationConfig::default()
+            })
+            .await;
+
+        let mut req = request(1, "pt-1");
+        req.permission_mode = Some("plan".into());
+        let _ = broker.handle_request(req).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("plan"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/acp/delegation/listener.rs
+++ b/src-tauri/src/acp/delegation/listener.rs
@@ -814,6 +814,17 @@ impl DelegationListener {
             .clone()
             .or_else(|| Some(entry.working_dir.to_string_lossy().to_string()));
 
+        // Optional per-call session mode. Blank/whitespace is treated as
+        // omitted so a model emitting `""` cannot clear the configured
+        // default by accident.
+        let permission_mode = req
+            .input
+            .get("permission_mode")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
         let delegation_req = DelegationRequest {
             parent_connection_id: req.parent_connection_id,
             parent_conversation_id,
@@ -822,6 +833,7 @@ impl DelegationListener {
             task,
             working_dir,
             requested_working_dir,
+            permission_mode,
             external_handle: req.external_handle,
         };
         self.broker.start_delegation(delegation_req).await
@@ -1522,6 +1534,7 @@ mod tests {
                 task: "do x".into(),
                 working_dir: None,
                 requested_working_dir: None,
+                permission_mode: None,
                 external_handle: None,
             })
             .await;
@@ -1675,6 +1688,7 @@ mod tests {
                         task: "do x".into(),
                         working_dir: None,
                         requested_working_dir: None,
+                        permission_mode: None,
                         external_handle: None,
                     })
                     .await
@@ -1777,6 +1791,7 @@ mod tests {
                 task: "do x".into(),
                 working_dir: None,
                 requested_working_dir: None,
+                permission_mode: None,
                 external_handle: None,
             })
             .await;
@@ -1828,6 +1843,7 @@ mod tests {
                     task: "do x".into(),
                     working_dir: None,
                     requested_working_dir: None,
+                    permission_mode: None,
                     external_handle: Some("h-1".into()),
                 };
                 broker.handle_request(req).await

--- a/src-tauri/src/acp/delegation/tool_schema.json
+++ b/src-tauri/src/acp/delegation/tool_schema.json
@@ -34,6 +34,10 @@
         "working_dir": {
           "type": "string",
           "description": "Absolute path the sub-agent runs in. Defaults to this session's working directory."
+        },
+        "permission_mode": {
+          "type": "string",
+          "description": "Optional. Session mode the sub-agent starts in, for THIS delegation only. Use it to bound what a delegated agent may do without being asked, for example keeping it on a prompting or approval mode instead of running everything unattended. The value is the target agent's own session mode id, the same one shown in that agent's mode selector and used by the per-agent delegation default in Settings. Omit to keep the configured default, so existing callers are unaffected. Agents that expose no session modes ignore it. This is a cooperative permission scope enforced by the agent, not an OS sandbox."
         }
       }
     }

--- a/src-tauri/src/acp/delegation/types.rs
+++ b/src-tauri/src/acp/delegation/types.rs
@@ -69,6 +69,15 @@ pub struct DelegationRequest {
     /// the defaulted value the child is actually spawned in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requested_working_dir: Option<String>,
+    /// Session mode the child should start in, as the LLM passed it in the
+    /// `delegate_to_agent` arguments. Overrides the per-agent
+    /// `AgentDelegationDefaults::mode_id` from settings for THIS call only;
+    /// `None` keeps the configured default, so omitting it is a no-op. The
+    /// value is the target agent's own ACP session mode id (the same
+    /// vocabulary the settings default uses), forwarded verbatim as
+    /// `ConnectionSpawner::spawn`'s `preferred_mode_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_handle: Option<String>,
 }

--- a/src-tauri/src/acp/lifecycle.rs
+++ b/src-tauri/src/acp/lifecycle.rs
@@ -2911,6 +2911,7 @@ mod tests {
             task: "do x".into(),
             working_dir: None,
             requested_working_dir: None,
+            permission_mode: None,
             external_handle: None,
         }
     }

--- a/src/components/message/delegated-sub-thread.tsx
+++ b/src/components/message/delegated-sub-thread.tsx
@@ -72,6 +72,7 @@ export function DelegatedSubThread({
   }
   const {
     agentType,
+    permissionMode,
     task,
     taskId,
     status,
@@ -96,6 +97,7 @@ export function DelegatedSubThread({
       <DelegationCardRow
         agentType={agentType}
         taskId={taskId}
+        permissionMode={permissionMode}
         status={status}
         errorCode={errorCode}
         task={task}

--- a/src/components/message/delegation-card-row.tsx
+++ b/src/components/message/delegation-card-row.tsx
@@ -30,6 +30,10 @@ interface Props {
   agentType: AgentType | null
   /** Broker task id; rendered as a `#`-prefixed 8-char handle when present. */
   taskId: string | null
+  /** Session mode the parent pinned for this one delegation. Omitted /`null`
+   *  means the child used the configured per-agent default, which is the
+   *  common case — then no chip is drawn and the row reads as it always did. */
+  permissionMode?: string | null
   status: DelegationCardStatus
   errorCode?: string
   /** The sub-agent's task text, one clamped line. */
@@ -43,6 +47,7 @@ interface Props {
 export function DelegationCardRow({
   agentType,
   taskId,
+  permissionMode,
   status,
   errorCode,
   task,
@@ -75,6 +80,14 @@ export function DelegationCardRow({
                 title={taskId}
               >
                 #{taskId.slice(0, 8)}
+              </span>
+            )}
+            {permissionMode && (
+              <span
+                className="shrink-0 rounded border border-border px-1 py-px font-mono text-[10px] leading-none text-muted-foreground"
+                title={t("delegationPinnedMode", { mode: permissionMode })}
+              >
+                {permissionMode}
               </span>
             )}
             <StatusBadge status={status} errorCode={errorCode} />

--- a/src/hooks/use-delegation-card-model.ts
+++ b/src/hooks/use-delegation-card-model.ts
@@ -61,6 +61,9 @@ export interface DelegationCardModel {
   errorCode: string | undefined
   childConversationId: number | null
   childConnectionId: string | null
+  /** Session mode the parent pinned for this delegation, or `null` when it
+   *  used the configured default. */
+  permissionMode: string | null
   /** False when there's no live binding and the input parsed to neither an
    *  agent type nor a task — nothing useful to draw. Callers render null. */
   hasModel: boolean
@@ -214,6 +217,9 @@ export function useDelegationCardModel(
     errorCode,
     childConversationId,
     childConnectionId,
+    // Only the parsed arguments carry this; hosts that strip arguments simply
+    // show no mode, which reads correctly as "the configured default".
+    permissionMode: parsed.permissionMode,
     // Broker-stamped meta alone is proof enough of a delegation — the
     // persisted Cursor shape has empty raw_input and no live binding. So is a
     // report that named the child: a persisted `resume_delegation` result has

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "العميل الفرعي قيد التشغيل…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "وكيل فرعي",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "عرض المحادثة",
         "resumed": "تم الاستئناف",
         "resumeDetail": "تفاصيل الاستئناف",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "Unteragent läuft…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "Sub-Agent",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "Konversation anzeigen",
         "resumed": "Fortgesetzt",
         "resumeDetail": "Details zur Fortsetzung",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "Sub-agent running…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "Sub-agent",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "Open conversation",
         "resumed": "Resumed",
         "resumeDetail": "Resume details",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "Subagente en ejecución…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "Sub-agente",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "Ver conversación",
         "resumed": "Reanudado",
         "resumeDetail": "Detalles de reanudación",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "Sous-agent en cours…",
         "noDetail": "Aucun détail disponible pour le moment.",
         "unknownAgent": "Sous-agent",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "Voir la conversation",
         "resumed": "Repris",
         "resumeDetail": "Détails de la reprise",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "サブエージェント実行中…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "サブエージェント",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "会話を表示",
         "resumed": "再開済み",
         "resumeDetail": "再開の詳細",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "서브에이전트 실행 중…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "하위 에이전트",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "대화 보기",
         "resumed": "재개됨",
         "resumeDetail": "재개 세부 정보",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "Subagente em execução…",
         "noDetail": "No detail available yet.",
         "unknownAgent": "Subagente",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "Ver conversa",
         "resumed": "Retomado",
         "resumeDetail": "Detalhes da retomada",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "子智能体运行中…",
         "noDetail": "暂无详情。",
         "unknownAgent": "子智能体",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "查看会话",
         "resumed": "已恢复",
         "resumeDetail": "恢复详情",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -3345,6 +3345,7 @@
         "subAgentRunning": "子代理執行中…",
         "noDetail": "暫無詳情。",
         "unknownAgent": "子智慧體",
+        "delegationPinnedMode": "Started in {mode} mode, pinned by the parent for this delegation",
         "openDetail": "檢視會話",
         "resumed": "已恢復",
         "resumeDetail": "恢復詳情",

--- a/src/lib/delegation-card.test.ts
+++ b/src/lib/delegation-card.test.ts
@@ -205,6 +205,27 @@ describe("parseDelegationMeta task fields", () => {
       })?.agentType
     ).toBe("custom:my-cli")
   })
+
+  it("parses permission_mode and trims it", () => {
+    const parsed = parseInput(
+      JSON.stringify({ agent_type: "codex", task: "t", permission_mode: "  plan  " })
+    )
+    expect(parsed.permissionMode).toBe("plan")
+  })
+
+  it("treats a blank permission_mode as absent", () => {
+    const parsed = parseInput(
+      JSON.stringify({ agent_type: "codex", task: "t", permission_mode: "   " })
+    )
+    expect(parsed.permissionMode).toBeNull()
+  })
+
+  it("leaves permissionMode null when the argument is omitted", () => {
+    const parsed = parseInput(
+      JSON.stringify({ agent_type: "codex", task: "t" })
+    )
+    expect(parsed.permissionMode).toBeNull()
+  })
 })
 
 describe("parseToolOutput agent type", () => {

--- a/src/lib/delegation-card.test.ts
+++ b/src/lib/delegation-card.test.ts
@@ -208,7 +208,11 @@ describe("parseDelegationMeta task fields", () => {
 
   it("parses permission_mode and trims it", () => {
     const parsed = parseInput(
-      JSON.stringify({ agent_type: "codex", task: "t", permission_mode: "  plan  " })
+      JSON.stringify({
+        agent_type: "codex",
+        task: "t",
+        permission_mode: "  plan  ",
+      })
     )
     expect(parsed.permissionMode).toBe("plan")
   })

--- a/src/lib/delegation-card.ts
+++ b/src/lib/delegation-card.ts
@@ -36,6 +36,10 @@ export type ParsedInput = {
   agentType: AgentType | null
   task: string | null
   workingDir: string | null
+  /** Session mode the parent pinned for this one delegation, from the
+   *  `permission_mode` argument. `null` when omitted, which means the child
+   *  used the configured per-agent default. */
+  permissionMode: string | null
 }
 
 // Derived from the canonical `ALL_AGENT_TYPES` so a newly added agent is
@@ -141,6 +145,7 @@ const EMPTY_PARSED_INPUT: ParsedInput = {
   agentType: null,
   task: null,
   workingDir: null,
+  permissionMode: null,
 }
 
 // Wrapper keys that hosts use to nest the actual tool arguments. JSON-RPC
@@ -182,7 +187,8 @@ function findDelegationArgs(
   if (
     typeof obj.task === "string" ||
     typeof obj.agent_type === "string" ||
-    typeof obj.working_dir === "string"
+    typeof obj.working_dir === "string" ||
+    typeof obj.permission_mode === "string"
   ) {
     return obj
   }
@@ -264,6 +270,10 @@ export function parseInput(raw: string | null | undefined): ParsedInput {
     agentType: coerceAgentType(obj.agent_type),
     task: typeof obj.task === "string" ? obj.task : null,
     workingDir: typeof obj.working_dir === "string" ? obj.working_dir : null,
+    permissionMode:
+      typeof obj.permission_mode === "string" && obj.permission_mode.trim()
+        ? obj.permission_mode.trim()
+        : null,
   }
 }
 


### PR DESCRIPTION
Stacks on #499, which adds the optional `permission_mode` argument. This PR is the read side of it.

## Problem

When a parent pins a session mode for one delegated child, nothing in the transcript records it. Reviewing a conversation afterwards you can see which agent ran and what it was asked to do, but not what it was allowed to do without being asked. That is the one detail you want when auditing what a sub-agent was permitted to touch.

## Change

A quiet monospace chip beside the task id on the delegation card, rendered only when the parent actually pinned a mode.

- No chip means the child used the configured per-agent default, which is the common case, so existing transcripts look unchanged.
- The value comes from the already-parsed `permission_mode` argument, so there is no new wire field, no broker change, and no migration.
- Hosts that strip tool arguments simply show no chip, which reads correctly rather than misleading.
- `parseInput` now also recognises a lone `permission_mode` as delegation args, matching how `task` / `agent_type` / `working_dir` are each treated as sufficient.

The tooltip string is added to all ten locale files with the English text, for translators to pick up.

## Tests

Three added to `delegation-card.test.ts`: parses and trims the value, treats a blank string as absent, leaves it null when the argument is omitted.

## Verification

Run locally on this branch:

- `npx tsc --noEmit -p tsconfig.json` clean, exit 0
- `npx vitest run src/components/message/ src/lib/delegation-card.test.ts` 31 files, 344 tests, all passing

`npx eslint` reports `Delete ␍` on these files, but it does so on untouched files too (276 on `delegation-settings.tsx`), so that is this Windows checkout's CRLF state rather than anything in this change. The committed diff is 57 insertions with no line-ending churn.