### PR TITLE
fix(markdown): 嵌套/未闭合代码块里的 \(...\) 被当成公式改写

### DIFF
--- a/src/components/ai-elements/math-delimiters.parse.test.ts
+++ b/src/components/ai-elements/math-delimiters.parse.test.ts
@@ -161,6 +161,32 @@ describe("remark-math with singleDollarTextMath: false", () => {
       expect(parseMath(normalizeMathDelimiters(text))).toEqual([])
     }
   })
+
+  it("does not rewrite \\(...\\) inside a fence nested in a longer fence", () => {
+    // ````md wraps a ```js block; the inner ``` must not close the outer
+    // ```` fence, so the code stays verbatim.
+    const text = "````md\n```js\nconst x = 1 // \\(x\\)\n```\n````"
+    expect(normalizeMathDelimiters(text)).toBe(text)
+    expect(parseMath(normalizeMathDelimiters(text))).toEqual([])
+  })
+
+  it("does not rewrite \\(...\\) inside a still-open fence (streaming mid-state)", () => {
+    // A code block whose closing fence has not streamed in yet runs to EOF;
+    // its contents must not be touched while it is transiently unclosed.
+    const text = "Here is the file:\n```tex\n\\(a+b\\)\n"
+    expect(normalizeMathDelimiters(text)).toBe(text)
+  })
+
+  it("still rewrites \\(...\\) in prose between two fenced blocks", () => {
+    const text =
+      "```\ncode1 \\(keep\\)\n```\nprose \\(x\\) here\n```\ncode2\n```"
+    const out = normalizeMathDelimiters(text)
+    expect(out).toContain("$$x$$")
+    expect(out).toContain("\\(keep\\)")
+    expect(parseMath(out)).toEqual([
+      { type: "inlineMath", value: "x", meta: null },
+    ])
+  })
 })
 
 describe("block structure around a normalized formula", () => {

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -381,8 +381,16 @@ export function normalizeMathDelimiters(text: string): string {
     saved.push(m)
     return `\0CBLK${saved.length - 1}\0`
   }
+  // A fenced block closes only on a fence of the SAME char run at least as
+  // long as its opener (CommonMark 4.5), and an unclosed fence runs to EOF.
+  // Pairing any 3+ run with the next one (the old `` `{3,}[\s\S]*?`{3,} ``)
+  // mis-split a ```` ````md ```` block at its inner ``` ``` ```` fence and left
+  // the code inside unmasked, so `\(...\)` there got rewritten — and every
+  // streaming code block hit the same rewrite while its closing fence was
+  // still pending. Capture the opener and require the closer to be `\1`+ (or
+  // end of string).
   const masked = text.replace(
-    /`{3,}[\s\S]*?`{3,}|~{3,}[\s\S]*?~{3,}|`[^`\n]+`/g,
+    /(`{3,})[\s\S]*?(?:\1`*|$)|(~{3,})[\s\S]*?(?:\2~*|$)|`[^`\n]+`/g,
     placeholder
   )
   // Fold line endings only after masking, so the offsets and line scans below


### PR DESCRIPTION
前几天在预览一篇讲 LaTeX 的 markdown 笔记时发现代码块里的内容被改了,排查下来是 `normalizeMathDelimiters` 屏蔽代码块的正则有问题,顺手修一下。

## 问题

屏蔽代码块用的是 `` `{3,}[\s\S]*?`{3,} ``,它把「任意 3+ 个反引号」和「下一撮 3+ 个反引号」配成一对,没有遵守 CommonMark 的规则——**围栏只能被同种、且不短于开启围栏的反引号关闭**。于是两种情况会漏:

1. **嵌套围栏**:用 ```` ````md ```` 包一个 ```` ```js ```` 代码块时(写教程展示代码块常见),外层四反引号围栏被里面的三反引号错误地「关闭」了,导致中间真正的代码没被屏蔽,里面的 `\(x\)` 被改写成 `$$x$$`。
2. **未闭合围栏**:流式输出时,代码块的结尾围栏还没到,此时整段是「未闭合」的,正则匹配不到收尾,代码内容同样被改写 —— 表现为代码块里的公式在流式过程中一直闪。

## 复现

新建一个 `.md` 文件,内容:

    ````md
    ```js
    const x = 1 // \(x\)
    ```
    ````

在文件预览里打开,代码块里的 `\(x\)` 会被渲染成 `$$x$$`(居中的斜体公式),而它本该原样显示。AI 回复里出现同样的嵌套结构,以及任意代码块在流式输出途中,都会命中。

## 修复

把开启围栏用捕获组存下来,要求收尾围栏是「同种字符、不短于开启围栏」的一撮(`` \1`* `` / `\2~*`),或者直接到字符串结尾(对应未闭合的情况)。两个真实围栏**之间**的正文公式仍然照常规范化,行为不变。

## 测试

在 `math-delimiters.parse.test.ts` 里补了 3 个用例(嵌套围栏、未闭合围栏、两围栏之间的正文公式),`pnpm test` 全绿(4296 passed),`pnpm eslint` 通过。