### PR TITLE
fix(tasks): preserve current waits after stale generation completion

### DIFF
--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -2036,9 +2036,7 @@ impl TaskEngine {
         };
 
         let summary = self.capture_summary(conn_id).await;
-        self.index.lock().await.remove(conn_id);
-        self.awaiting.lock().await.remove(&task_id);
-        self.forget_delegation_children_of(conn_id).await;
+        self.retire_connection(conn_id, task_id).await;
         let _ = self.manager.disconnect(conn_id).await;
 
         let task = work_task_service::get_model(&self.db.conn, task_id).await.ok();
@@ -7398,6 +7396,78 @@ mod tests {
         // The old connection's cancel finally arrives.
         engine.on_turn_complete(PARENT_CONN, "cancelled").await;
 
+        assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn a_previous_generation_cancel_does_not_clear_current_waits() {
+        let (engine, task_id) = running_task().await;
+        let row = work_task_service::get_model(&engine.db.conn, task_id)
+            .await
+            .expect("task row");
+        let (stale_seq, conv_id) = (row.run_seq, row.conversation_id.expect("conversation"));
+
+        assert!(work_task_service::settle_review(
+            &engine.db.conn,
+            task_id,
+            stale_seq,
+            None,
+            None,
+        )
+        .await
+        .expect("settle review"));
+        let next_seq = work_task_service::claim_for_run(
+            &engine.db.conn,
+            task_id,
+            WorkTaskStatus::Review,
+            "test",
+        )
+        .await
+        .expect("claim")
+        .expect("claimed");
+        assert!(work_task_service::begin_setup(&engine.db.conn, task_id, next_seq)
+            .await
+            .expect("begin_setup"));
+        assert!(work_task_service::mark_running(
+            &engine.db.conn,
+            task_id,
+            next_seq,
+            conv_id,
+            "conn-next",
+        )
+        .await
+        .expect("mark_running"));
+        engine
+            .index
+            .lock()
+            .await
+            .insert("conn-next".into(), (task_id, next_seq));
+
+        engine
+            .track_request("conn-next", "permission-a".into(), true)
+            .await;
+        engine
+            .track_request("conn-next", "permission-b".into(), true)
+            .await;
+        assert_eq!(
+            status_of(&engine, task_id).await,
+            WorkTaskStatus::AwaitingInput
+        );
+
+        engine.on_turn_complete(PARENT_CONN, "cancelled").await;
+        engine
+            .track_request("conn-next", "permission-a".into(), false)
+            .await;
+
+        assert_eq!(
+            status_of(&engine, task_id).await,
+            WorkTaskStatus::AwaitingInput,
+            "the second request in the current generation is still outstanding"
+        );
+
+        engine
+            .track_request("conn-next", "permission-b".into(), false)
+            .await;
         assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Running);
     }
 

--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -1946,12 +1946,14 @@ impl TaskEngine {
         }
     }
 
