### PR TITLE
Keep the final answer visible when a Goal reloads

### DIFF
--- a/src/components/message/goal-tool-call.test.tsx
+++ b/src/components/message/goal-tool-call.test.tsx
@@ -5,6 +5,10 @@ import { describe, expect, it } from "vitest"
 
 import { GoalRunPart, GoalToolCallPart } from "./goal-tool-call"
 import { GoalControlProvider } from "./goal-control-context"
+import type {
+  AdaptedContentPart,
+  AdaptedGoalRunPart,
+} from "@/lib/adapters/ai-elements-adapter"
 import enMessages from "@/i18n/messages/en.json"
 import zhMessages from "@/i18n/messages/zh-CN.json"
 
@@ -19,6 +23,25 @@ function renderWithIntl(
     </NextIntlClientProvider>
   )
 }
+
+function runningGoalRun(items: AdaptedContentPart[]): AdaptedGoalRunPart {
+  return {
+    type: "goal-run",
+    start: {
+      type: "tool-call",
+      toolCallId: "call-create-goal",
+      toolName: "create_goal",
+      input: JSON.stringify({ objective: "Analyze README file" }),
+      state: "output-available",
+    },
+    end: null,
+    items,
+    isRunning: true,
+  }
+}
+
+const renderTextPart = (part: AdaptedContentPart, key: string) =>
+  part.type === "text" ? <div key={key}>{part.text}</div> : null
 
 describe("GoalToolCallPart", () => {
   it("renders Codex goal completion as a compact goal card", () => {
@@ -89,6 +112,83 @@ describe("GoalToolCallPart", () => {
     expect(screen.getByText("Reading README.md")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button"))
+
+    expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
+  })
+
+  it("opens a live goal when its body arrives without a remount", () => {
+    // The production mount order: `create_goal` is adapted on its own, so the
+    // card first renders with an EMPTY body and the process content streams in
+    // afterwards under the same key. A mount-time seed would miss this.
+    const { rerender } = renderWithIntl(
+      <GoalRunPart part={runningGoalRun([])} renderPart={renderTextPart} />
+    )
+
+    expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <GoalRunPart
+          part={runningGoalRun([{ type: "text", text: "Reading README.md" }])}
+          renderPart={renderTextPart}
+        />
+      </NextIntlClientProvider>
+    )
+
+    expect(screen.getByText("Reading README.md")).toBeInTheDocument()
+  })
+
+  it("keeps a manual collapse across later body updates", () => {
+    const { rerender } = renderWithIntl(
+      <GoalRunPart
+        part={runningGoalRun([{ type: "text", text: "Reading README.md" }])}
+        renderPart={renderTextPart}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button"))
+    expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <GoalRunPart
+          part={runningGoalRun([
+            { type: "text", text: "Reading README.md" },
+            { type: "text", text: "Reading CLAUDE.md" },
+          ])}
+          renderPart={renderTextPart}
+        />
+      </NextIntlClientProvider>
+    )
+
+    // The user's choice wins over the derived default.
+    expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
+    expect(screen.queryByText("Reading CLAUDE.md")).not.toBeInTheDocument()
+  })
+
+  it("collapses the capsule again once the run settles", () => {
+    // Settling lifts the answer out of the run (see `groupGoalRuns`), so the
+    // capsule folds back to a status chip without hiding anything.
+    const { rerender } = renderWithIntl(
+      <GoalRunPart
+        part={runningGoalRun([{ type: "text", text: "Reading README.md" }])}
+        renderPart={renderTextPart}
+      />
+    )
+
+    expect(screen.getByText("Reading README.md")).toBeInTheDocument()
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <GoalRunPart
+          part={{
+            ...runningGoalRun([{ type: "text", text: "Reading README.md" }]),
+            isRunning: false,
+          }}
+          renderPart={renderTextPart}
+        />
+      </NextIntlClientProvider>
+    )
 
     expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
   })

--- a/src/components/message/goal-tool-call.test.tsx
+++ b/src/components/message/goal-tool-call.test.tsx
@@ -85,11 +85,12 @@ describe("GoalToolCallPart", () => {
     expect(runningTitle).toHaveClass("text-transparent")
     expect(screen.queryByText("Goal active")).not.toBeInTheDocument()
     expect(button.querySelectorAll("svg")).toHaveLength(1)
-    expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
+    // A live goal with process text starts open so the work is visible.
+    expect(screen.getByText("Reading README.md")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button"))
 
-    expect(screen.getByText("Reading README.md")).toBeInTheDocument()
+    expect(screen.queryByText("Reading README.md")).not.toBeInTheDocument()
   })
 
   it("shows active status for wrapper-prefixed create_goal names", () => {

--- a/src/components/message/goal-tool-call.tsx
+++ b/src/components/message/goal-tool-call.tsx
@@ -225,9 +225,18 @@ function GoalCard({
     Boolean(startPart.errorText) ||
     endPart?.state === "output-error" ||
     Boolean(endPart?.errorText)
-  const [bodyOpen, setBodyOpen] = useState(
-    isError || (isRunning && items.length > 0)
-  )
+  // Derived, not mount-initialised: a `useState` seed is evaluated once, and
+  // the card always mounts BEFORE its body exists (create_goal is adapted on
+  // its own, so the run starts with `items: []`). Seeding would leave the
+  // default hostage to whether the row happens to remount later — it does on
+  // the sub-turn merge and on virtualizer recycling, but not on a plain
+  // same-key update. Deriving keeps the DEFAULT a function of the data:
+  // a live run opens as soon as it holds anything, settling collapses it
+  // again (its answer has been lifted out by then), and an error opens even
+  // when it lands late. `userOpen` is the manual override and wins once set,
+  // so any of those defaults yields to a deliberate toggle.
+  const [userOpen, setUserOpen] = useState<boolean | null>(null)
+  const bodyOpen = userOpen ?? (isError || (isRunning && items.length > 0))
   const goal = useMemo(
     () => parseGoal(startPart, endPart),
     [startPart, endPart]
@@ -263,7 +272,7 @@ function GoalCard({
     (normalizedStatus === "active" || normalizedStatus === "paused")
 
   return (
-    <Collapsible open={bodyOpen} onOpenChange={setBodyOpen} className="w-full">
+    <Collapsible open={bodyOpen} onOpenChange={setUserOpen} className="w-full">
       <CollapsibleTrigger
         className={cn(
           "group inline-flex max-w-full items-center gap-1.5 rounded-full px-3.5 py-2 text-xs font-medium transition-colors",

--- a/src/components/message/goal-tool-call.tsx
+++ b/src/components/message/goal-tool-call.tsx
@@ -225,7 +225,9 @@ function GoalCard({
     Boolean(startPart.errorText) ||
     endPart?.state === "output-error" ||
     Boolean(endPart?.errorText)
-  const [bodyOpen, setBodyOpen] = useState(isError)
+  const [bodyOpen, setBodyOpen] = useState(
+    isError || (isRunning && items.length > 0)
+  )
   const goal = useMemo(
     () => parseGoal(startPart, endPart),
     [startPart, endPart]

--- a/src/lib/adapters/ai-elements-adapter.test.ts
+++ b/src/lib/adapters/ai-elements-adapter.test.ts
@@ -507,6 +507,73 @@ describe("groupGoalRuns", () => {
     expect(out[1]).toEqual(text)
   })
 
+  it("lifts a trailing proposed plan and generated image too", () => {
+    // A Plan-mode document and a generated image ARE the turn's answer; a
+    // collapsed capsule must not hide them either. Reasoning is process and
+    // stays inside.
+    const proposedPlan: AdaptedContentPart = {
+      type: "proposed-plan",
+      markdown: "## Plan\n1. do the thing",
+      isStreaming: false,
+    }
+    const generatedImage: AdaptedContentPart = {
+      type: "generated-image",
+      revisedPrompt: null,
+      image: null,
+      status: "completed",
+    }
+    const reasoning: AdaptedContentPart = {
+      type: "reasoning",
+      content: "thinking about it",
+      isStreaming: false,
+    }
+
+    const out = groupGoalRuns(
+      [poll("create_goal"), reasoning, text, proposedPlan, generatedImage],
+      false
+    )
+
+    expect(out.map((p) => p.type)).toEqual([
+      "goal-run",
+      "text",
+      "proposed-plan",
+      "generated-image",
+    ])
+    expect(goalRunOf(out[0]).items).toEqual([reasoning])
+    expect(out.slice(1)).toEqual([text, proposedPlan, generatedImage])
+  })
+
+  it("keeps mid-run prose inside a settled unfinished goal", () => {
+    // Prose followed by more work is a mid-run note, not a wrap-up: lifting it
+    // would reorder the reply, so the scan stops at the last process part.
+    const midRunNote: AdaptedContentPart = { type: "text", text: "checking" }
+    const out = groupGoalRuns(
+      [poll("create_goal"), midRunNote, poll("exec_command")],
+      false
+    )
+
+    expect(out.map((p) => p.type)).toEqual(["goal-run"])
+    expect(goalRunOf(out[0]).items.map((p) => p.type)).toEqual([
+      "text",
+      "tool-call",
+    ])
+  })
+
+  it("keeps the answer inside a live unfinished goal", () => {
+    // While streaming, the card holds the answer and opens itself; lifting
+    // mid-stream would make the prose jump out and back as tools interleave.
+    const proposedPlan: AdaptedContentPart = {
+      type: "proposed-plan",
+      markdown: "## Plan",
+      isStreaming: false,
+    }
+    const out = groupGoalRuns([poll("create_goal"), text, proposedPlan], true)
+
+    expect(out.map((p) => p.type)).toEqual(["goal-run"])
+    expect(goalRunOf(out[0]).items).toEqual([text, proposedPlan])
+    expect(goalRunOf(out[0]).isRunning).toBe(true)
+  })
+
   it("does not mutate a reopened unfinished goal run when closing across turns", () => {
     const firstText: AdaptedContentPart = {
       type: "text",

--- a/src/lib/adapters/ai-elements-adapter.test.ts
+++ b/src/lib/adapters/ai-elements-adapter.test.ts
@@ -485,13 +485,26 @@ describe("groupGoalRuns", () => {
   it("settles an unfinished goal run when not streaming", () => {
     // codex leaves a `/goal` active without a closing update_goal, so a stopped
     // turn or a reloaded conversation must NOT shimmer the capsule forever.
+    // Trailing prose is lifted out so the collapsed chip does not hide it.
     const out = groupGoalRuns([poll("create_goal"), text], false)
 
-    expect(out).toHaveLength(1)
+    expect(out.map((p) => p.type)).toEqual(["goal-run", "text"])
     const goalRun = goalRunOf(out[0])
     expect(goalRun.end).toBeNull()
-    expect(goalRun.items).toEqual([text])
+    expect(goalRun.items).toEqual([])
     expect(goalRun.isRunning).toBe(false)
+    expect(out[1]).toEqual(text)
+  })
+
+  it("lifts trailing prose out of a settled unfinished goal after tools", () => {
+    const out = groupGoalRuns(
+      [poll("create_goal"), poll("exec_command"), text],
+      false
+    )
+
+    expect(out.map((p) => p.type)).toEqual(["goal-run", "text"])
+    expect(goalRunOf(out[0]).items.map((p) => p.type)).toEqual(["tool-call"])
+    expect(out[1]).toEqual(text)
   })
 
   it("does not mutate a reopened unfinished goal run when closing across turns", () => {
@@ -553,8 +566,10 @@ describe("groupGoalRuns", () => {
 
     const out = groupGoalRuns([firstRun, repeatedRun, nextText])
 
-    expect(out).toHaveLength(1)
-    expect(goalRunOf(out[0]).items).toEqual([firstText, nextText])
+    expect(out.map((p) => p.type)).toEqual(["goal-run", "text", "text"])
+    expect(goalRunOf(out[0]).items).toEqual([])
+    expect(out[1]).toEqual(firstText)
+    expect(out[2]).toEqual(nextText)
   })
 
   it("closes an active cross-turn goal when the next turn already has a completed goal run", () => {

--- a/src/lib/adapters/ai-elements-adapter.ts
+++ b/src/lib/adapters/ai-elements-adapter.ts
@@ -1566,18 +1566,35 @@ function mergeGoalObjectiveHints(
  * run flushes with `isRunning: isStreaming`, so it settles (static) once the
  * turn stops or on history reload, and shimmers only while live.
  *
- * The Goal card starts collapsed, so a settled run must not keep the turn's
- * trailing prose inside the chip. After the last non-text item (or when the
- * body is only text), lift those text parts out so a reload still shows the
- * final answer under the chip. While the turn is live the prose stays in the
- * card; the card opens itself while running.
+ * The Goal card starts collapsed once the run settles, so a settled run must
+ * not keep the turn's answer inside the chip. After the last process item (or
+ * when the body is only answer parts), lift those parts out so a reload still
+ * shows the final answer under the chip. While the turn is live the answer
+ * stays in the card, which opens itself as soon as it holds anything.
  */
-function splitTrailingTextParts(items: AdaptedContentPart[]): {
+
+/**
+ * Parts that ARE the turn's answer rather than the process that produced it:
+ * prose, the codex Plan-mode document the user has to read, and a generated
+ * image. Everything else (tool calls/results/groups, reasoning, todo plans,
+ * delegation and background-task polls) is process and belongs in the capsule.
+ */
+const GOAL_ANSWER_PART_TYPES: ReadonlySet<AdaptedContentPart["type"]> = new Set(
+  ["text", "proposed-plan", "generated-image"]
+)
+
+/**
+ * Split a settled unfinished run's body at the last process part: everything
+ * after it is the answer and gets lifted out, in order. Answer parts BEFORE a
+ * process part stay inside — prose followed by more work is a mid-run note,
+ * not a wrap-up, and lifting it would reorder the reply.
+ */
+function splitTrailingAnswerParts(items: AdaptedContentPart[]): {
   body: AdaptedContentPart[]
   trailing: AdaptedContentPart[]
 } {
   let end = items.length
-  while (end > 0 && items[end - 1]?.type === "text") {
+  while (end > 0 && GOAL_ANSWER_PART_TYPES.has(items[end - 1]!.type)) {
     end -= 1
   }
   if (end === items.length) {
@@ -1618,9 +1635,9 @@ export function groupGoalRuns(
     items: AdaptedContentPart[],
     isRunning: boolean
   ) => {
-    // Keep live prose inside the running card (it opens while in flight).
-    // Once the turn settles, lift trailing text so a collapsed chip on
-    // reload does not hide the answer.
+    // Keep the live answer inside the running card (it opens while in flight).
+    // Once the turn settles, lift the trailing answer so a collapsed chip on
+    // reload does not hide it.
     // Only lift when the run never closed. A completed update_goal already
     // leaves later prose as siblings; mid-run notes stay in that card.
     const shouldLiftTrailing = !isRunning && end === null
@@ -1634,7 +1651,7 @@ export function groupGoalRuns(
       })
       return
     }
-    const { body, trailing } = splitTrailingTextParts(items)
+    const { body, trailing } = splitTrailingAnswerParts(items)
     result.push({
       type: "goal-run",
       start,

--- a/src/lib/adapters/ai-elements-adapter.ts
+++ b/src/lib/adapters/ai-elements-adapter.ts
@@ -1565,7 +1565,27 @@ function mergeGoalObjectiveHints(
  * reloaded goal capsule spins forever. `isStreaming` gates that: an unfinished
  * run flushes with `isRunning: isStreaming`, so it settles (static) once the
  * turn stops or on history reload, and shimmers only while live.
+ *
+ * The Goal card starts collapsed, so a settled run must not keep the turn's
+ * trailing prose inside the chip. After the last non-text item (or when the
+ * body is only text), lift those text parts out so a reload still shows the
+ * final answer under the chip. While the turn is live the prose stays in the
+ * card; the card opens itself while running.
  */
+function splitTrailingTextParts(items: AdaptedContentPart[]): {
+  body: AdaptedContentPart[]
+  trailing: AdaptedContentPart[]
+} {
+  let end = items.length
+  while (end > 0 && items[end - 1]?.type === "text") {
+    end -= 1
+  }
+  if (end === items.length) {
+    return { body: items, trailing: [] }
+  }
+  return { body: items.slice(0, end), trailing: items.slice(end) }
+}
+
 export function groupGoalRuns(
   parts: AdaptedContentPart[],
   isStreaming: boolean = false
@@ -1592,17 +1612,44 @@ export function groupGoalRuns(
     return Boolean(objective && completedGoalObjectives.has(objective))
   }
 
-  const flushActive = () => {
-    if (!active) return
+  const pushGoalRun = (
+    start: AdaptedToolCallPart,
+    end: AdaptedToolCallPart | null,
+    items: AdaptedContentPart[],
+    isRunning: boolean
+  ) => {
+    // Keep live prose inside the running card (it opens while in flight).
+    // Once the turn settles, lift trailing text so a collapsed chip on
+    // reload does not hide the answer.
+    // Only lift when the run never closed. A completed update_goal already
+    // leaves later prose as siblings; mid-run notes stay in that card.
+    const shouldLiftTrailing = !isRunning && end === null
+    if (!shouldLiftTrailing) {
+      result.push({
+        type: "goal-run",
+        start,
+        end,
+        items: [...items],
+        isRunning,
+      })
+      return
+    }
+    const { body, trailing } = splitTrailingTextParts(items)
     result.push({
       type: "goal-run",
-      start: active.start,
+      start,
       end: null,
-      items: [...active.items],
-      // Unfinished run: shimmer only while the turn is live. A stopped or
-      // reloaded goal (codex never emits a closing update_goal) settles static.
-      isRunning: isStreaming,
+      items: body,
+      isRunning: false,
     })
+    result.push(...trailing)
+  }
+
+  const flushActive = () => {
+    if (!active) return
+    // Unfinished run: shimmer only while the turn is live. A stopped or
+    // reloaded goal (codex never emits a closing update_goal) settles static.
+    pushGoalRun(active.start, null, active.items, isStreaming)
     active = null
   }
 
@@ -1619,10 +1666,7 @@ export function groupGoalRuns(
         } else if (part.end === null) {
           active = { start: part.start, items: [...part.items] }
         } else {
-          result.push({
-            ...part,
-            items: [...part.items],
-          })
+          pushGoalRun(part.start, part.end, part.items, part.isRunning)
           rememberCompletedGoal(part.start, part.end)
         }
         continue
@@ -1637,13 +1681,12 @@ export function groupGoalRuns(
       if (part.end === null) {
         active.items.push(...part.items)
       } else {
-        result.push({
-          type: "goal-run",
-          start: active.start,
-          end: part.end,
-          items: [...active.items, ...part.items],
-          isRunning: part.isRunning,
-        })
+        pushGoalRun(
+          active.start,
+          part.end,
+          [...active.items, ...part.items],
+          part.isRunning
+        )
         rememberCompletedGoal(active.start, part.end)
         active = null
       }
@@ -1664,13 +1707,7 @@ export function groupGoalRuns(
     }
 
     if (active && isGoalEndPart(part)) {
-      result.push({
-        type: "goal-run",
-        start: active.start,
-        end: part,
-        items: [...active.items],
-        isRunning: isRunningToolCall(part),
-      })
+      pushGoalRun(active.start, part, active.items, isRunningToolCall(part))
       rememberCompletedGoal(active.start, part)
       active = null
       continue


### PR DESCRIPTION
If a `/goal` is still active, Codeg folds the rest of the turn into the Goal chip. That chip starts collapsed, so after a reload you just see `Goal: …` plus New files / Files changed, and the wrap-up is gone until you expand the chip.

This lifts trailing prose out of a settled unfinished goal so the answer stays under the chip. A live goal that still has process text starts open.

Reload a chat that used `/goal` and didn't close it. The last assistant message should still be there, not only the Goal pill.