### PR TITLE
fix(tasks): preserve review status after session cancellation

### DIFF
--- a/src-tauri/src/db/service/work_task_service.rs
+++ b/src-tauri/src/db/service/work_task_service.rs
@@ -1485,6 +1485,45 @@ pub async fn fail(
     Ok(true)
 }
 
+/// Cancel the active generation when its agent reports a cancelled turn.
+///
+/// Unlike [`cancel`], this is an engine-owned transition: a delayed event must
+/// not overwrite a generation that has already settled for review (or a newer
+/// generation of the same task).
+pub async fn cancel_running_generation(
+    conn: &DatabaseConnection,
+    id: i32,
+    run_seq: i32,
+) -> Result<bool, DbError> {
+    let now = Utc::now();
+    let txn = conn.begin().await?;
+    let res = work_task::Entity::update_many()
+        .col_expr(
+            work_task::Column::Status,
+            Expr::value(status_str(WorkTaskStatus::Canceled)),
+        )
+        .col_expr(work_task::Column::ConnectionId, Expr::value(None::<String>))
+        .col_expr(work_task::Column::PendingMerge, Expr::value(None::<String>))
+        .col_expr(work_task::Column::FinishedAt, Expr::value(Some(now)))
+        .col_expr(work_task::Column::UpdatedAt, Expr::value(now))
+        .filter(work_task::Column::Id.eq(id))
+        .filter(
+            work_task::Column::Status
+                .is_in([WorkTaskStatus::Running, WorkTaskStatus::AwaitingInput]),
+        )
+        .filter(work_task::Column::RunSeq.eq(run_seq))
+        .filter(work_task::Column::DeletedAt.is_null())
+        .exec(&txn)
+        .await?;
+    if res.rows_affected != 1 {
+        txn.rollback().await?;
+        return Ok(false);
+    }
+    status_changed_event(&txn, id, "engine", None, WorkTaskStatus::Canceled, None).await?;
+    txn.commit().await?;
+    Ok(true)
+}
+
 /// running/awaiting_input → review for the given generation. Captures the
 /// agent's summary and the diff-stat snapshot; also writes a `diff_stat` event
 /// when stats are present.

--- a/src-tauri/src/db/service/work_task_service.rs
+++ b/src-tauri/src/db/service/work_task_service.rs
@@ -1495,33 +1495,15 @@ pub async fn cancel_running_generation(
     id: i32,
     run_seq: i32,
 ) -> Result<bool, DbError> {
-    let now = Utc::now();
-    let txn = conn.begin().await?;
-    let res = work_task::Entity::update_many()
-        .col_expr(
-            work_task::Column::Status,
-            Expr::value(status_str(WorkTaskStatus::Canceled)),
-        )
-        .col_expr(work_task::Column::ConnectionId, Expr::value(None::<String>))
-        .col_expr(work_task::Column::PendingMerge, Expr::value(None::<String>))
-        .col_expr(work_task::Column::FinishedAt, Expr::value(Some(now)))
-        .col_expr(work_task::Column::UpdatedAt, Expr::value(now))
-        .filter(work_task::Column::Id.eq(id))
-        .filter(
-            work_task::Column::Status
-                .is_in([WorkTaskStatus::Running, WorkTaskStatus::AwaitingInput]),
-        )
-        .filter(work_task::Column::RunSeq.eq(run_seq))
-        .filter(work_task::Column::DeletedAt.is_null())
-        .exec(&txn)
-        .await?;
-    if res.rows_affected != 1 {
-        txn.rollback().await?;
-        return Ok(false);
-    }
-    status_changed_event(&txn, id, "engine", None, WorkTaskStatus::Canceled, None).await?;
-    txn.commit().await?;
-    Ok(true)
+    cancel_inner(
+        conn,
+        id,
+        &[WorkTaskStatus::Running, WorkTaskStatus::AwaitingInput],
+        Some(run_seq),
+        "engine",
+        None,
+    )
+    .await
 }
 
 /// running/awaiting_input → review for the given generation. Captures the
