### PR TITLE
fix(acp): adopt a Claude title written after the turn ends

### DIFF
--- a/src-tauri/src/acp/background_watch.rs
+++ b/src-tauri/src/acp/background_watch.rs
@@ -37,13 +37,23 @@
 //!   consumed exactly once, so a cron//loop re-fire of the SAME text later
 //!   correctly classifies as out-of-turn).
 //!
+//! * **Session title** — Claude Code's generated name arrives as a dedicated
+//!   `ai-title` transcript record whenever the background summarizer finishes,
+//!   routinely AFTER the turn that triggered it ended. The ACP adapter only
+//!   pulls the name at turn-end (`maybeUpdateSessionTitle`, claude-agent-acp
+//!   0.69.0), so on a short session there is nothing to read yet and no wire
+//!   event ever follows. These bytes are already being tailed, so the records
+//!   are folded here and handed to [`publish_native_title`] — the same path a
+//!   live ACP title takes. Not activity: it rides alongside the activity event
+//!   rather than inside it (see `run_watch`).
+//!
 //! The watcher is connection-scoped on purpose: background work cannot outlive
 //! the agent CLI process, whose lifetime IS the connection's. Poll ticks are
 //! mtime-gated (an unchanged file costs one `stat`).
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufRead, Read, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -313,8 +323,11 @@ async fn run_watch(
         // common case for a title generated after the last turn ended.
         //
         // Held rather than dropped while the conversation row is still
-        // unbound: unlike a live ACP title there is no resend to fall back on,
-        // because the record is read once and those bytes are never re-read.
+        // unbound: unlike a live ACP title there is no resend to COUNT on.
+        // These bytes are read exactly once, and while the CLI does re-emit the
+        // record on its own metadata flushes, nothing guarantees another one
+        // lands after the row binds — a session that ends right there would
+        // keep its first-prompt name.
         //
         // Bound to a `let` so the read guard is released before
         // `publish_native_title` asks for the write lock, and short-circuited
@@ -481,6 +494,11 @@ pub(crate) struct WatchState {
     /// string so the user's `/rename` keeps winning over a title Claude Code
     /// generates afterwards, exactly as `parse_conversation_detail` resolves
     /// the pair over the whole file.
+    ///
+    /// Seeded from the skipped pre-baseline history at arm time
+    /// (`seed_titles_from_history`) precisely because that resolution IS a
+    /// whole-file rule — the two records are appended independently, so the
+    /// tail alone is not enough to resolve them.
     custom_title: Option<String>,
     ai_title: Option<String>,
     /// A resolved title this watch read but has not published yet. Set only
@@ -817,8 +835,63 @@ impl WatchState {
             // must see this tick as changed so a baseline that landed BEFORE
             // EOF (pre-discovery records to process) is read immediately, not
             // on the next unrelated append.
+            self.seed_titles_from_history(&f, self.committed);
         }
         self.file = Some(f);
+    }
+
+    /// Fold the title records in the SKIPPED history into the title slots,
+    /// without queueing any of them for publication.
+    ///
+    /// `customTitle ?? aiTitle` is a WHOLE-FILE rule, and Claude Code appends
+    /// the two records INDEPENDENTLY: `/rename` writes a lone `custom-title`,
+    /// the background summarizer writes a lone `ai-title` (verified in the
+    /// 2.1.185 CLI — two separate one-record writers, plus a metadata flush
+    /// that re-emits whichever are set). A session renamed before this watch
+    /// armed therefore keeps its `custom-title` entirely in the history the
+    /// baseline skips, and resolving over the tail alone would let the next
+    /// `ai-title` publish over the user's own name — which the CLI re-emits
+    /// constantly (228 identical copies in one observed transcript), so the
+    /// exposure is not theoretical. Seeding costs one bounded read of the
+    /// prefix, once per arm, on top of the whole-file read
+    /// `baseline_offset_since` just did.
+    ///
+    /// `pending_title` is deliberately untouched: history renders through the
+    /// ordinary detail fetch, which already resolved this same pair over these
+    /// same bytes, so re-publishing it would rename on every reconnect.
+    fn seed_titles_from_history(&mut self, path: &PathBuf, upto: u64) {
+        if upto == 0 {
+            return;
+        }
+        let Ok(file) = std::fs::File::open(path) else {
+            return;
+        };
+        let mut reader = std::io::BufReader::new(file.take(upto));
+        let mut line = Vec::new();
+        loop {
+            line.clear();
+            match reader.read_until(b'\n', &mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+            // Mirror the tail reader: a non-UTF-8 (or unparsable) line is
+            // skipped, never fatal to the rest of the scan.
+            let Ok(text) = std::str::from_utf8(&line) else {
+                continue;
+            };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(text.trim_end()) else {
+                continue;
+            };
+            let Some(record_type) = value.get("type").and_then(|t| t.as_str()) else {
+                continue;
+            };
+            capture_title_record(
+                &value,
+                record_type,
+                &mut self.custom_title,
+                &mut self.ai_title,
+            );
+        }
     }
 
     /// Read bytes appended since `committed`, returning COMPLETE lines only;
@@ -2840,5 +2913,117 @@ mod tests {
         write_lines(&path, &[&ai_title("New Session Name")]);
         let _ = tick_now(&mut ws, &ledger);
         assert_eq!(ws.pending_title.take().as_deref(), Some("New Session Name"));
+    }
+
+    /// `customTitle ?? aiTitle` is a WHOLE-FILE rule, but the two records are
+    /// appended independently — `/rename` writes a lone `custom-title`, the
+    /// summarizer a lone `ai-title`. A session renamed BEFORE this watch armed
+    /// keeps its `custom-title` in the skipped history, so resolving over the
+    /// tail alone would let the very next `ai-title` (the CLI re-emits it
+    /// constantly) publish over the user's own name. The arm seeds the slots
+    /// from history to close that.
+    #[test]
+    fn a_pre_baseline_user_title_outranks_a_generated_one_read_later() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(
+            &path,
+            &[
+                &user_prompt_array("u-old", "old prompt"),
+                &custom_title("auth-refactor"),
+            ],
+        );
+
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::new();
+        ws.rearm("s1".to_string(), epoch("2030-01-01T00:00:00Z"));
+        ws.adopt_file(path.clone());
+        assert_eq!(
+            ws.resolved_title().as_deref(),
+            Some("auth-refactor"),
+            "the arm must read the name the user already set"
+        );
+        assert_eq!(
+            ws.pending_title, None,
+            "seeding is not a publication — history rides the detail fetch"
+        );
+
+        // Only the GENERATED title lands in this watch's tail.
+        write_lines(&path, &[&ai_title("Concise AI Summary")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(
+            ws.pending_title, None,
+            "a generated title must not take the name back from the user"
+        );
+        assert_eq!(ws.resolved_title().as_deref(), Some("auth-refactor"));
+
+        // A new user-set name still publishes normally.
+        write_lines(&path, &[&custom_title("auth-refactor-v2")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title.take().as_deref(), Some("auth-refactor-v2"));
+    }
+
+    /// The CLI re-emits the SAME `ai-title` record throughout a session (228
+    /// identical copies in one observed transcript). On a resumed session the
+    /// first one past the baseline is a repeat of what history — and therefore
+    /// the detail fetch, and therefore the row — already holds, so seeding must
+    /// swallow it rather than spend a lifecycle write on a no-op.
+    #[test]
+    fn a_generated_title_already_in_history_is_not_republished() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(
+            &path,
+            &[
+                &user_prompt_array("u-old", "old prompt"),
+                &ai_title("Old Session Name"),
+            ],
+        );
+
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::new();
+        ws.rearm("s1".to_string(), epoch("2030-01-01T00:00:00Z"));
+        ws.adopt_file(path.clone());
+
+        write_lines(&path, &[&ai_title("Old Session Name")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title, None);
+
+        // A genuinely NEW generated name is still this watch's to surface.
+        write_lines(&path, &[&ai_title("Renamed By The Summarizer")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(
+            ws.pending_title.take().as_deref(),
+            Some("Renamed By The Summarizer")
+        );
+    }
+
+    /// A brand-new session baselines at offset 0 (its file is created after the
+    /// spawn epoch), so there is no history to seed and the seed must be a
+    /// no-op — the path this PR actually targets stays untouched.
+    #[test]
+    fn seeding_is_a_noop_for_a_fresh_session_whose_whole_file_is_ours() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(
+            &path,
+            &[
+                &user_prompt_array("u-new", "first prompt"),
+                &ai_title("Find current vLLM stable release tag"),
+            ],
+        );
+
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::new();
+        ws.rearm("s1".to_string(), epoch("2020-01-01T00:00:00Z"));
+        ws.adopt_file(path.clone());
+        assert_eq!(ws.committed, 0, "the whole file belongs to this watch");
+        assert_eq!(ws.resolved_title(), None, "nothing to seed from");
+
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(
+            ws.pending_title.take().as_deref(),
+            Some("Find current vLLM stable release tag")
+        );
     }
 }

--- a/src-tauri/src/acp/background_watch.rs
+++ b/src-tauri/src/acp/background_watch.rs
@@ -51,14 +51,16 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 use crate::acp::session_state::{background_keepalive_max_age, SessionState};
+use crate::acp::session_title::publish_native_title;
 use crate::acp::types::{AcpEvent, BackgroundSettledInfo, ConnectionStatus};
 use crate::models::agent::AgentType;
 use crate::models::message::MessageTurn;
 use crate::parsers::claude::{
-    capture_tag, find_session_file, group_into_turns, is_meta_message, slash_command_display,
-    task_notification_result_regex, task_notification_status_regex, task_notification_summary_regex,
-    task_notification_task_id_regex, task_notification_tool_use_id_regex, ClaudeRecordAccumulator,
-    BACKGROUND_RESULT_MAX_CHARS, CONTEXT_CONTINUATION_PREFIX,
+    capture_tag, capture_title_record, find_session_file, group_into_turns, is_meta_message,
+    slash_command_display, task_notification_result_regex, task_notification_status_regex,
+    task_notification_summary_regex, task_notification_task_id_regex,
+    task_notification_tool_use_id_regex, ClaudeRecordAccumulator, BACKGROUND_RESULT_MAX_CHARS,
+    CONTEXT_CONTINUATION_PREFIX,
 };
 use crate::parsers::truncate_str;
 use crate::web::event_bridge::{emit_with_state, EventEmitter};
@@ -303,6 +305,28 @@ async fn run_watch(
             }
         };
 
+        // Publish a title the transcript just named the session, exactly like
+        // a live ACP one (same skip-cache, same lifecycle write). Deliberately
+        // OUTSIDE the activity emit below: a tick whose tail is nothing but an
+        // `ai-title` record produces no turns, no settlements and no
+        // accounting change, so `tick` correctly returns `None` — which is the
+        // common case for a title generated after the last turn ended.
+        //
+        // Held rather than dropped while the conversation row is still
+        // unbound: unlike a live ACP title there is no resend to fall back on,
+        // because the record is read once and those bytes are never re-read.
+        //
+        // Bound to a `let` so the read guard is released before
+        // `publish_native_title` asks for the write lock, and short-circuited
+        // on `pending_title` so a settled session never takes the lock at all.
+        let title_is_publishable =
+            ws.pending_title.is_some() && state.read().await.conversation_id.is_some();
+        if title_is_publishable {
+            if let Some(title) = ws.pending_title.take() {
+                publish_native_title(&state, &emitter, title).await;
+            }
+        }
+
         if let Some(event) = event {
             if let AcpEvent::BackgroundActivity {
                 turns,
@@ -451,6 +475,18 @@ pub(crate) struct WatchState {
     /// they were written before the transcript file was first discovered;
     /// records before it are pre-existing history. Set by `rearm`.
     epoch: Option<std::time::SystemTime>,
+    /// Newest non-empty `custom-title` / `ai-title` value this watch has read
+    /// off the transcript, in the parser's own two slots (`parsers::claude::
+    /// capture_title_record`). Kept separate rather than folded into one
+    /// string so the user's `/rename` keeps winning over a title Claude Code
+    /// generates afterwards, exactly as `parse_conversation_detail` resolves
+    /// the pair over the whole file.
+    custom_title: Option<String>,
+    ai_title: Option<String>,
+    /// A resolved title this watch read but has not published yet. Set only
+    /// when a title RECORD actually changed the resolution, so a session with
+    /// a settled name costs nothing per tick.
+    pending_title: Option<String>,
 }
 
 impl WatchState {
@@ -479,6 +515,45 @@ impl WatchState {
             armed_logged: false,
             last_episode_base: 0,
             epoch: None,
+            custom_title: None,
+            ai_title: None,
+            pending_title: None,
+        }
+    }
+
+    /// The session's name as this watch currently understands it: the user's
+    /// own `/rename` first, then Claude Code's generated summary — the same
+    /// precedence `parsers::claude` applies when it resolves the whole file.
+    fn resolved_title(&self) -> Option<String> {
+        self.custom_title.clone().or_else(|| self.ai_title.clone())
+    }
+
+    /// Fold one transcript record into the title slots, queueing the result
+    /// for publication when it changed the resolved name.
+    ///
+    /// Claude Code writes its generated title as a dedicated `ai-title`
+    /// record, and it lands whenever the background summarizer finishes —
+    /// routinely AFTER the turn that triggered it has already ended. The ACP
+    /// adapter only reads the name back at turn-end, so on a short session
+    /// that title is never published and the conversation keeps its
+    /// first-prompt fallback name. The watcher is already tailing these exact
+    /// bytes, so surfacing the record here is what makes the name appear
+    /// while the session is still live instead of on its next detail load.
+    ///
+    /// Only records that carry a title are inspected — everything else costs
+    /// one string compare.
+    fn capture_title(&mut self, value: &serde_json::Value) {
+        let record_type = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if !matches!(record_type, "custom-title" | "ai-title") {
+            return;
+        }
+        let before = self.resolved_title();
+        capture_title_record(value, record_type, &mut self.custom_title, &mut self.ai_title);
+        let after = self.resolved_title();
+        // `capture_title_record` ignores blank values, so `after` is `None`
+        // only when nothing has ever been captured — never a clear.
+        if after.is_some() && after != before {
+            self.pending_title = after;
         }
     }
 
@@ -656,6 +731,7 @@ impl WatchState {
                             Err(_) => continue,
                         };
                         self.account(&value, &mut settled);
+                        self.capture_title(&value);
                         self.classify_and_feed(&value, ledger, cwd, &mut changed_turns);
                     }
                     if !lines.is_empty() {
@@ -1406,6 +1482,17 @@ mod tests {
         format!(
             r#"{{"type":"user","timestamp":"2026-07-07T03:49:00.000Z","uuid":"u-cron","isMeta":true,"userType":"external","message":{{"role":"user","content":"{text}"}}}}"#
         )
+    }
+
+    /// Real-shape generated-title record. Claude Code writes it with NO
+    /// timestamp and no message body (captured from a live transcript).
+    fn ai_title(title: &str) -> String {
+        format!(r#"{{"type":"ai-title","aiTitle":"{title}","sessionId":"s1"}}"#)
+    }
+
+    /// Real-shape user-set title record (`/rename`, `claude -n`, a fork).
+    fn custom_title(title: &str) -> String {
+        format!(r#"{{"type":"custom-title","customTitle":"{title}","sessionId":"s1"}}"#)
     }
 
     fn tick_now(ws: &mut WatchState, ledger: &PromptLedger) -> Option<AcpEvent> {
@@ -2624,5 +2711,134 @@ mod tests {
         let cmd = r#"{"type":"user","uuid":"u-cmd","message":{"role":"user","content":"<command-name>/init</command-name><command-args>now</command-args>"}}"#;
         let cmd: serde_json::Value = serde_json::from_str(cmd).unwrap();
         assert_eq!(turn_initiator_text(&cmd).as_deref(), Some("/init now"));
+    }
+
+    /// The whole point of reading titles here: Claude Code's background
+    /// summarizer writes `ai-title` AFTER the turn that triggered it has
+    /// ended, and the ACP adapter only reads the name back at turn-end — so on
+    /// a short session nothing ever publishes it. That tail is pure metadata:
+    /// no turns, no settlements, no accounting change, so `tick` returns
+    /// `None`. The title must still come out, which is why `run_watch` takes
+    /// it independently of the activity event.
+    #[test]
+    fn a_title_only_tail_yields_no_activity_event_but_still_surfaces_the_title() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(&path, &[]);
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::with_file_for_test("s1", path.clone());
+
+        write_lines(&path, &[&ai_title("Find current vLLM stable release tag")]);
+
+        assert!(
+            tick_now(&mut ws, &ledger).is_none(),
+            "a title record is not background ACTIVITY"
+        );
+        assert_eq!(
+            ws.pending_title.take().as_deref(),
+            Some("Find current vLLM stable release tag")
+        );
+    }
+
+    /// Once taken, the same name must not be re-queued on every later tick —
+    /// each publish walks the state write lock and a DB write.
+    #[test]
+    fn an_unchanged_title_is_queued_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(&path, &[]);
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::with_file_for_test("s1", path.clone());
+
+        write_lines(&path, &[&ai_title("Fix the login flow")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title.take().as_deref(), Some("Fix the login flow"));
+
+        // Claude Code re-emits the record; the resolved name did not change.
+        write_lines(&path, &[&ai_title("Fix the login flow")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title, None);
+
+        // A genuinely new name is queued again.
+        write_lines(&path, &[&ai_title("Fix the signup flow")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title.take().as_deref(), Some("Fix the signup flow"));
+    }
+
+    /// `customTitle ?? aiTitle` — Claude Code's own precedence, and the one
+    /// `parsers::claude` applies over the whole file. A generated title
+    /// arriving after the user named the session must not take the name back.
+    #[test]
+    fn a_user_set_title_outranks_a_later_generated_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(&path, &[]);
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::with_file_for_test("s1", path.clone());
+
+        write_lines(&path, &[&custom_title("auth-refactor")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title.take().as_deref(), Some("auth-refactor"));
+
+        write_lines(&path, &[&ai_title("Concise AI Summary")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(
+            ws.pending_title,
+            None,
+            "the generated title must not displace the user's own name"
+        );
+        assert_eq!(ws.resolved_title().as_deref(), Some("auth-refactor"));
+
+        // A NEW user-set name still wins.
+        write_lines(&path, &[&custom_title("auth-refactor-v2")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title.take().as_deref(), Some("auth-refactor-v2"));
+    }
+
+    /// Claude Code writes an empty `aiTitle` for trivial sessions. Publishing
+    /// it would rename the conversation to nothing.
+    #[test]
+    fn a_blank_title_record_is_never_queued() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(&path, &[]);
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::with_file_for_test("s1", path.clone());
+
+        write_lines(&path, &[&ai_title("   ")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title, None);
+        assert_eq!(ws.resolved_title(), None);
+    }
+
+    /// History before the arm baseline renders through the ordinary detail
+    /// fetch, which resolves the title from the whole file. Re-publishing it
+    /// from here would rename the conversation on every reconnect.
+    #[test]
+    fn a_title_in_pre_baseline_history_is_not_queued() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = temp_session(&dir);
+        write_lines(
+            &path,
+            &[
+                &user_prompt_array("u-old", "old prompt"),
+                &ai_title("Old Session Name"),
+            ],
+        );
+
+        let ledger = PromptLedger::shared();
+        let mut ws = WatchState::new();
+        // Arm with an epoch after the existing records, exactly as `run_watch`
+        // does for a resumed session, and take the real baseline.
+        ws.rearm("s1".to_string(), epoch("2030-01-01T00:00:00Z"));
+        ws.adopt_file(path.clone());
+
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title, None);
+
+        // A title written from here on IS this watch's to surface.
+        write_lines(&path, &[&ai_title("New Session Name")]);
+        let _ = tick_now(&mut ws, &ledger);
+        assert_eq!(ws.pending_title.take().as_deref(), Some("New Session Name"));
     }
 }

--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -12008,26 +12008,10 @@ async fn emit_conversation_update(
             if let Some(title) = crate::acp::session_title::native_title_from_session_info(
                 info.title.value().map(|s| s.as_str()),
             ) {
-                // Test and set under ONE write lock. Nothing can interleave
-                // here today — a session's notifications are handled serially,
-                // and the only other writer of `last_native_title` is the
-                // `ConversationLinked` arm, which is emitted ONLY while the row
-                // is still unbound and therefore can never race a title this
-                // admits. That safety currently rests on two guards in
-                // different files agreeing; keeping the halves in one critical
-                // section makes it hold by construction instead.
-                let admit = {
-                    let mut s = state.write().await;
-                    let admit = s.conversation_id.is_some()
-                        && s.last_native_title.as_deref() != Some(title.as_str());
-                    if admit {
-                        s.last_native_title = Some(title.clone());
-                    }
-                    admit
-                };
-                if admit {
-                    emit_with_state(state, emitter, AcpEvent::NativeSessionTitle { title }).await;
-                }
+                // Shared with the transcript watcher's title path so the
+                // skip-cache and the unbound-row drop have exactly one
+                // spelling — see `session_title::publish_native_title`.
+                crate::acp::session_title::publish_native_title(state, emitter, title).await;
             }
             let neutral_goal_channel = state.read().await.neutral_goal_channel;
             if let Some(goal) =

--- a/src-tauri/src/acp/session_title.rs
+++ b/src-tauri/src/acp/session_title.rs
@@ -4,6 +4,21 @@
 //! used to ignore that field and only adopt a title the next time the
 //! conversation was loaded from disk. These helpers extract a usable title
 //! from the live notification so the lifecycle worker can write it immediately.
+//!
+//! Not every agent can push. Claude Code's adapter has no wire event for its
+//! generated title — it reads the name back out of the session file at
+//! turn-end — so `acp::background_watch` reads the same `ai-title` /
+//! `custom-title` records off the transcript it is already tailing and hands
+//! them to [`publish_native_title`], which is the one place that decides
+//! whether a title reaches the lifecycle worker.
+
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::acp::session_state::SessionState;
+use crate::acp::types::AcpEvent;
+use crate::web::event_bridge::{emit_with_state, EventEmitter};
 
 /// Pull a usable session title out of ACP `session_info_update.title`.
 ///
@@ -17,6 +32,45 @@ pub(crate) fn native_title_from_session_info(title: Option<&str>) -> Option<Stri
         None
     } else {
         Some(crate::parsers::truncate_str(t, 100))
+    }
+}
+
+/// Emit `title` as this connection's live session title, unless it is a repeat
+/// of the last one emitted here.
+///
+/// Test and set under ONE write lock. Nothing can interleave here today — a
+/// session's notifications are handled serially, and the only other writer of
+/// `last_native_title` is the `ConversationLinked` arm, which is emitted ONLY
+/// while the row is still unbound and therefore can never race a title this
+/// admits. That safety would otherwise rest on two guards in different files
+/// agreeing; keeping the halves in one critical section makes it hold by
+/// construction instead.
+///
+/// A title published before the first prompt binds the row has nowhere to land
+/// and is dropped WITHOUT being remembered, so the same string is still
+/// accepted once the row exists.
+///
+/// The emitted `NativeSessionTitle` reaches `acp::lifecycle`, whose
+/// `refresh_auto_title` write is itself a no-op on a user-renamed
+/// (`title_locked`) row and on an unchanged value — so repeats that do get
+/// past the skip-cache still cost nothing and can never overwrite a name the
+/// user chose.
+pub(crate) async fn publish_native_title(
+    state: &Arc<RwLock<SessionState>>,
+    emitter: &EventEmitter,
+    title: String,
+) {
+    let admit = {
+        let mut s = state.write().await;
+        let admit = s.conversation_id.is_some()
+            && s.last_native_title.as_deref() != Some(title.as_str());
+        if admit {
+            s.last_native_title = Some(title.clone());
+        }
+        admit
+    };
+    if admit {
+        emit_with_state(state, emitter, AcpEvent::NativeSessionTitle { title }).await;
     }
 }
 

--- a/src-tauri/src/acp/session_title.rs
+++ b/src-tauri/src/acp/session_title.rs
@@ -38,13 +38,29 @@ pub(crate) fn native_title_from_session_info(title: Option<&str>) -> Option<Stri
 /// Emit `title` as this connection's live session title, unless it is a repeat
 /// of the last one emitted here.
 ///
-/// Test and set under ONE write lock. Nothing can interleave here today — a
-/// session's notifications are handled serially, and the only other writer of
-/// `last_native_title` is the `ConversationLinked` arm, which is emitted ONLY
-/// while the row is still unbound and therefore can never race a title this
-/// admits. That safety would otherwise rest on two guards in different files
-/// agreeing; keeping the halves in one critical section makes it hold by
-/// construction instead.
+/// Test and set under ONE write lock, because there are genuinely two
+/// concurrent producers: the connection's notification loop (which handles a
+/// session's `session_info_update`s serially) and — for Claude — the transcript
+/// watcher's own task, which reads the same name off `ai-title` /
+/// `custom-title` records on its own poll cadence. Splitting the test from the
+/// set would let both admit the same string and write it twice; the single
+/// critical section makes "only a CHANGED title gets through" hold by
+/// construction rather than by the two callers happening not to overlap.
+///
+/// What the critical section does NOT order is the `emit` that follows it: two
+/// producers admitting DIFFERENT strings can broadcast in the opposite order,
+/// leaving the older name written last. Note what does NOT repair that: the
+/// transcript re-emitting the same `ai-title` record, because the watcher has
+/// already folded that value into its own slots and will not re-queue it. What
+/// does is a later detail fetch (it re-resolves the whole file) or the next
+/// genuinely different title from either producer — including the adapter's own
+/// turn-end pull, whose `lastTitle` now differs from what the file holds. So the
+/// window is recoverable auto-title staleness, not a stuck name, and not worth
+/// serializing the whole publish behind the state lock.
+///
+/// The third writer of `last_native_title` is the `ConversationLinked` arm,
+/// which is emitted ONLY while the row is still unbound and therefore can never
+/// race a title this admits.
 ///
 /// A title published before the first prompt binds the row has nowhere to land
 /// and is dropped WITHOUT being remembered, so the same string is still
@@ -76,7 +92,94 @@ pub(crate) async fn publish_native_title(
 
 #[cfg(test)]
 mod tests {
-    use super::native_title_from_session_info;
+    use super::{native_title_from_session_info, publish_native_title};
+    use crate::acp::session_state::SessionState;
+    use crate::acp::types::AcpEvent;
+    use crate::models::agent::AgentType;
+    use crate::web::event_bridge::EventEmitter;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn title_state(conversation_id: Option<i32>) -> Arc<RwLock<SessionState>> {
+        let mut st = SessionState::new(
+            "conn-title".to_string(),
+            AgentType::ClaudeCode,
+            None,
+            "win".to_string(),
+            None,
+        );
+        st.conversation_id = conversation_id;
+        Arc::new(RwLock::new(st))
+    }
+
+    /// Titles emitted on this connection so far, oldest first.
+    async fn emitted(state: &Arc<RwLock<SessionState>>) -> Vec<String> {
+        state
+            .read()
+            .await
+            .recent_events_after(0)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|e| match &e.payload {
+                AcpEvent::NativeSessionTitle { title } => Some(title.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The skip-cache is what keeps the two producers cheap: Claude Code
+    /// re-emits its `ai-title` record throughout a session (228 identical
+    /// copies in one observed transcript) and CodeBuddy re-pushes its fallback
+    /// after every prompt. Only a CHANGED name may reach the lifecycle worker.
+    #[tokio::test]
+    async fn only_a_changed_title_is_emitted() {
+        let state = title_state(Some(7));
+
+        publish_native_title(&state, &EventEmitter::Noop, "Fix the login flow".into()).await;
+        publish_native_title(&state, &EventEmitter::Noop, "Fix the login flow".into()).await;
+        publish_native_title(&state, &EventEmitter::Noop, "Fix the signup flow".into()).await;
+
+        assert_eq!(
+            emitted(&state).await,
+            vec![
+                "Fix the login flow".to_string(),
+                "Fix the signup flow".to_string()
+            ]
+        );
+    }
+
+    /// A title published before the first prompt binds the row has nowhere to
+    /// land, so it is dropped — and deliberately NOT remembered, or the retry
+    /// that follows `ConversationLinked` would be swallowed and the row would
+    /// keep its fallback name for the rest of the connection.
+    #[tokio::test]
+    async fn a_title_dropped_while_unbound_does_not_poison_the_cache() {
+        let state = title_state(None);
+
+        publish_native_title(&state, &EventEmitter::Noop, "Fix the login flow".into()).await;
+        assert!(emitted(&state).await.is_empty(), "no row to write to yet");
+        assert!(
+            state.read().await.last_native_title.is_none(),
+            "a dropped title must not poison the skip-cache"
+        );
+
+        state
+            .write()
+            .await
+            .apply_event(&AcpEvent::ConversationLinked {
+                conversation_id: 7,
+                folder_id: 1,
+                parent_conversation_id: None,
+                parent_tool_use_id: None,
+            });
+
+        publish_native_title(&state, &EventEmitter::Noop, "Fix the login flow".into()).await;
+        assert_eq!(
+            emitted(&state).await,
+            vec!["Fix the login flow".to_string()],
+            "the same title must be accepted once the row exists"
+        );
+    }
 
     #[test]
     fn rejects_missing_and_blank() {


### PR DESCRIPTION
Claude Code has no ACP event for its generated title. Its adapter reads the name back out of the session file at turn-end, and the SDK writes that name in the background, so on a short chat the turn is over before there is anything to read. Nothing publishes the title and the conversation keeps its first-prompt name until the next time you open it.

The transcript watcher is already tailing those exact bytes for background activity. It now also folds `ai-title` / `custom-title` records into the session's name and hands the result to the same path a live ACP title takes, so the sidebar updates a beat after Claude generates the name instead of on the next detail load.

Resolution is `customTitle ?? aiTitle`, matching what the parser already does over the whole file, so a `/rename` still outranks a generated title. Blank values are ignored, an unchanged name is not republished, and history before the watch baseline is left to the ordinary detail fetch. The write itself is unchanged: `refresh_auto_title` still skips a conversation the user renamed and still no-ops when the value has not moved.

The skip-cache and the unbound-row drop moved into `session_title::publish_native_title` so the ACP path and this one cannot drift apart.
