### PR TITLE
Right-click Copy image on staged composer attachments

### DIFF
--- a/src/components/chat/composer/composer-image-thumbnails.test.tsx
+++ b/src/components/chat/composer/composer-image-thumbnails.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { NextIntlClientProvider } from "next-intl"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import enMessages from "@/i18n/messages/en.json"
+import type { ImageInputAttachment } from "@/components/chat/message-input-attachments"
+
+const mocks = vi.hoisted(() => ({
+  canCopyImageToClipboard: vi.fn(() => true),
+  copyImageToClipboard: vi.fn(async () => {}),
+  downloadImage: vi.fn(async () => true),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  ancestorContextMenu: vi.fn(),
+}))
+
+vi.mock("@/lib/copy-image", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/copy-image")>()
+  return {
+    ...actual,
+    canCopyImageToClipboard: mocks.canCopyImageToClipboard,
+    copyImageToClipboard: mocks.copyImageToClipboard,
+  }
+})
+
+vi.mock("@/lib/image-download", () => ({ downloadImage: mocks.downloadImage }))
+
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}))
+
+import { ComposerImageThumbnails } from "./composer-image-thumbnails"
+
+const ATTACHMENT: ImageInputAttachment = {
+  id: "att-1",
+  type: "image",
+  data: "QQ==",
+  uri: null,
+  name: "shot.png",
+  mimeType: "image/png",
+}
+
+function renderStrip() {
+  return render(
+    // The outer handler stands in for the composer's own text context menu,
+    // which wraps the whole input area including the attachment strip.
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <div onContextMenu={mocks.ancestorContextMenu}>
+        <ComposerImageThumbnails
+          attachments={[ATTACHMENT]}
+          onRemove={vi.fn()}
+        />
+      </div>
+    </NextIntlClientProvider>
+  )
+}
+
+/** The context-menu trigger wrapped around the staged thumbnail. */
+function trigger(): HTMLElement {
+  const element = document.querySelector<HTMLElement>("[data-image-actions]")
+  if (!element) throw new Error("expected a context-menu trigger on the tile")
+  return element
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.canCopyImageToClipboard.mockReturnValue(true)
+})
+
+describe("ComposerImageThumbnails", () => {
+  it("offers Copy image on right-click instead of the composer text menu", async () => {
+    renderStrip()
+
+    fireEvent.contextMenu(trigger())
+
+    const copyItem = await screen.findByRole("menuitem", {
+      name: "Copy image",
+    })
+    expect(mocks.ancestorContextMenu).not.toHaveBeenCalled()
+
+    fireEvent.click(copyItem)
+    await waitFor(() =>
+      expect(mocks.copyImageToClipboard).toHaveBeenCalledWith({
+        data: ATTACHMENT.data,
+        mime_type: ATTACHMENT.mimeType,
+      })
+    )
+  })
+
+  it("offers Download image on right-click", async () => {
+    renderStrip()
+
+    fireEvent.contextMenu(trigger())
+
+    const downloadItem = await screen.findByRole("menuitem", {
+      name: "Download image",
+    })
+    fireEvent.click(downloadItem)
+    await waitFor(() =>
+      expect(mocks.downloadImage).toHaveBeenCalledWith({
+        data: ATTACHMENT.data,
+        mime_type: ATTACHMENT.mimeType,
+        suggestedName: ATTACHMENT.name,
+      })
+    )
+  })
+
+  it("keeps the tile out of our menu when the clipboard cannot take images", () => {
+    mocks.canCopyImageToClipboard.mockReturnValue(false)
+    renderStrip()
+
+    // The native-menu passthrough still blocks the composer's text menu.
+    const native = document.querySelector("[data-image-actions-native]")
+    expect(native).not.toBeNull()
+    fireEvent.contextMenu(native as HTMLElement)
+    expect(mocks.ancestorContextMenu).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/chat/composer/composer-image-thumbnails.test.tsx
+++ b/src/components/chat/composer/composer-image-thumbnails.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react"
 import { NextIntlClientProvider } from "next-intl"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -103,6 +109,50 @@ describe("ComposerImageThumbnails", () => {
         suggestedName: ATTACHMENT.name,
       })
     )
+  })
+
+  it("carries the actions into the blown-up preview", async () => {
+    renderStrip()
+
+    fireEvent.click(screen.getByAltText(ATTACHMENT.name))
+    const dialog = await screen.findByRole("dialog")
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Copy image" }))
+    await waitFor(() =>
+      expect(mocks.copyImageToClipboard).toHaveBeenCalledWith({
+        data: ATTACHMENT.data,
+        mime_type: ATTACHMENT.mimeType,
+      })
+    )
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: "Download image" })
+    )
+    await waitFor(() => expect(mocks.downloadImage).toHaveBeenCalled())
+    // Neither action doubles as "close": the buttons stop the click from
+    // reaching the backdrop that dismisses the preview.
+    expect(screen.queryByRole("dialog")).not.toBeNull()
+  })
+
+  it("offers the right-click menu on the blown-up image too", async () => {
+    renderStrip()
+
+    fireEvent.click(screen.getByAltText(ATTACHMENT.name))
+    const dialog = await screen.findByRole("dialog")
+    const previewTrigger = dialog.querySelector<HTMLElement>(
+      "[data-image-actions]"
+    )
+    expect(previewTrigger).not.toBeNull()
+
+    fireEvent.contextMenu(previewTrigger as HTMLElement)
+    const downloadItem = await screen.findByRole("menuitem", {
+      name: "Download image",
+    })
+
+    fireEvent.click(downloadItem)
+    await waitFor(() => expect(mocks.downloadImage).toHaveBeenCalled())
+    // The menu is portaled out, but its click still bubbles through the React
+    // tree to the dialog's dismiss-on-click backdrop — which must not fire.
+    expect(screen.queryByRole("dialog")).not.toBeNull()
   })
 
   it("keeps the tile out of our menu when the clipboard cannot take images", () => {

--- a/src/components/chat/composer/composer-image-thumbnails.tsx
+++ b/src/components/chat/composer/composer-image-thumbnails.tsx
@@ -6,7 +6,22 @@ import { useTranslations } from "next-intl"
 import { Loader2, X } from "lucide-react"
 
 import { ImagePreviewDialog } from "@/components/ui/image-preview-dialog"
+import {
+  ImageActions,
+  useImageActions,
+} from "@/components/message/image-actions"
+import type { UserImageDisplay } from "@/lib/adapters/ai-elements-adapter"
 import type { ImageInputAttachment } from "@/components/chat/message-input-attachments"
+
+/** The staged attachment reshaped for the shared transcript image actions. */
+function toDisplay(attachment: ImageInputAttachment): UserImageDisplay {
+  return {
+    name: attachment.name,
+    data: attachment.data,
+    mime_type: attachment.mimeType,
+    uri: attachment.uri,
+  }
+}
 
 /**
  * The composer's image attachment strip: one thumbnail per pasted / dropped /
@@ -17,6 +32,11 @@ import type { ImageInputAttachment } from "@/components/chat/message-input-attac
  * alongside the context chips, while the to-do task composers put it in a plain
  * row above the editor. The preview dialog is owned here: it's an artifact of
  * clicking a tile, not state any host needs.
+ *
+ * Tiles and the blown-up preview carry the same right-click Copy / Download
+ * menu as transcript images (`ImageActions`); without it a right-click on a
+ * staged image fell through to the composer's own text context menu, whose
+ * Copy row copies nothing for an image.
  */
 export function ComposerImageThumbnails({
   attachments,
@@ -26,16 +46,22 @@ export function ComposerImageThumbnails({
   onRemove: (id: string) => void
 }) {
   const t = useTranslations("Folder.chat.messageInput")
+  // The shared image actions live in the transcript's namespace; reusing the
+  // exact keys keeps the two menus identical in every locale.
+  const tImage = useTranslations("Folder.chat.messageList")
   const [previewId, setPreviewId] = useState<string | null>(null)
+  const { canCopy, copy, download } = useImageActions()
   const preview = previewId
     ? (attachments.find((a) => a.id === previewId) ?? null)
     : null
+  const previewDisplay = preview ? toDisplay(preview) : null
 
   return (
     <>
       {attachments.map((attachment) => (
-        <div
+        <ImageActions
           key={attachment.id}
+          image={toDisplay(attachment)}
           className="relative shrink-0 overflow-hidden rounded-md border border-border/70 bg-muted/30"
         >
           <button
@@ -67,7 +93,7 @@ export function ComposerImageThumbnails({
           >
             <X className="h-3 w-3" />
           </button>
-        </div>
+        </ImageActions>
       ))}
       <ImagePreviewDialog
         src={preview ? `data:${preview.mimeType};base64,${preview.data}` : ""}
@@ -76,6 +102,23 @@ export function ComposerImageThumbnails({
         onOpenChange={(open) => {
           if (!open) setPreviewId(null)
         }}
+        onDownload={
+          previewDisplay ? () => void download(previewDisplay) : undefined
+        }
+        downloadLabel={tImage("downloadImage")}
+        onCopy={
+          previewDisplay && canCopy
+            ? () => void copy(previewDisplay)
+            : undefined
+        }
+        copyLabel={tImage("copyImage")}
+        renderImage={
+          previewDisplay
+            ? (image) => (
+                <ImageActions image={previewDisplay}>{image}</ImageActions>
+              )
+            : undefined
+        }
       />
     </>
   )


### PR DESCRIPTION
## Symptom

Right-clicking an image that is STAGED in the composer (a pasted or attached picture, or its blown-up preview) opens the composer's text context menu (Cut / Copy / Paste as plain text / Select all / Quick messages). The Copy row copies nothing for an image, and there is no Copy image row at all.

## Cause

#482 wired the Copy/Download image actions onto the transcript surfaces (generated images, user attachments in messages, and their preview dialogs). The composer's own attachment strip (`ComposerImageThumbnails`) and the preview it opens were never covered, so a right-click there bubbles up to `message-input`'s text menu.

## Fix

Wrap each staged tile in the same `ImageActions` context menu, and pass the preview dialog the same `onCopy` / `onDownload` / `renderImage` it already supports. The menu reuses the transcript's translation keys, so no new locale strings and both menus stay identical in every language. The non-secure-context fallback (native browser image menu instead of a Copy row that can only fail) carries over for free.

## Validation

- 3 new tests on the strip: right-click offers Copy image and Download image without triggering the composer's ancestor menu, copy/download hit the shared clipboard/download helpers with the staged bytes, and the no-clipboard passthrough still blocks the text menu.
- Full `src/components/message` + `src/components/chat/composer` suites: 715 tests pass.
- `eslint` and `tsc --noEmit` clean.