-    /// Drop every delegation-child mapping belonging to a retired run. Called
-    /// wherever a run leaves `index`; the run's outstanding-request set is
-    /// cleared wholesale by those same call sites.
-    async fn forget_delegation_children_of(&self, parent_conn_id: &str) {
+    /// Drop every delegation-child mapping belonging to a retired run, and
+    /// return the connection ids that were detached — their outstanding
+    /// requests are now unanswerable, so whoever does not clear the task's set
+    /// wholesale has to retract those keys by hand (see
+    /// [`Self::retire_connection`]).
+    async fn forget_delegation_children_of(&self, parent_conn_id: &str) -> Vec<String> {
         // `parent_conn_id` is a run connection, never a key in this map.
-        self.detach_delegation_subtree(parent_conn_id, false).await;
+        self.detach_delegation_subtree(parent_conn_id, false).await
     }
 
     /// Drop every engine-side trace of a run connection: its `index` entry, the
@@ -1964,6 +1966,17 @@ impl TaskEngine {
     /// arrive calls this; the entry has no other way out (`reconcile_once`
     /// only ever looks at `running` / `awaiting_input` rows).
     async fn retire_connection(&self, conn_id: &str, task_id: i32) {
+        // Unmap this run's delegation children FIRST: the purge below needs
+        // their ids, and a child that is already detached can no longer publish
+        // a fresh key (`track_request` resolves a child through
+        // `delegation_parents`, and an unmapped one resolves to nothing).
+        let orphaned: Vec<String> = self
+            .forget_delegation_children_of(conn_id)
+            .await
+            .iter()
+            .map(|child| format!("{child}#"))
+            .collect();
+
         // The outstanding-request set is keyed by TASK, not by connection, so
         // clearing it while another generation still owns the row would drop
         // ITS pending permissions — resolving one of the survivors then empties
@@ -1975,14 +1988,74 @@ impl TaskEngine {
         // its parent is indexed), so holding it is what keeps the answer true
         // until the set is gone. Lock order is index → awaiting; every other
         // `awaiting` critical section is a leaf, so it cannot invert.
-        {
+        let emptied_for = {
             let mut index = self.index.lock().await;
             index.remove(conn_id);
-            if !index.values().any(|(tid, _)| *tid == task_id) {
-                self.awaiting.lock().await.remove(&task_id);
+            let survivor = index
+                .values()
+                .find(|(tid, _)| *tid == task_id)
+                .map(|(_, run_seq)| *run_seq);
+            let mut awaiting = self.awaiting.lock().await;
+            match survivor {
+                // Last one out, so the whole set goes — orphans included. A set
+                // inherited by the next generation would never flip the row to
+                // `awaiting_input` again.
+                None => {
+                    awaiting.remove(&task_id);
+                    None
+                }
+                // Someone else still owns the row: keep THEIR requests, but
+                // retract this run's children's. Sparing those is the opposite
+                // error and the worse one — the chain that named them is gone,
+                // so neither `track_request` nor `forget_delegation_child` can
+                // resolve them any more, and one key stuck in a shared set pins
+                // the survivor on the wrong side of the `running` ⇄
+                // `awaiting_input` edge until something clears the set
+                // wholesale. Only a LATER retirement that is the last one out
+                // (or a cancel) does that, so it outlasts every generation the
+                // orphan is actually lying about.
+                Some(run_seq) => Self::retract_keys(&mut awaiting, task_id, &orphaned)
+                    .then_some(run_seq),
+            }
+        };
+
+        // Emptied by the retraction alone: the row is parked on requests that
+        // just became unanswerable, so return it to the survivor's `running`
+        // through the same flip `track_request` would have used.
+        if let Some(run_seq) = emptied_for {
+            let flipped = work_task_service::flip_awaiting(&self.db.conn, task_id, run_seq, false)
+                .await
+                .unwrap_or(false);
+            if flipped {
+                self.emit_upsert(task_id);
             }
         }
-        self.forget_delegation_children_of(conn_id).await;
+    }
+
+    /// Drop every key under `prefixes` from the task's outstanding set,
+    /// reporting whether that is what emptied it (and so owes a flip back to
+    /// `running`). An untouched set never reports `true`, however empty.
+    fn retract_keys(
+        awaiting: &mut HashMap<i32, HashSet<String>>,
+        task_id: i32,
+        prefixes: &[String],
+    ) -> bool {
+        if prefixes.is_empty() {
+            return false;
+        }
+        let Some(set) = awaiting.get_mut(&task_id) else {
+            return false;
+        };
+        let before = set.len();
+        set.retain(|k| !prefixes.iter().any(|p| k.starts_with(p.as_str())));
+        if set.len() == before {
+            return false; // nothing of this subtree's was outstanding
+        }
+        if set.is_empty() {
+            awaiting.remove(&task_id);
+            return true;
+        }
+        false
     }
 
     /// Drop a finished delegation child (and anything it delegated in turn) plus
@@ -2004,20 +2077,7 @@ impl TaskEngine {
         let prefixes: Vec<String> = detached.iter().map(|c| format!("{c}#")).collect();
         let emptied = {
             let mut awaiting = self.awaiting.lock().await;
-            let Some(set) = awaiting.get_mut(&task_id) else {
-                return;
-            };
-            let before = set.len();
-            set.retain(|k| !prefixes.iter().any(|p| k.starts_with(p.as_str())));
-            if set.len() == before {
-                return; // nothing of this subtree's was outstanding
-            }
-            if set.is_empty() {
-                awaiting.remove(&task_id);
-                true
-            } else {
-                false
-            }
+            Self::retract_keys(&mut awaiting, task_id, &prefixes)
         };
         if emptied {
             let flipped = work_task_service::flip_awaiting(&self.db.conn, task_id, run_seq, false)
@@ -7399,18 +7459,19 @@ mod tests {
         assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Running);
     }
 
-    #[tokio::test]
-    async fn a_previous_generation_cancel_does_not_clear_current_waits() {
-        let (engine, task_id) = running_task().await;
+    /// Walk the row on to a fresh generation running on `conn_id`, WITHOUT
+    /// retiring the previous one's `index` entry — the state a delayed
+    /// `TurnComplete` from the old connection lands in. Returns the new run_seq.
+    async fn relaunch_on(engine: &TaskEngine, task_id: i32, conn_id: &str) -> i32 {
         let row = work_task_service::get_model(&engine.db.conn, task_id)
             .await
             .expect("task row");
-        let (stale_seq, conv_id) = (row.run_seq, row.conversation_id.expect("conversation"));
+        let conv_id = row.conversation_id.expect("conversation");
 
         assert!(work_task_service::settle_review(
             &engine.db.conn,
             task_id,
-            stale_seq,
+            row.run_seq,
             None,
             None,
         )
@@ -7433,7 +7494,7 @@ mod tests {
             task_id,
             next_seq,
             conv_id,
-            "conn-next",
+            conn_id,
         )
         .await
         .expect("mark_running"));
@@ -7441,7 +7502,14 @@ mod tests {
             .index
             .lock()
             .await
-            .insert("conn-next".into(), (task_id, next_seq));
+            .insert(conn_id.into(), (task_id, next_seq));
+        next_seq
+    }
+
+    #[tokio::test]
+    async fn a_previous_generation_cancel_does_not_clear_current_waits() {
+        let (engine, task_id) = running_task().await;
+        relaunch_on(&engine, task_id, "conn-next").await;
 
         engine
             .track_request("conn-next", "permission-a".into(), true)
@@ -7467,6 +7535,51 @@ mod tests {
 
         engine
             .track_request("conn-next", "permission-b".into(), false)
+            .await;
+        assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Running);
+    }
+
+    /// The mirror image of the case above, and the half sparing the set opens:
+    /// a retired run's DELEGATION children are namespaced by connection id, so
+    /// keeping the task's set keeps THEIR keys too — with nothing left that
+    /// could ever answer them, because the same retirement just unmapped the
+    /// chain (`track_request` and `forget_delegation_child` both resolve a
+    /// detached child to nothing). One orphan pins the set non-empty until a
+    /// wholesale clear comes along — a later retirement that IS the last one
+    /// out, or a cancel — and until then every generation's first request
+    /// misses the `len() == 1` edge: the board says `running` for a run parked
+    /// on the user, which is bug #447 all over again. Unlike the transient
+    /// over-clear, answering the request is not what gets you out of it.
+    #[tokio::test]
+    async fn retiring_a_run_takes_its_orphaned_delegation_requests_with_it() {
+        let (engine, task_id) = running_task().await;
+        engine
+            .on_event(&delegation_started(PARENT_CONN, CHILD_CONN))
+            .await;
+        engine.on_event(&permission_request(CHILD_CONN, "r1")).await;
+        assert_eq!(
+            status_of(&engine, task_id).await,
+            WorkTaskStatus::AwaitingInput
+        );
+
+        relaunch_on(&engine, task_id, "conn-next").await;
+        engine.on_turn_complete(PARENT_CONN, "cancelled").await;
+
+        assert!(
+            engine.awaiting.lock().await.get(&task_id).is_none(),
+            "a child's key cannot outlive the delegation chain that named it"
+        );
+
+        // ...and the surviving generation's own edge still swings both ways.
+        engine
+            .track_request("conn-next", "p:r9".into(), true)
+            .await;
+        assert_eq!(
+            status_of(&engine, task_id).await,
+            WorkTaskStatus::AwaitingInput
+        );
+        engine
+            .track_request("conn-next", "p:r9".into(), false)
             .await;
         assert_eq!(status_of(&engine, task_id).await, WorkTaskStatus::Running);
     }


### PR DESCRIPTION
## 问题

当同一个任务已经从 generation N 进入 generation N+1 后，generation N 的旧连接仍可能延迟送达 `TurnComplete(cancelled)`。

数据库状态本身已经由 `task_id + run_seq + status` 的 CAS 保护：旧 generation 的事件不能把新 generation 改成 `canceled`。但 `TaskEngine::on_turn_complete` 原先会在执行该数据库 CAS 前，直接按 `task_id` 删除整个 `awaiting` 集合：

```rust
self.index.lock().await.remove(conn_id);
self.awaiting.lock().await.remove(&task_id);
self.forget_delegation_children_of(conn_id).await;
```

这里的关键问题是：`index` 能区分连接及其 generation，而 `awaiting` 只以 `task_id` 为 key。因此，旧连接完成时会误删当前 generation 的所有待处理 permission/question 请求。

一个确定性的失败过程如下：

1. generation N+1 同时存在 `permission-a` 和 `permission-b` 两个未处理请求，任务状态为 `awaiting_input`；
2. generation N 的旧连接延迟送达 `TurnComplete(cancelled)`；
3. 数据库 CAS 正确拒绝旧 generation 的取消写入，但内存中的 `awaiting` 集合已经被旧事件清空；
4. 用户只处理 `permission-a` 后，`track_request` 看到空集合，错误地把任务恢复为 `running`；
5. `permission-b` 实际仍未处理，agent 仍然阻塞，界面状态与真实运行状态不一致。

这与 #546 修复的数据库状态回退问题相关，但发生在数据库 CAS 之前的内存清理阶段。#546 保证旧事件不能取消当前 generation；本 PR 补上“旧事件也不能清除当前 generation 的等待请求”这一层保护。

## 改动

- 在 `TaskEngine::on_turn_complete` 中复用已有的 `retire_connection(conn_id, task_id)`，替代对 `index`、`awaiting` 和 delegation children 的三段直接清理。
- `retire_connection` 会先移除结束连接的索引，并在同一 `index` 锁保护下确认该任务是否仍有其他连接：
  - 如果当前 generation 的连接仍在，就保留该任务的 `awaiting` 集合；
  - 只有最后一个连接退出时，才清理任务级等待集合；
  - delegation children 仍由同一 helper 清理，原有行为保持不变。
- 新增回归测试 `a_previous_generation_cancel_does_not_clear_current_waits`，构造两个 generation 和两个当前等待请求，覆盖完整状态变化。

实现保持为单文件的最小修改，没有改变数据库 schema，也没有扩大 `awaiting` 的 key 结构。

## 修复结果

新增测试验证了以下行为：

1. 当前 generation 注册两个等待请求后，任务进入 `AwaitingInput`；
2. 旧 generation 的 `cancelled` 完成事件不会取消当前 generation，也不会清空它的等待集合；
3. 只解决第一个请求后，任务仍保持 `AwaitingInput`；
4. 解决最后一个请求后，任务才恢复为 `Running`。

修复前，该回归测试稳定失败，实际状态为 `Running`、期望状态为 `AwaitingInput`；连续复现 5 次均失败。应用本修改后测试通过，因此本 PR 覆盖并解决了 #564 描述的状态损坏路径。

## 测试

以下验证均已完成：

- 定向回归测试：

  ```bash
  cargo test --locked --no-default-features --lib \
    a_previous_generation_cancel_does_not_clear_current_waits -- --nocapture
  ```

  结果：`1 passed; 0 failed`。

- 服务器端 `work_task` 相关测试集：

  ```bash
  cargo test --locked --no-default-features --bin codeg-server --lib work_task
  ```

  结果：library target `143 passed; 0 failed`；`codeg-server` binary target `0 tests`。

- 服务器端严格 Clippy：

  ```bash
  cargo clippy --locked --no-default-features --bin codeg-server --lib -- -D warnings
  ```

  结果：通过。

- 桌面 feature 定向回归测试：

  ```bash
  cargo test -j 1 --lib --features test-utils \
    a_previous_generation_cancel_does_not_clear_current_waits -- --nocapture
  ```

  结果：`1 passed; 0 failed`。

- `git diff --check`：通过。

补充说明：Rust 1.98.0 下运行全仓库 `cargo fmt --all -- --check` 会报告大量本 PR 之前已存在的格式差异，因此没有用它改写无关文件；本 PR 仍保持仅修改 `src-tauri/src/work_task/engine.rs`，且 diff 空白检查通过。

## 测试环境

- Base commit：`d6eb97e9da508266053911561f17deae81a2f582`
- Codeg：`v0.28.1-6-gd6eb97e9`
- 主机：macOS 14.5（23F79），Apple Silicon arm64
- Docker：29.7.2
- Rust 镜像：`reposteward-runner-rust:latest`（arm64）
- Rust：`rustc 1.98.0`
- Cargo：`cargo 1.98.0`
- 服务器验证：`--no-default-features`
- 桌面验证：一次性容器内安装 GTK/WebKit/Tauri 系统依赖，并使用 `-j 1` 避免并发链接内存压力

请维护者审查这个连接感知的清理方案，尤其是 `retire_connection` 在旧、新 generation 连接并存时保留任务级等待集合的语义，以及现有 `index -> awaiting` 锁顺序是否符合预期。如需将 `awaiting` 进一步按 `(task_id, run_seq)` 分区，我也可以根据审查意见继续调整。

Fixes #564
