### PR TITLE
fix(window): show a hidden owner when its auxiliary window closes

### DIFF
--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -826,18 +826,25 @@ pub async fn open_import_sessions_window(
     Ok(())
 }
 
-/// Bring an auxiliary window's owner back to the front when that auxiliary
-/// window closes.
+/// Bring `label` to the foreground: unminimize, unhide, then focus.
 ///
-/// `set_focus` on its own is not enough: it is skipped entirely while the
-/// window is hidden or minimized, and the workspace close button *hides*
-/// `main` to the tray (see the `main` `CloseRequested` arm in `lib.rs`).
-/// Settings is deliberately an independent top-level window, so the workspace
-/// can be hidden while it is still open; restoring by focus alone then left
-/// the app with nothing on screen once settings was closed too. Mirrors
-/// `show_main_window`'s unminimize → show → focus order.
-fn restore_owner_window(app: &AppHandle, owner_label: &str) {
-    let Some(window) = app.get_webview_window(owner_label) else {
+/// `set_focus` on its own is not enough: tao skips it outright while the
+/// window is hidden or minimized (both the Windows and the macOS backend
+/// guard on `is_visible && !is_minimized`), and the workspace close button
+/// *hides* `main` to the tray (see the `main` `CloseRequested` arm in
+/// `lib.rs`). Settings is deliberately an independent top-level window, so
+/// the workspace can be hidden while it is still open; restoring an owner by
+/// focus alone then left the app with nothing on screen once settings was
+/// closed too.
+///
+/// Single source of truth for the sequence: the tray / dock / single-instance
+/// path (`show_main_window`) and the auxiliary-window owner restores must not
+/// drift apart again. `unminimize` is inert when the window isn't minimized
+/// (macOS returns early; Windows first syncs the flag from `IsIconic`, so the
+/// diff it applies is empty), and `show` preserves the maximized flag — a
+/// tray-hidden maximized workspace comes back maximized.
+fn show_and_focus_window(app: &AppHandle, label: &str) {
+    let Some(window) = app.get_webview_window(label) else {
         return;
     };
     let _ = window.unminimize();
@@ -851,7 +858,7 @@ pub fn restore_windows_after_settings(
     settings_window_label: &str,
 ) {
     if let Some(owner_label) = state.take_owner(settings_window_label) {
-        restore_owner_window(app, &owner_label);
+        show_and_focus_window(app, &owner_label);
     }
 }
 
@@ -861,7 +868,7 @@ pub fn restore_window_after_commit(
     commit_window_label: &str,
 ) {
     if let Some(owner_label) = state.take_owner(commit_window_label) {
-        restore_owner_window(app, &owner_label);
+        show_and_focus_window(app, &owner_label);
     }
 }
 
@@ -971,7 +978,7 @@ pub fn restore_window_after_merge(
     merge_window_label: &str,
 ) {
     if let Some(owner_label) = state.take_owner(merge_window_label) {
-        restore_owner_window(app, &owner_label);
+        show_and_focus_window(app, &owner_label);
     }
 }
 
@@ -1962,11 +1969,7 @@ pub fn can_hide_to_tray() -> bool {
 ///   * macOS dock-icon reopen
 #[cfg(feature = "tauri-runtime")]
 pub fn show_main_window(app: &AppHandle) {
-    if let Some(main) = app.get_webview_window("main") {
-        let _ = main.unminimize();
-        let _ = main.show();
-        let _ = main.set_focus();
-    }
+    show_and_focus_window(app, "main");
 }
 
 #[cfg(feature = "tauri-runtime")]

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -826,15 +826,32 @@ pub async fn open_import_sessions_window(
     Ok(())
 }
 
+/// Bring an auxiliary window's owner back to the front when that auxiliary
+/// window closes.
+///
+/// `set_focus` on its own is not enough: it is skipped entirely while the
+/// window is hidden or minimized, and the workspace close button *hides*
+/// `main` to the tray (see the `main` `CloseRequested` arm in `lib.rs`).
+/// Settings is deliberately an independent top-level window, so the workspace
+/// can be hidden while it is still open; restoring by focus alone then left
+/// the app with nothing on screen once settings was closed too. Mirrors
+/// `show_main_window`'s unminimize → show → focus order.
+fn restore_owner_window(app: &AppHandle, owner_label: &str) {
+    let Some(window) = app.get_webview_window(owner_label) else {
+        return;
+    };
+    let _ = window.unminimize();
+    let _ = window.show();
+    let _ = window.set_focus();
+}
+
 pub fn restore_windows_after_settings(
     app: &AppHandle,
     state: &SettingsWindowState,
     settings_window_label: &str,
 ) {
     if let Some(owner_label) = state.take_owner(settings_window_label) {
-        if let Some(window) = app.get_webview_window(&owner_label) {
-            let _ = window.set_focus();
-        }
+        restore_owner_window(app, &owner_label);
     }
 }
 
@@ -844,9 +861,7 @@ pub fn restore_window_after_commit(
     commit_window_label: &str,
 ) {
     if let Some(owner_label) = state.take_owner(commit_window_label) {
-        if let Some(window) = app.get_webview_window(&owner_label) {
-            let _ = window.set_focus();
-        }
+        restore_owner_window(app, &owner_label);
     }
 }
 
@@ -956,9 +971,7 @@ pub fn restore_window_after_merge(
     merge_window_label: &str,
 ) {
     if let Some(owner_label) = state.take_owner(merge_window_label) {
-        if let Some(window) = app.get_webview_window(&owner_label) {
-            let _ = window.set_focus();
-        }
+        restore_owner_window(app, &owner_label);
     }
 }
 
@@ -2131,6 +2144,35 @@ pub async fn set_tray_locale(
 ) -> Result<(), AppCommandError> {
     refresh_tray_menu(&app, locale)
         .map_err(|e| AppCommandError::window("Failed to refresh tray menu", e.to_string()))
+}
+
+#[cfg(test)]
+mod owner_window_tests {
+    use super::SettingsWindowState;
+
+    // `lib.rs` runs the restore on both `CloseRequested` and `Destroyed`, so the
+    // owner has to be handed back exactly once. That mattered less while the
+    // restore was a bare `set_focus`; now that it also unhides the owner, a
+    // second pass would fight a user who re-hid the workspace in between.
+    #[test]
+    fn settings_owner_is_handed_back_once() {
+        let state = SettingsWindowState::new();
+        state.set_owner("settings".to_string(), "main".to_string());
+
+        assert_eq!(state.take_owner("settings").as_deref(), Some("main"));
+        assert_eq!(state.take_owner("settings"), None);
+    }
+
+    // Re-opening settings from a different window re-points the owner, so the
+    // restore brings back the window the user actually came from.
+    #[test]
+    fn reopening_settings_repoints_the_owner() {
+        let state = SettingsWindowState::new();
+        state.set_owner("settings".to_string(), "main".to_string());
+        state.set_owner("settings".to_string(), "remote-workspace-3".to_string());
+
+        assert_eq!(state.take_owner("settings").as_deref(), Some("remote-workspace-3"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hit this on Windows 11: open Settings, then close the workspace window (its X hides to tray, which is easy to do by accident with Settings sitting on top of it). Close Settings and the app is now on screen nowhere.

`restore_windows_after_settings` only calls `set_focus()` on the owner window. That call is skipped outright when the window is hidden or minimized, on Windows and on macOS both, so a workspace that got hidden to the tray never comes back and you are left with no visible window. Settings is intentionally not a child window, so nothing else pulls it back either.

`show_main_window` in the same file already has the right sequence for the tray and dock paths, so this pulls that into a small helper and uses it for the settings, commit and merge owner restores, which all had the same bare `set_focus`.

Two unit tests for the owner map, since the restore now has a visible effect and the handler fires on both CloseRequested and Destroyed.
