### PR TITLE
fix(chat): name image cards after the tool or page, not Image generation

### DIFF
--- a/src/components/message/content-parts-renderer.tsx
+++ b/src/components/message/content-parts-renderer.tsx
@@ -3079,6 +3079,7 @@ export const ContentPartsRenderer = memo(function ContentPartsRenderer({
       return (
         <GeneratedImagesBlock
           key={`gimg-${keyId}`}
+          label={part.label}
           revisedPrompt={part.revisedPrompt}
           image={part.image}
           status={part.status}

--- a/src/components/message/generated-images-block.test.tsx
+++ b/src/components/message/generated-images-block.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react"
+import { NextIntlClientProvider } from "next-intl"
+import { describe, expect, it } from "vitest"
+
+import { GeneratedImagesBlock } from "./generated-images-block"
+import enMessages from "@/i18n/messages/en.json"
+import type { UserImageDisplay } from "@/lib/adapters/ai-elements-adapter"
+
+const image: UserImageDisplay = {
+  name: "page-capture.png",
+  data: "QUJD",
+  mime_type: "image/png",
+  uri: null,
+}
+
+function renderCard(props: Partial<{ label: string | null }> = {}) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <GeneratedImagesBlock revisedPrompt={null} image={image} {...props} />
+    </NextIntlClientProvider>
+  )
+}
+
+describe("GeneratedImagesBlock heading", () => {
+  it("keeps the translated generation copy when no label is passed", () => {
+    // codex image generation is the one caller that leaves `label` unset.
+    renderCard()
+    expect(screen.getByText("Image generation")).toBeInTheDocument()
+  })
+
+  it("falls back to the generation copy for a blank label", () => {
+    renderCard({ label: "   " })
+    expect(screen.getByText("Image generation")).toBeInTheDocument()
+  })
+
+  it("shows the tool/page name when one is passed", () => {
+    renderCard({ label: "Page Capture" })
+    expect(screen.getByText("Page Capture")).toBeInTheDocument()
+    expect(screen.queryByText("Image generation")).not.toBeInTheDocument()
+  })
+
+  it("bounds a long heading to one line and keeps the full text reachable", () => {
+    // The heading is agent-authored now, so it can be arbitrarily long.
+    const long = "Read file '/Users/x/very/long/path/to/a-page-capture.png'"
+    renderCard({ label: long })
+    const heading = screen.getByText(long)
+    expect(heading.className).toContain("truncate")
+    expect(heading).toHaveAttribute("title", long)
+  })
+})

--- a/src/components/message/generated-images-block.tsx
+++ b/src/components/message/generated-images-block.tsx
@@ -12,6 +12,12 @@ import { cn } from "@/lib/utils"
 
 interface GeneratedImagesBlockProps {
   /**
+   * Card heading. Codex image generation leaves this unset so the
+   * translated "Image generation" copy is used. A Read, screenshot, or
+   * fetched page passes the tool/page name instead.
+   */
+  label?: string | null
+  /**
    * codex's revised prompt — what the model rewrote the user's request
    * into before passing to the image API. `null` when codex didn't echo
    * one back (e.g. failed generations) or it hasn't streamed in yet.
@@ -59,6 +65,7 @@ interface GeneratedImagesBlockProps {
  *   - web: blob `<a download>`
  */
 export const GeneratedImagesBlock = memo(function GeneratedImagesBlock({
+  label,
   revisedPrompt,
   image,
   status,
@@ -86,7 +93,7 @@ export const GeneratedImagesBlock = memo(function GeneratedImagesBlock({
     >
       <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
         <ImagePlus className="h-3.5 w-3.5 text-primary" />
-        <span>{t("imageGeneration")}</span>
+        <span>{label?.trim() || t("imageGeneration")}</span>
       </div>
 
       <div className="mt-2.5 flex flex-col gap-3 @[28rem]/genimg:flex-row @[28rem]/genimg:items-start">

--- a/src/components/message/generated-images-block.tsx
+++ b/src/components/message/generated-images-block.tsx
@@ -84,6 +84,11 @@ export const GeneratedImagesBlock = memo(function GeneratedImagesBlock({
   const trimmedPrompt =
     typeof revisedPrompt === "string" ? revisedPrompt.trim() : ""
 
+  // The heading is agent-authored now (a filename, a page slug, or a tool
+  // title) instead of one short fixed string, so it is bounded to a single
+  // ellipsized line and carries the full text as a tooltip.
+  const heading = label?.trim() || t("imageGeneration")
+
   return (
     <div
       className={cn(
@@ -92,8 +97,10 @@ export const GeneratedImagesBlock = memo(function GeneratedImagesBlock({
       )}
     >
       <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-        <ImagePlus className="h-3.5 w-3.5 text-primary" />
-        <span>{label?.trim() || t("imageGeneration")}</span>
+        <ImagePlus className="h-3.5 w-3.5 shrink-0 text-primary" />
+        <span className="min-w-0 truncate" title={heading}>
+          {heading}
+        </span>
       </div>
 
       <div className="mt-2.5 flex flex-col gap-3 @[28rem]/genimg:flex-row @[28rem]/genimg:items-start">

--- a/src/lib/adapters/ai-elements-adapter.test.ts
+++ b/src/lib/adapters/ai-elements-adapter.test.ts
@@ -1280,6 +1280,7 @@ describe("adaptMessageTurn — image tool results", () => {
     expect(part.image?.data).toBe("QUJD")
     expect(part.image?.mime_type).toBe("image/png")
     expect(part.revisedPrompt).toBeNull()
+    expect(part.label).toBe("Clean V1")
   })
 
   it("emits one generated-image part per image (multi-page PDF read)", () => {
@@ -1315,6 +1316,45 @@ describe("adaptMessageTurn — image tool results", () => {
       "generated-image",
       "generated-image",
     ])
+    expect(
+      adapted.content
+        .filter((p) => p.type === "generated-image")
+        .every((p) => p.type === "generated-image" && p.label === "Doc")
+    ).toBe(true)
+  })
+
+  it("names a fetched page from its URL, not Image generation", () => {
+    const adapted = adaptMessageTurn(
+      {
+        id: "fetch-page",
+        role: "assistant",
+        timestamp: "2026-06-02T00:00:00.000Z",
+        blocks: [
+          {
+            type: "tool_use",
+            tool_use_id: "toolu_3",
+            tool_name: "WebFetch",
+            input_preview: JSON.stringify({
+              url: "https://example.com/docs/getting-started",
+            }),
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_3",
+            output_preview: null,
+            is_error: false,
+            images: [{ data: "UAGE3", mime_type: "image/png" }],
+          },
+        ],
+      },
+      msgText,
+      false
+    )
+    const part = adapted.content[0]
+    if (part.type !== "generated-image") {
+      throw new Error("expected a generated-image part")
+    }
+    expect(part.label).toBe("Getting Started")
   })
 
   it("leaves a normal text Read result as a tool card (no regression)", () => {

--- a/src/lib/adapters/ai-elements-adapter.ts
+++ b/src/lib/adapters/ai-elements-adapter.ts
@@ -28,6 +28,7 @@ import {
   unescapeReferenceLabel,
   unwrapReferenceDestination,
 } from "@/lib/reference-link"
+import { imageCardLabel } from "@/lib/image-tool-label"
 
 /**
  * Adapted content part types for AI SDK Elements components
@@ -92,6 +93,8 @@ export type AdaptedGeneratedImagePart = {
   /** `null` while the agent has emitted the ToolCall but no image yet. */
   image: UserImageDisplay | null
   status: ToolCallStatus | null
+  /** Unset for Codex image generation; otherwise the tool or page name. */
+  label?: string | null
 }
 
 export type AdaptedGoalRunPart = {
@@ -1073,6 +1076,7 @@ function adaptContentBlock(
         revisedPrompt: block.revised_prompt ?? null,
         image: display,
         status: block.status ?? null,
+        label: block.label ?? null,
       }
     }
 
@@ -1116,11 +1120,23 @@ function deriveImageNameFromImageData(img: {
  * through to the normal tool-card path. Images missing `data`/`mime_type` are
  * skipped; if that empties the list, `null` is returned too.
  */
-function adaptImageToolResultParts(result: {
-  images?: ImageData[] | null
-}): AdaptedGeneratedImagePart[] | null {
+function adaptImageToolResultParts(
+  result: {
+    images?: ImageData[] | null
+  },
+  ctx?: {
+    toolName?: string | null
+    input?: string | null
+    title?: string | null
+  }
+): AdaptedGeneratedImagePart[] | null {
   const images = result.images
   if (!images || images.length === 0) return null
+  const label = imageCardLabel({
+    title: ctx?.title,
+    toolName: ctx?.toolName,
+    input: ctx?.input,
+  })
   const parts: AdaptedGeneratedImagePart[] = []
   for (const img of images) {
     if (!img.data || !img.mime_type) continue
@@ -1137,6 +1153,7 @@ function adaptImageToolResultParts(result: {
       // Historical replay always carries a present image, so status is
       // irrelevant to the renderer; `null` is treated as success.
       status: null,
+      label,
     })
   }
   return parts.length > 0 ? parts : null
@@ -1871,7 +1888,10 @@ export function adaptMessageTurn(
         // mid-stream we keep the spinner via the normal tool-call path.
         const imageParts = isToolStillRunning
           ? null
-          : adaptImageToolResultParts(matchedResult)
+          : adaptImageToolResultParts(matchedResult, {
+              toolName: block.tool_name,
+              input: block.input_preview,
+            })
         if (imageParts) {
           adaptedContent.push(...imageParts)
           continue
@@ -1908,7 +1928,10 @@ export function adaptMessageTurn(
           positionMatchedIndices.add(index + 1)
           // Same image-result handling as the id-matched branch above: a Read
           // returning image bytes renders as image card(s) in-position.
-          const imageParts = adaptImageToolResultParts(positionalResult)
+          const imageParts = adaptImageToolResultParts(positionalResult, {
+            toolName: block.tool_name,
+            input: block.input_preview,
+          })
           if (imageParts) {
             adaptedContent.push(...imageParts)
             continue

--- a/src/lib/image-tool-label.test.ts
+++ b/src/lib/image-tool-label.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  imageCardLabel,
+  isImageGenerationTitle,
+  pathFromToolInput,
+} from "./image-tool-label"
+
+describe("isImageGenerationTitle", () => {
+  it("matches the hardcoded codex-acp title only", () => {
+    expect(isImageGenerationTitle("Image generation")).toBe(true)
+    expect(isImageGenerationTitle("  image generation  ")).toBe(true)
+    expect(isImageGenerationTitle("Getting Started")).toBe(false)
+    expect(isImageGenerationTitle("Read")).toBe(false)
+    expect(isImageGenerationTitle("")).toBe(false)
+    expect(isImageGenerationTitle(null)).toBe(false)
+  })
+})
+
+describe("pathFromToolInput", () => {
+  it("reads common path and url fields", () => {
+    expect(
+      pathFromToolInput(JSON.stringify({ file_path: "shots/page-capture.png" }))
+    ).toBe("shots/page-capture.png")
+    expect(
+      pathFromToolInput(
+        JSON.stringify({
+          url: "https://example.com/docs/getting-started",
+        })
+      )
+    ).toBe("https://example.com/docs/getting-started")
+    expect(pathFromToolInput("not-json")).toBeNull()
+  })
+})
+
+describe("imageCardLabel", () => {
+  it("keeps a real tool or page title", () => {
+    expect(imageCardLabel({ title: "Getting Started" })).toBe("Getting Started")
+    expect(imageCardLabel({ title: "Getting Started | Example Docs" })).toBe(
+      "Getting Started | Example Docs"
+    )
+  })
+
+  it("does not treat the generation title as a label", () => {
+    expect(imageCardLabel({ title: "Image generation" })).toBeNull()
+  })
+
+  it("falls back to a humanized filename or URL slug", () => {
+    expect(
+      imageCardLabel({
+        title: "Image generation",
+        input: JSON.stringify({ file_path: "page-capture.png" }),
+      })
+    ).toBe("Page Capture")
+    expect(
+      imageCardLabel({
+        input: JSON.stringify({
+          url: "https://example.com/docs/getting-started",
+        }),
+      })
+    ).toBe("Getting Started")
+  })
+
+  it("uses the tool name when nothing else is available", () => {
+    expect(imageCardLabel({ toolName: "Read" })).toBe("Read")
+    expect(imageCardLabel({ toolName: "Image generation" })).toBeNull()
+  })
+})

--- a/src/lib/image-tool-label.test.ts
+++ b/src/lib/image-tool-label.test.ts
@@ -5,6 +5,8 @@ import {
   isImageGenerationTitle,
   pathFromToolInput,
 } from "./image-tool-label"
+import { adaptMessageTurn } from "@/lib/adapters/ai-elements-adapter"
+import { buildStreamingTurnsFromLiveMessage } from "@/stores/conversation-runtime-store"
 
 describe("isImageGenerationTitle", () => {
   it("matches the hardcoded codex-acp title only", () => {
@@ -64,5 +66,139 @@ describe("imageCardLabel", () => {
   it("uses the tool name when nothing else is available", () => {
     expect(imageCardLabel({ toolName: "Read" })).toBe("Read")
     expect(imageCardLabel({ toolName: "Image generation" })).toBeNull()
+  })
+
+  it("names a Windows path after its file, not the whole drive path", () => {
+    // `new URL("C:\\...")` parses — WHATWG reads the drive letter as the
+    // protocol — so a single-letter scheme must not open the URL branch.
+    expect(
+      imageCardLabel({
+        input: JSON.stringify({ file_path: "C:\\Users\\x\\shot-of-page.png" }),
+      })
+    ).toBe("Shot Of Page")
+    expect(
+      imageCardLabel({
+        input: JSON.stringify({ path: "D:/captures/login-form.png" }),
+      })
+    ).toBe("Login Form")
+  })
+
+  it("keeps the host intact for a URL with no slug", () => {
+    // "example.com" must not be run through the extension strip.
+    expect(
+      imageCardLabel({ input: JSON.stringify({ url: "https://example.com" }) })
+    ).toBe("example.com")
+    expect(
+      imageCardLabel({ input: JSON.stringify({ url: "https://example.com/" }) })
+    ).toBe("example.com")
+  })
+
+  it("decodes a percent-escaped slug and survives a malformed one", () => {
+    expect(
+      imageCardLabel({
+        input: JSON.stringify({
+          url: "https://example.com/docs/get%20started",
+        }),
+      })
+    ).toBe("Get Started")
+    expect(
+      imageCardLabel({
+        input: JSON.stringify({ url: "https://example.com/docs/100%" }),
+      })
+    ).toBe("100%")
+  })
+
+  it("prefers the input path over a live-only title", () => {
+    // The title exists only on the live ACP stream; the path exists on both
+    // sides. Ranking the path first is what keeps a card's heading stable
+    // across a reload — see the parity test below.
+    expect(
+      imageCardLabel({
+        title: "Read file '/Users/x/shots/page-capture.png'",
+        input: JSON.stringify({ file_path: "/Users/x/shots/page-capture.png" }),
+      })
+    ).toBe("Page Capture")
+  })
+})
+
+describe("image card heading — live/historical parity", () => {
+  const FILE = "/Users/x/shots/page-capture.png"
+
+  /** The heading the live ACP stream puts on the card. */
+  function liveLabel(): string | null | undefined {
+    const { turns } = buildStreamingTurnsFromLiveMessage(1, {
+      id: "lm-read-img",
+      role: "assistant",
+      startedAt: 0,
+      content: [
+        {
+          type: "tool_call",
+          info: {
+            tool_call_id: "toolu_1",
+            // claude-agent-acp's own human title for a Read.
+            title: `Read file '${FILE}'`,
+            kind: "read",
+            status: "completed",
+            content: null,
+            raw_input: JSON.stringify({ file_path: FILE }),
+            raw_output_chunks: [],
+            raw_output_total_bytes: 0,
+            locations: null,
+            meta: null,
+            images: [{ data: "QUJD", mime_type: "image/png" }],
+          },
+        },
+      ],
+    })
+    const block = turns[0]?.blocks[0]
+    if (block?.type !== "image_generation") {
+      throw new Error("expected an image_generation block")
+    }
+    return block.label
+  }
+
+  /** The heading the same call gets after the conversation is reloaded. */
+  function historicalLabel(): string | null | undefined {
+    const adapted = adaptMessageTurn(
+      {
+        id: "read-img",
+        role: "assistant",
+        timestamp: "2026-06-02T00:00:00.000Z",
+        blocks: [
+          {
+            type: "tool_use",
+            tool_use_id: "toolu_1",
+            tool_name: "Read",
+            input_preview: JSON.stringify({ file_path: FILE }),
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            output_preview: null,
+            is_error: false,
+            images: [{ data: "QUJD", mime_type: "image/png" }],
+          },
+        ],
+      },
+      {
+        attachedResources: "Attached resources",
+        toolCallFailed: "Tool failed",
+      },
+      false
+    )
+    const part = adapted.content[0]
+    if (part.type !== "generated-image") {
+      throw new Error("expected a generated-image part")
+    }
+    return part.label
+  }
+
+  it("gives one Read of a PNG the same heading before and after a reload", () => {
+    // A live tool_call carries the agent's `title`; the persisted tool_use row
+    // does not. If the title outranked the input path, this same card read
+    // "Read file '/Users/x/shots/page-capture.png'" live and "Page Capture"
+    // after a refresh.
+    expect(liveLabel()).toBe("Page Capture")
+    expect(historicalLabel()).toBe(liveLabel())
   })
 })

--- a/src/lib/image-tool-label.ts
+++ b/src/lib/image-tool-label.ts
@@ -1,0 +1,87 @@
+/**
+ * Label for an in-position image card.
+ *
+ * Codex image generation hardcodes the English title "Image generation"
+ * (codex-acp PR #271). Codeg also routes ANY image-bearing tool (Read of a
+ * PNG, a page screenshot, a fetched resource) through that same card, and
+ * the card used to print "Image generation" even when the tool already had
+ * a real name. Keep the dedicated copy only for actual generation; otherwise
+ * use the tool title, URL slug, or filename the agent already knew.
+ */
+
+const IMAGE_GENERATION_TITLE = "image generation"
+
+export function isImageGenerationTitle(
+  title: string | null | undefined
+): boolean {
+  return (title ?? "").trim().toLowerCase() === IMAGE_GENERATION_TITLE
+}
+
+function lastPathSegment(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ""
+  try {
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+      const url = new URL(trimmed)
+      const path = url.pathname.replace(/\/+$/, "")
+      const leaf = path.split("/").filter(Boolean).pop()
+      return decodeURIComponent(leaf || url.hostname)
+    }
+  } catch {
+    /* not a URL */
+  }
+  const leaf = trimmed.split(/[\\/]/).filter(Boolean).pop() ?? trimmed
+  return leaf
+}
+
+function humanizeSegment(segment: string): string {
+  const withoutExt = segment.replace(/\.[a-z0-9]{1,8}$/i, "")
+  const words = withoutExt.replace(/[-_]+/g, " ").trim()
+  if (!words) return segment
+  return words.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+/** Filename or URL from a tool's JSON input preview. */
+export function pathFromToolInput(
+  input: string | null | undefined
+): string | null {
+  if (!input) return null
+  try {
+    const parsed: unknown = JSON.parse(input)
+    if (!parsed || typeof parsed !== "object") return null
+    const obj = parsed as Record<string, unknown>
+    return (
+      stringField(obj.file_path) ||
+      stringField(obj.path) ||
+      stringField(obj.filename) ||
+      stringField(obj.url) ||
+      stringField(obj.uri)
+    )
+  } catch {
+    return null
+  }
+}
+
+export function imageCardLabel(opts: {
+  title?: string | null
+  toolName?: string | null
+  input?: string | null
+}): string | null {
+  const title = opts.title?.trim() || null
+  if (title && !isImageGenerationTitle(title)) return title
+
+  const fromInput = pathFromToolInput(opts.input ?? null)
+  if (fromInput) {
+    const segment = lastPathSegment(fromInput)
+    if (segment) return humanizeSegment(segment)
+  }
+
+  const toolName = opts.toolName?.trim() || null
+  if (toolName && !isImageGenerationTitle(toolName)) return toolName
+
+  return null
+}

--- a/src/lib/image-tool-label.ts
+++ b/src/lib/image-tool-label.ts
@@ -6,7 +6,8 @@
  * PNG, a page screenshot, a fetched resource) through that same card, and
  * the card used to print "Image generation" even when the tool already had
  * a real name. Keep the dedicated copy only for actual generation; otherwise
- * use the tool title, URL slug, or filename the agent already knew.
+ * use the filename or URL slug the agent already knew, falling back to the
+ * tool's own title/name.
  */
 
 const IMAGE_GENERATION_TITLE = "image generation"
@@ -17,21 +18,51 @@ export function isImageGenerationTitle(
   return (title ?? "").trim().toLowerCase() === IMAGE_GENERATION_TITLE
 }
 
-function lastPathSegment(raw: string): string {
-  const trimmed = raw.trim()
-  if (!trimmed) return ""
+/**
+ * Parse as a URL, or `null` when the string is a filesystem path.
+ *
+ * The scheme must be at least TWO characters: `new URL("C:\\shots\\x.png")`
+ * succeeds — WHATWG reads the drive letter as protocol `c:` and hands back
+ * `\shots\x.png` as one opaque path — so a single-letter scheme would send
+ * every Windows absolute path down the URL branch and print the whole thing
+ * as the heading. No real scheme is one character.
+ */
+function asUrl(raw: string): URL | null {
+  if (!/^[a-z][a-z0-9+.-]+:/i.test(raw)) return null
   try {
-    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
-      const url = new URL(trimmed)
-      const path = url.pathname.replace(/\/+$/, "")
-      const leaf = path.split("/").filter(Boolean).pop()
-      return decodeURIComponent(leaf || url.hostname)
-    }
+    return new URL(raw)
   } catch {
-    /* not a URL */
+    return null
   }
-  const leaf = trimmed.split(/[\\/]/).filter(Boolean).pop() ?? trimmed
-  return leaf
+}
+
+/** The heading-worthy part of a filesystem path or URL. */
+function labelFromPathOrUrl(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  const url = asUrl(trimmed)
+  if (url) {
+    const leaf = url.pathname
+      .replace(/\/+$/, "")
+      .split("/")
+      .filter(Boolean)
+      .pop()
+    // A root URL has no slug to humanize; the host IS the page name, and it
+    // must skip `humanizeSegment` — whose extension strip would eat the TLD
+    // and turn "example.com" into "Example".
+    if (!leaf) return url.hostname || null
+    let decoded = leaf
+    try {
+      decoded = decodeURIComponent(leaf)
+    } catch {
+      /* malformed percent-escape — the raw slug still names the page */
+    }
+    return humanizeSegment(decoded) || null
+  }
+
+  const leaf = trimmed.split(/[\\/]/).filter(Boolean).pop()
+  return leaf ? humanizeSegment(leaf) : null
 }
 
 function humanizeSegment(segment: string): string {
@@ -71,14 +102,24 @@ export function imageCardLabel(opts: {
   toolName?: string | null
   input?: string | null
 }): string | null {
-  const title = opts.title?.trim() || null
-  if (title && !isImageGenerationTitle(title)) return title
-
+  // The tool input comes FIRST because it is the only naming signal both
+  // renderers hold. The live ACP stream has the agent's `title`; a reloaded
+  // conversation does not — a persisted tool_use row keeps `tool_name` and
+  // `input_preview` only. Reading the title first made the same Read print
+  // "Read file '/Users/x/shots/page-capture.png'" live and "Page Capture"
+  // after a reload, re-opening the live/historical asymmetry that
+  // `adaptImageToolResultParts` exists to close.
   const fromInput = pathFromToolInput(opts.input ?? null)
   if (fromInput) {
-    const segment = lastPathSegment(fromInput)
-    if (segment) return humanizeSegment(segment)
+    const fromPath = labelFromPathOrUrl(fromInput)
+    if (fromPath) return fromPath
   }
+
+  // Both remaining fallbacks are one-sided (title is live-only, tool_name is
+  // history-only), so they can still disagree across a reload — but only for
+  // an image tool whose input carries no path at all.
+  const title = opts.title?.trim() || null
+  if (title && !isImageGenerationTitle(title)) return title
 
   const toolName = opts.toolName?.trim() || null
   if (toolName && !isImageGenerationTitle(toolName)) return toolName

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,6 +183,8 @@ export type ContentBlock =
       revised_prompt?: string | null
       image?: ImageData | null
       status?: ToolCallStatus | null
+      /** Real tool/page name when this card is not Codex image generation. */
+      label?: string | null
     }
   | {
       type: "tool_use"

--- a/src/stores/conversation-runtime-store.ts
+++ b/src/stores/conversation-runtime-store.ts
@@ -36,6 +36,7 @@ import { collapseLiveCollabBlocks } from "@/lib/collab-collapse"
 import { kimiTodoWriteEntries } from "@/lib/plan-parse"
 import { toErrorMessage } from "@/lib/app-error"
 import { BACKGROUND_TASK_MARKER } from "@/lib/background-agent"
+import { imageCardLabel } from "@/lib/image-tool-label"
 
 /**
  * Conversation-runtime shared state as a Zustand store — the per-conversation
@@ -1093,6 +1094,10 @@ export function buildStreamingTurnsFromLiveMessage(
           // each renders as its own card.
           const imgs = block.info.images ?? []
           const revisedPrompt = extractRevisedPrompt(block.info.content)
+          const label = imageCardLabel({
+            title: block.info.title,
+            input: block.info.raw_input,
+          })
           // Live ToolCallStatus is forwarded so the renderer can show a
           // failure slot when codex reports the call failed before any
           // image bytes arrived. Without this the in-flight skeleton would
@@ -1106,6 +1111,7 @@ export function buildStreamingTurnsFromLiveMessage(
               revised_prompt: revisedPrompt,
               image: null,
               status,
+              label,
             })
           } else {
             for (const img of imgs) {
@@ -1118,6 +1124,7 @@ export function buildStreamingTurnsFromLiveMessage(
                   uri: img.uri ?? null,
                 },
                 status,
+                label,
               })
             }
           }


### PR DESCRIPTION
The in-position image card always printed Image generation. That is right for Codex image generation. It is wrong for a Read of a screenshot or a fetched page.

The card still shows the picture in place. The heading now uses the tool title when it is not that hardcoded Codex string, or the URL slug / filename from the tool input. Real generation is unchanged.