@@ -2326,9 +2308,40 @@ pub async fn cancel(
     id: i32,
     reason: Option<&str>,
 ) -> Result<bool, DbError> {
+    cancel_inner(
+        conn,
+        id,
+        &[
+            WorkTaskStatus::Todo,
+            WorkTaskStatus::Queued,
+            WorkTaskStatus::Preparing,
+            WorkTaskStatus::Running,
+            WorkTaskStatus::AwaitingInput,
+            WorkTaskStatus::Review,
+            WorkTaskStatus::Failed,
+        ],
+        None,
+        "user",
+        reason,
+    )
+    .await
+}
+
+/// The single conditional UPDATE behind both cancels: `expected` (and, for an
+/// engine-owned transition, `run_seq`) is the CAS; `actor` / `reason` is the
+/// audit trail. One write, so the columns a cancel has to clear can never drift
+/// between the user's stop button and the engine's own.
+async fn cancel_inner(
+    conn: &DatabaseConnection,
+    id: i32,
+    expected: &[WorkTaskStatus],
+    run_seq: Option<i32>,
+    actor: &str,
+    reason: Option<&str>,
+) -> Result<bool, DbError> {
     let now = Utc::now();
     let txn = conn.begin().await?;
-    let res = work_task::Entity::update_many()
+    let mut update = work_task::Entity::update_many()
         .col_expr(
             work_task::Column::Status,
             Expr::value(status_str(WorkTaskStatus::Canceled)),
@@ -2339,7 +2352,9 @@ pub async fn cancel(
         .col_expr(work_task::Column::PendingMerge, Expr::value(None::<String>))
         // Same reasoning for a planned start: stopping a task drops its plan,
         // so a requeue days later cannot resurrect a time nobody remembers
-        // setting and launch an agent unattended.
+        // setting and launch an agent unattended. (A running row carries no
+        // plan — every claim consumes it — so this only bites the user path,
+        // but the clear belongs to "canceled", not to one caller.)
         .col_expr(
             work_task::Column::ScheduledAt,
             Expr::value(None::<chrono::DateTime<Utc>>),
@@ -2347,18 +2362,12 @@ pub async fn cancel(
         .col_expr(work_task::Column::FinishedAt, Expr::value(Some(now)))
         .col_expr(work_task::Column::UpdatedAt, Expr::value(now))
         .filter(work_task::Column::Id.eq(id))
-        .filter(work_task::Column::Status.is_in([
-            WorkTaskStatus::Todo,
-            WorkTaskStatus::Queued,
-            WorkTaskStatus::Preparing,
-            WorkTaskStatus::Running,
-            WorkTaskStatus::AwaitingInput,
-            WorkTaskStatus::Review,
-            WorkTaskStatus::Failed,
-        ]))
-        .filter(work_task::Column::DeletedAt.is_null())
-        .exec(&txn)
-        .await?;
+        .filter(work_task::Column::Status.is_in(expected.iter().copied()))
+        .filter(work_task::Column::DeletedAt.is_null());
+    if let Some(run_seq) = run_seq {
+        update = update.filter(work_task::Column::RunSeq.eq(run_seq));
+    }
+    let res = update.exec(&txn).await?;
     if res.rows_affected != 1 {
         txn.rollback().await?;
         return Ok(false);
@@ -2367,7 +2376,7 @@ pub async fn cancel(
         .map(str::trim)
         .filter(|r| !r.is_empty())
         .map(|r| serde_json::json!({ "reason": r }));
-    status_changed_event(&txn, id, "user", None, WorkTaskStatus::Canceled, extra).await?;
+    status_changed_event(&txn, id, actor, None, WorkTaskStatus::Canceled, extra).await?;
     txn.commit().await?;
     Ok(true)
 }

--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -2061,9 +2061,10 @@ impl TaskEngine {
                 }
             }
             "cancelled" => {
-                // The user stopped the agent from the conversation UI — that is
-                // a task cancel, not an agent failure.
-                work_task_service::cancel(&self.db.conn, task_id, None)
+                // A cancelled task generation is a cancellation, not an agent
+                // failure. Keep it generation-scoped: a delayed event must not
+                // cancel a task that already reached review or was requeued.
+                work_task_service::cancel_running_generation(&self.db.conn, task_id, run_seq)
                     .await
                     .unwrap_or(false)
             }
@@ -4368,9 +4369,13 @@ impl TaskEngine {
                     settled
                 }
                 Some(ConversationStatus::Cancelled) => {
-                    work_task_service::cancel(&self.db.conn, task.id, None)
-                        .await
-                        .unwrap_or(false)
+                    work_task_service::cancel_running_generation(
+                        &self.db.conn,
+                        task.id,
+                        task.run_seq,
+                    )
+                    .await
+                    .unwrap_or(false)
                 }
                 _ => work_task_service::fail(
                     &self.db.conn,
@@ -7121,6 +7126,37 @@ mod tests {
             .await
             .expect("task row")
             .status
+    }
+
+    #[tokio::test]
+    async fn a_late_cancelled_event_does_not_cancel_a_task_in_review() {
+        let (engine, task_id) = running_task().await;
+        let run_seq = work_task_service::get_model(&engine.db.conn, task_id)
+            .await
+            .expect("task row")
+            .run_seq;
+        assert!(work_task_service::settle_review(
+            &engine.db.conn,
+            task_id,
+            run_seq,
+            None,
+            None,
+        )
+        .await
+        .expect("settle review"));
+
+        engine.on_turn_complete(PARENT_CONN, "cancelled").await;
+
+        assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Review);
+    }
+
+    #[tokio::test]
+    async fn a_current_cancelled_event_cancels_the_running_task() {
+        let (engine, task_id) = running_task().await;
+
+        engine.on_turn_complete(PARENT_CONN, "cancelled").await;
+
+        assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Canceled);
     }
 
     fn env(conn_id: &str, payload: AcpEvent) -> EventEnvelope {

--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -7159,6 +7159,55 @@ mod tests {
         assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Canceled);
     }
 
+    /// The other half of the CAS: the status alone would let a stale
+    /// connection's cancel land on the RUN AFTER it, which is `running` again
+    /// and so passes the status gate. Only `run_seq` tells the two apart.
+    #[tokio::test]
+    async fn a_previous_generation_cancelled_event_spares_the_current_run() {
+        let (engine, task_id) = running_task().await;
+        let row = work_task_service::get_model(&engine.db.conn, task_id)
+            .await
+            .expect("task row");
+        let (stale_seq, conv_id) = (row.run_seq, row.conversation_id.expect("conversation"));
+        // Walk the real chain into the next generation: settle, requeue, run.
+        assert!(work_task_service::settle_review(
+            &engine.db.conn,
+            task_id,
+            stale_seq,
+            None,
+            None,
+        )
+        .await
+        .expect("settle review"));
+        let next_seq = work_task_service::claim_for_run(
+            &engine.db.conn,
+            task_id,
+            WorkTaskStatus::Review,
+            "test",
+        )
+        .await
+        .expect("claim")
+        .expect("claimed");
+        assert_ne!(next_seq, stale_seq);
+        assert!(work_task_service::begin_setup(&engine.db.conn, task_id, next_seq)
+            .await
+            .expect("begin_setup"));
+        assert!(work_task_service::mark_running(
+            &engine.db.conn,
+            task_id,
+            next_seq,
+            conv_id,
+            "conn-next",
+        )
+        .await
+        .expect("mark_running"));
+
+        // The old connection's cancel finally arrives.
+        engine.on_turn_complete(PARENT_CONN, "cancelled").await;
+
+        assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Running);
+    }
+
     fn env(conn_id: &str, payload: AcpEvent) -> EventEnvelope {
         EventEnvelope {
             seq: 0,


### PR DESCRIPTION
我在这次修改中解决了 #543：任务完成后从会话继续聊天，任务状态被错误标记为“已取消”。

## 原本的问题

我确认任务正常完成并进入“待验收”状态后，如果用户回到对应会话继续聊天，或者此时触发会话状态同步，一个较晚到达的智能体“已取消”结束事件仍可能把任务状态从“待验收”改成“已取消”。

这会覆盖任务已经完成并等待用户验收的真实状态，让用户误以为任务被主动取消，同时丢失正确的后续处理入口。

## 问题根因

我检查后发现，实时会话结束回调和断线后的状态对账在处理 `cancelled` 事件时，都调用了通用的任务取消方法 `cancel`。

这个通用方法还承担用户从任务面板明确执行“取消任务”的功能，因此它允许取消处于“待验收”状态的任务。问题在于，智能体产生的结束事件也复用了同一条状态转换路径：当旧事件延迟到达，或者任务对应的运行批次已经结束时，它仍然可以覆盖当前有效状态。

## 我做的修改

1. 我新增了 `cancel_running_generation`，专门处理由任务引擎产生的取消事件。
2. 我让这项数据库更新同时校验任务编号、运行批次 `run_seq` 和当前状态。只有同一运行批次且仍处于“运行中”或“等待输入”的任务，才能被引擎改为“已取消”。
3. 我把实时会话的 `cancelled` 结束回调和断线后的会话状态对账都切换到这项受限操作，确保两条引擎取消路径遵循相同规则。
4. 引擎确认取消当前运行批次时，我会同时清理会话连接和待合并状态，并记录对应的状态变化事件。
5. 我保留了原有通用 `cancel` 方法的行为，用户仍然可以从任务面板明确取消处于“待验收”状态的任务。
6. 我补充了两个回归测试：一个验证延迟到达的取消事件不会覆盖“待验收”状态，另一个验证当前运行批次收到取消事件后仍会正常进入“已取消”状态。

## 为什么这样修改

我没有简单地禁止取消所有处于“待验收”状态的任务，因为这会破坏用户主动取消任务的既有能力。这里需要区分的是取消事件的来源，而不是一刀切地收窄所有取消操作。

通过校验 `run_seq`，我可以阻止旧运行批次的事件影响新批次；通过限制当前状态，我可以阻止已经完成并进入“待验收”的任务被引擎事件回退；通过数据库单次条件更新完成校验和状态写入，我也避免了先读取、再判断、最后更新所产生的并发竞态。

这样既修复了延迟事件覆盖有效状态的问题，也保留了用户明确操作时应有的状态控制能力。

## 验证结果

- 我运行了 `cd src-tauri && cargo test --no-default-features --lib work_task`，共 133 项测试通过，0 项失败。
- 我运行了 `git -c safe.directory=/workspace diff --check`，检查通过。


