### PR TITLE
feat(diff): add a side-by-side view to the inline diff preview

### DIFF
--- a/src/components/diff/unified-diff-preview.test.tsx
+++ b/src/components/diff/unified-diff-preview.test.tsx
@@ -218,6 +218,27 @@ describe("UnifiedDiffPreview — side-by-side view", () => {
     expect(screen.getAllByText("shared context")).toHaveLength(2)
   })
 
+  it("lays the split rows out on one grid sized to its content", () => {
+    // jsdom does no layout, so this pins the two declarations that ARE the
+    // behaviour. Both were verified in Chromium and WebKit: with per-row flex
+    // boxes (or a grid without `w-max`) the container resolves to the tracks'
+    // minimum size, `1fr 1fr` halves it, and the longer side of a row paints
+    // its line over the opposite column — two lines of code on top of each
+    // other. Shared tracks give every row the same break point; `w-max` keeps
+    // each track wide enough for its widest line.
+    localStorage.setItem("workspace:diff-view-mode", "split")
+    const { container } = renderWithIntl(
+      <UnifiedDiffPreview diffText={modifiedDiff()} />
+    )
+
+    const grid = container.querySelector('[class*="grid-cols-"]')
+    expect(grid).not.toBeNull()
+    expect(grid).toHaveClass("w-max")
+    expect(grid).toHaveClass("grid-cols-[repeat(2,minmax(260px,1fr))]")
+    // Cells must not size themselves — the track owns the width.
+    expect(grid?.firstElementChild?.className).not.toMatch(/flex-1|basis-0/)
+  })
+
   it("still switches when persisting the choice throws", () => {
     // Storage disabled / over quota: the mode won't survive a reload, but the
     // button must not look dead. The broadcast carries the new mode instead of

--- a/src/components/diff/unified-diff-preview.test.tsx
+++ b/src/components/diff/unified-diff-preview.test.tsx
@@ -111,6 +111,20 @@ function modifiedDiff(): string {
   ].join("\n")
 }
 
+/** A second modified file, for asserting that two previews on one screen share
+ *  the view-mode preference. */
+function otherModifiedDiff(): string {
+  return [
+    "diff --git a/other.ts b/other.ts",
+    "--- a/other.ts",
+    "+++ b/other.ts",
+    "@@ -1,2 +1,2 @@",
+    " shared context",
+    "-was here",
+    "+is here",
+  ].join("\n")
+}
+
 /** The unified rows `parseUnifiedDiff` derives from `modifiedDiff`, so the
  *  pairing unit tests feed the exact shape production renders. */
 function modifiedRows(): ParsedDiffRow[] {
@@ -182,6 +196,72 @@ describe("UnifiedDiffPreview — side-by-side view", () => {
     expect(screen.getByText("+")).toBeInTheDocument()
     expect(localStorage.getItem("workspace:diff-view-mode")).toBe("unified")
   })
+
+  it("flips every preview mounted alongside it, not just the clicked one", () => {
+    // A transcript renders one preview per Edit/Write tool call, and a
+    // permission dialog stacks another on top. The view mode is a single
+    // preference, so toggling one must not leave its siblings inline until
+    // they happen to remount.
+    renderWithIntl(
+      <>
+        <UnifiedDiffPreview diffText={modifiedDiff()} />
+        <UnifiedDiffPreview diffText={otherModifiedDiff()} />
+      </>
+    )
+
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Switch to side-by-side view" })[0]!
+    )
+
+    // Context rows render once per side in split mode — both previews switched.
+    expect(screen.getAllByText("keep one")).toHaveLength(2)
+    expect(screen.getAllByText("shared context")).toHaveLength(2)
+  })
+
+  it("still switches when persisting the choice throws", () => {
+    // Storage disabled / over quota: the mode won't survive a reload, but the
+    // button must not look dead. The broadcast carries the new mode instead of
+    // making every listener re-read what was never written.
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError")
+      })
+    try {
+      renderWithIntl(<UnifiedDiffPreview diffText={modifiedDiff()} />)
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Switch to side-by-side view" })
+      )
+
+      expect(screen.getAllByText("keep one")).toHaveLength(2)
+    } finally {
+      setItem.mockRestore()
+    }
+  })
+
+  it("hides the toggle for a diff that has no side to split", () => {
+    // A pure new-file diff renders as plain content in both modes, so the
+    // control would be a visible no-op.
+    renderWithIntl(<UnifiedDiffPreview diffText={newFileDiff(3)} />)
+
+    expect(
+      screen.queryByRole("button", { name: "Switch to side-by-side view" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Switch to inline view" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps the toggle when a new file is mixed with a modified one", () => {
+    renderWithIntl(
+      <UnifiedDiffPreview diffText={`${newFileDiff(2)}\n${modifiedDiff()}`} />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Switch to side-by-side view" })
+    ).toBeInTheDocument()
+  })
 })
 
 describe("toSplitRows", () => {
@@ -220,6 +300,22 @@ describe("toSplitRows", () => {
       text: null,
       marker: "none",
     })
+  })
+
+  it("spans a 'modified' row instead of spinning on it", () => {
+    // `ParsedDiffRow` has a fourth type the current classifier never emits.
+    // Pairing must still consume it: a row that matches neither the delete run
+    // nor the add run would leave the cursor parked and hang the tab in a
+    // synchronous loop no test timeout can interrupt.
+    const rows = toSplitRows([
+      { type: "modified", text: "touched", sign: " ", oldLine: 7, newLine: 7 },
+      { type: "added", text: "after", sign: "+", oldLine: null, newLine: 8 },
+    ])
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]?.left).toMatchObject({ text: "touched", line: 7 })
+    expect(rows[0]?.right).toMatchObject({ text: "touched", line: 7 })
+    expect(rows[1]?.right).toMatchObject({ text: "after", marker: "added" })
   })
 
   it("gives a pure insertion an empty left cell", () => {

--- a/src/components/diff/unified-diff-preview.test.tsx
+++ b/src/components/diff/unified-diff-preview.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { NextIntlClientProvider } from "next-intl"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { UnifiedDiffPreview } from "./unified-diff-preview"
+import {
+  UnifiedDiffPreview,
+  toSplitRows,
+  type ParsedDiffRow,
+} from "./unified-diff-preview"
 import enMessages from "@/i18n/messages/en.json"
 
 // The component reads the active folder only to strip a path prefix from the
@@ -88,5 +92,143 @@ describe("UnifiedDiffPreview", () => {
     ).toBeInTheDocument()
     expect(screen.getByText("line 500")).toBeInTheDocument()
     expect(screen.queryByText("line 700")).not.toBeInTheDocument()
+  })
+})
+
+/** A single-file modified diff: one context row, two deletions, one addition,
+ *  one more context row — exercises the split pairing with unequal runs. */
+function modifiedDiff(): string {
+  return [
+    "diff --git a/app.ts b/app.ts",
+    "--- a/app.ts",
+    "+++ b/app.ts",
+    "@@ -1,5 1,4 @@",
+    " keep one",
+    "-old line A",
+    "-old line B",
+    "+new line A",
+    " keep two",
+  ].join("\n")
+}
+
+/** The unified rows `parseUnifiedDiff` derives from `modifiedDiff`, so the
+ *  pairing unit tests feed the exact shape production renders. */
+function modifiedRows(): ParsedDiffRow[] {
+  return [
+    { type: "context", text: "keep one", sign: " ", oldLine: 1, newLine: 1 },
+    {
+      type: "deleted",
+      text: "old line A",
+      sign: "-",
+      oldLine: 2,
+      newLine: null,
+    },
+    {
+      type: "deleted",
+      text: "old line B",
+      sign: "-",
+      oldLine: 3,
+      newLine: null,
+    },
+    { type: "added", text: "new line A", sign: "+", oldLine: null, newLine: 2 },
+    { type: "context", text: "keep two", sign: " ", oldLine: 4, newLine: 3 },
+  ]
+}
+
+describe("UnifiedDiffPreview — side-by-side view", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("renders unified signs by default and keeps the split mode opt-in", () => {
+    renderWithIntl(<UnifiedDiffPreview diffText={modifiedDiff()} />)
+
+    expect(screen.getAllByText("+")).toHaveLength(1)
+    expect(screen.getAllByText("-")).toHaveLength(2)
+  })
+
+  it("reads a persisted split preference before the first render", () => {
+    localStorage.setItem("workspace:diff-view-mode", "split")
+    renderWithIntl(<UnifiedDiffPreview diffText={modifiedDiff()} />)
+
+    expect(screen.queryByText("+")).not.toBeInTheDocument()
+    // Context rows now render once per side.
+    expect(screen.getAllByText("keep one")).toHaveLength(2)
+  })
+
+  it("toggles to split, renders both sides, and persists the choice", () => {
+    renderWithIntl(<UnifiedDiffPreview diffText={modifiedDiff()} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Switch to side-by-side view" })
+    )
+
+    // No unified sign column anymore; both sides' texts are on screen.
+    expect(screen.queryByText("+")).not.toBeInTheDocument()
+    expect(screen.getAllByText("keep one")).toHaveLength(2)
+    expect(screen.getByText("old line A")).toBeInTheDocument()
+    expect(screen.getByText("new line A")).toBeInTheDocument()
+    expect(localStorage.getItem("workspace:diff-view-mode")).toBe("split")
+  })
+
+  it("toggles back to unified and persists it", () => {
+    localStorage.setItem("workspace:diff-view-mode", "split")
+    renderWithIntl(<UnifiedDiffPreview diffText={modifiedDiff()} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Switch to inline view" })
+    )
+
+    expect(screen.getByText("+")).toBeInTheDocument()
+    expect(localStorage.getItem("workspace:diff-view-mode")).toBe("unified")
+  })
+})
+
+describe("toSplitRows", () => {
+  it("spans context rows across both sides", () => {
+    const [row] = toSplitRows(modifiedRows().slice(0, 1))
+
+    expect(row?.left).toEqual({
+      line: 1,
+      text: "keep one",
+      marker: "none",
+    })
+    expect(row?.right).toEqual({
+      line: 1,
+      text: "keep one",
+      marker: "none",
+    })
+  })
+
+  it("pairs a delete-run with its add-run positionally", () => {
+    const rows = toSplitRows(modifiedRows().slice(1, 4))
+
+    expect(rows).toHaveLength(2)
+    // First pair: old A faces new A.
+    expect(rows[0]?.left).toMatchObject({
+      text: "old line A",
+      marker: "deleted",
+    })
+    expect(rows[0]?.right).toMatchObject({
+      text: "new line A",
+      marker: "added",
+    })
+    // The longer delete run leaves a filler cell on the right.
+    expect(rows[1]?.left).toMatchObject({ text: "old line B" })
+    expect(rows[1]?.right).toEqual({
+      line: null,
+      text: null,
+      marker: "none",
+    })
+  })
+
+  it("gives a pure insertion an empty left cell", () => {
+    const rows = toSplitRows([
+      { type: "added", text: "fresh", sign: "+", oldLine: null, newLine: 5 },
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.left).toEqual({ line: null, text: null, marker: "none" })
+    expect(rows[0]?.right).toMatchObject({ text: "fresh", line: 5 })
   })
 })

--- a/src/components/diff/unified-diff-preview.tsx
+++ b/src/components/diff/unified-diff-preview.tsx
@@ -5,34 +5,14 @@ import { useTranslations } from "next-intl"
 import { Columns2, Rows3 } from "lucide-react"
 import { useActiveFolder } from "@/contexts/active-folder-context"
 import { cn } from "@/lib/utils"
+import { useDiffViewMode, type DiffViewMode } from "@/lib/diff-view-mode-prefs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { FilePathLink } from "@/components/ai-elements/link-safety"
 
 type RowMarker = "none" | "added" | "deleted" | "modified"
 type DiffFileMode = "modified" | "added" | "deleted" | "renamed"
-export type DiffViewMode = "unified" | "split"
 
-const DIFF_VIEW_MODE_KEY = "workspace:diff-view-mode"
-
-export function loadDiffViewMode(): DiffViewMode {
-  if (typeof window === "undefined") return "unified"
-  try {
-    const raw = localStorage.getItem(DIFF_VIEW_MODE_KEY)
-    if (raw === "split" || raw === "unified") return raw
-  } catch {
-    /* ignore */
-  }
-  return "unified"
-}
-
-export function saveDiffViewMode(mode: DiffViewMode): void {
-  if (typeof window === "undefined") return
-  try {
-    localStorage.setItem(DIFF_VIEW_MODE_KEY, mode)
-  } catch {
-    /* ignore */
-  }
-}
+export type { DiffViewMode }
 
 interface RawDiffRow {
   kind: "context" | "add" | "del"
@@ -514,7 +494,13 @@ export function toSplitRows(rows: ParsedDiffRow[]): SplitRow[] {
     const row = rows[index]
     if (!row) break
 
-    if (row.type === "context") {
+    // Everything that is not part of a delete/add run spans both sides. The
+    // branch keys off "not added and not deleted" rather than "is context" so
+    // that the loop is guaranteed to consume a row on every pass: a row of the
+    // fourth `ParsedDiffRow` type ("modified") would otherwise match neither
+    // this branch nor either run below, leaving `index` unmoved and spinning
+    // the tab forever.
+    if (row.type !== "added" && row.type !== "deleted") {
       out.push({
         left: { line: row.oldLine, text: row.text, marker: "none" },
         right: { line: row.newLine, text: row.text, marker: "none" },
@@ -657,6 +643,14 @@ function HunkSplitLines({ rows }: { rows: ParsedDiffRow[] }) {
 
 function isNewFileOnly(file: ParsedDiffFile): boolean {
   return file.mode === "added" && file.deletions === 0
+}
+
+/** New files render as plain content in BOTH modes (there is no "before" side
+ *  to put anything on), so a diff made only of them has nothing to switch —
+ *  offering the toggle there would be a control that visibly does nothing.
+ *  Write-tool previews in a transcript are exactly this shape. */
+function supportsSplitView(files: ParsedDiffFile[]): boolean {
+  return files.some((file) => !isNewFileOnly(file))
 }
 
 // Beyond this many rows a single file is rendered as a bounded preview: each
@@ -847,12 +841,7 @@ export function UnifiedDiffPreview({
   const t = useTranslations("Folder.diffPreview")
   const { activeFolder: folder } = useActiveFolder()
   const files = useMemo(() => parseUnifiedDiff(diffText), [diffText])
-  const [view, setView] = useState<DiffViewMode>(() => loadDiffViewMode())
-
-  const switchView = (mode: DiffViewMode) => {
-    setView(mode)
-    saveDiffViewMode(mode)
-  }
+  const [view, switchView] = useDiffViewMode()
 
   if (!diffText.trim()) {
     return (
@@ -889,22 +878,24 @@ export function UnifiedDiffPreview({
   return (
     <Frame className={className}>
       <div className={embedded ? "space-y-2" : "space-y-3"}>
-        <div className="flex items-center justify-end gap-1">
-          <ViewModeButton
-            active={view === "unified"}
-            label={t("viewMode.unified")}
-            onClick={() => switchView("unified")}
-          >
-            <Rows3 className="h-3 w-3" />
-          </ViewModeButton>
-          <ViewModeButton
-            active={view === "split"}
-            label={t("viewMode.split")}
-            onClick={() => switchView("split")}
-          >
-            <Columns2 className="h-3 w-3" />
-          </ViewModeButton>
-        </div>
+        {supportsSplitView(files) && (
+          <div className="flex items-center justify-end gap-1">
+            <ViewModeButton
+              active={view === "unified"}
+              label={t("viewMode.unified")}
+              onClick={() => switchView("unified")}
+            >
+              <Rows3 className="h-3 w-3" />
+            </ViewModeButton>
+            <ViewModeButton
+              active={view === "split"}
+              label={t("viewMode.split")}
+              onClick={() => switchView("split")}
+            >
+              <Columns2 className="h-3 w-3" />
+            </ViewModeButton>
+          </div>
+        )}
         {files.map((file) => (
           <DiffFileSection
             key={file.key}

--- a/src/components/diff/unified-diff-preview.tsx
+++ b/src/components/diff/unified-diff-preview.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react"
 import { useTranslations } from "next-intl"
+import { Columns2, Rows3 } from "lucide-react"
 import { useActiveFolder } from "@/contexts/active-folder-context"
 import { cn } from "@/lib/utils"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -9,6 +10,29 @@ import { FilePathLink } from "@/components/ai-elements/link-safety"
 
 type RowMarker = "none" | "added" | "deleted" | "modified"
 type DiffFileMode = "modified" | "added" | "deleted" | "renamed"
+export type DiffViewMode = "unified" | "split"
+
+const DIFF_VIEW_MODE_KEY = "workspace:diff-view-mode"
+
+export function loadDiffViewMode(): DiffViewMode {
+  if (typeof window === "undefined") return "unified"
+  try {
+    const raw = localStorage.getItem(DIFF_VIEW_MODE_KEY)
+    if (raw === "split" || raw === "unified") return raw
+  } catch {
+    /* ignore */
+  }
+  return "unified"
+}
+
+export function saveDiffViewMode(mode: DiffViewMode): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(DIFF_VIEW_MODE_KEY, mode)
+  } catch {
+    /* ignore */
+  }
+}
 
 interface RawDiffRow {
   kind: "context" | "add" | "del"
@@ -17,7 +41,7 @@ interface RawDiffRow {
   newLine: number | null
 }
 
-interface ParsedDiffRow {
+export interface ParsedDiffRow {
   type: "context" | "added" | "deleted" | "modified"
   text: string
   sign: " " | "+" | "-"
@@ -459,6 +483,75 @@ function rowMarker(row: ParsedDiffRow): RowMarker {
   return "none"
 }
 
+/** One half of a side-by-side row. `text === null` marks the filler cell a
+ *  delete-only or add-only block leaves on the opposite side. */
+export interface SplitCell {
+  line: number | null
+  text: string | null
+  marker: RowMarker
+}
+
+export interface SplitRow {
+  left: SplitCell
+  right: SplitCell
+}
+
+const EMPTY_CELL: SplitCell = { line: null, text: null, marker: "none" }
+
+/**
+ * Re-pair a hunk's unified rows for the side-by-side view: context rows span
+ * both sides, and each delete-run followed by its add-run is zipped
+ * positionally — the i-th deleted line faces the i-th added line, and the
+ * longer run's remainder faces a filler cell (the same alignment GitHub's
+ * split view uses; the lines share a row, they are not claimed to be
+ * related).
+ */
+export function toSplitRows(rows: ParsedDiffRow[]): SplitRow[] {
+  const out: SplitRow[] = []
+  let index = 0
+
+  while (index < rows.length) {
+    const row = rows[index]
+    if (!row) break
+
+    if (row.type === "context") {
+      out.push({
+        left: { line: row.oldLine, text: row.text, marker: "none" },
+        right: { line: row.newLine, text: row.text, marker: "none" },
+      })
+      index += 1
+      continue
+    }
+
+    const dels: ParsedDiffRow[] = []
+    const adds: ParsedDiffRow[] = []
+    while (index < rows.length && rows[index]?.type === "deleted") {
+      dels.push(rows[index]!)
+      index += 1
+    }
+    while (index < rows.length && rows[index]?.type === "added") {
+      adds.push(rows[index]!)
+      index += 1
+    }
+
+    const pairs = Math.max(dels.length, adds.length)
+    for (let p = 0; p < pairs; p++) {
+      const del = dels[p]
+      const add = adds[p]
+      out.push({
+        left: del
+          ? { line: del.oldLine, text: del.text, marker: "deleted" }
+          : EMPTY_CELL,
+        right: add
+          ? { line: add.newLine, text: add.text, marker: "added" }
+          : EMPTY_CELL,
+      })
+    }
+  }
+
+  return out
+}
+
 function HunkSeparator({ hunk }: { hunk: ParsedDiffHunk }) {
   const label =
     hunk.oldStart != null && hunk.oldCount != null
@@ -516,6 +609,52 @@ function NewFileLines({ rows }: { rows: ParsedDiffRow[] }) {
   )
 }
 
+function SplitCellView({
+  cell,
+  gutterClassName,
+}: {
+  cell: SplitCell
+  gutterClassName: string
+}) {
+  const empty = cell.text === null
+  return (
+    <div
+      className={cn(
+        "flex min-w-[260px] flex-1 basis-0",
+        empty ? "bg-muted/20" : ROW_CLASS[cell.marker]
+      )}
+    >
+      <span
+        className={cn(
+          gutterClassName,
+          "shrink-0 select-none pr-1 text-right",
+          empty ? "text-transparent" : "text-muted-foreground/40"
+        )}
+      >
+        {cell.line ?? ""}
+      </span>
+      <span className="flex-1 whitespace-pre pr-3">{cell.text}</span>
+    </div>
+  )
+}
+
+function HunkSplitLines({ rows }: { rows: ParsedDiffRow[] }) {
+  const splitRows = useMemo(() => toSplitRows(rows), [rows])
+  return (
+    <div className="font-mono text-[12px] leading-[20px]">
+      {splitRows.map((row, i) => (
+        <div key={i} className="flex">
+          <SplitCellView cell={row.left} gutterClassName="w-[3rem]" />
+          <SplitCellView
+            cell={row.right}
+            gutterClassName="w-[3rem] border-l border-border/40"
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function isNewFileOnly(file: ParsedDiffFile): boolean {
   return file.mode === "added" && file.deletions === 0
 }
@@ -550,12 +689,14 @@ function capHunks(hunks: ParsedDiffHunk[], limit: number): ParsedDiffHunk[] {
 
 function DiffFileSection({
   file,
+  view,
   embedded,
   clickableFilePath,
   folderPath,
   unbounded,
 }: {
   file: ParsedDiffFile
+  view: DiffViewMode
   embedded: boolean
   clickableFilePath: boolean
   folderPath: string | null
@@ -649,7 +790,11 @@ function DiffFileSection({
             : hunks.map((hunk, hunkIdx) => (
                 <div key={hunk.key}>
                   {hunkIdx > 0 && <HunkSeparator hunk={hunk} />}
-                  <HunkLines rows={hunk.rows} />
+                  {view === "split" ? (
+                    <HunkSplitLines rows={hunk.rows} />
+                  ) : (
+                    <HunkLines rows={hunk.rows} />
+                  )}
                 </div>
               ))}
         </div>
@@ -702,6 +847,12 @@ export function UnifiedDiffPreview({
   const t = useTranslations("Folder.diffPreview")
   const { activeFolder: folder } = useActiveFolder()
   const files = useMemo(() => parseUnifiedDiff(diffText), [diffText])
+  const [view, setView] = useState<DiffViewMode>(() => loadDiffViewMode())
+
+  const switchView = (mode: DiffViewMode) => {
+    setView(mode)
+    saveDiffViewMode(mode)
+  }
 
   if (!diffText.trim()) {
     return (
@@ -738,10 +889,27 @@ export function UnifiedDiffPreview({
   return (
     <Frame className={className}>
       <div className={embedded ? "space-y-2" : "space-y-3"}>
+        <div className="flex items-center justify-end gap-1">
+          <ViewModeButton
+            active={view === "unified"}
+            label={t("viewMode.unified")}
+            onClick={() => switchView("unified")}
+          >
+            <Rows3 className="h-3 w-3" />
+          </ViewModeButton>
+          <ViewModeButton
+            active={view === "split"}
+            label={t("viewMode.split")}
+            onClick={() => switchView("split")}
+          >
+            <Columns2 className="h-3 w-3" />
+          </ViewModeButton>
+        </div>
         {files.map((file) => (
           <DiffFileSection
             key={file.key}
             file={file}
+            view={view}
             embedded={embedded}
             clickableFilePath={clickableFilePath}
             folderPath={folder?.path ?? null}
@@ -750,6 +918,34 @@ export function UnifiedDiffPreview({
         ))}
       </div>
     </Frame>
+  )
+}
+
+function ViewModeButton({
+  active,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+      className={cn(
+        "inline-flex items-center gap-1 rounded border border-border bg-background px-2 py-0.5 text-[10px] transition-colors hover:bg-muted",
+        active ? "text-foreground" : "text-muted-foreground"
+      )}
+    >
+      {children}
+    </button>
   )
 }
 

--- a/src/components/diff/unified-diff-preview.tsx
+++ b/src/components/diff/unified-diff-preview.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState } from "react"
+import { Fragment, useMemo, useState } from "react"
 import { useTranslations } from "next-intl"
 import { Columns2, Rows3 } from "lucide-react"
 import { useActiveFolder } from "@/contexts/active-folder-context"
@@ -603,13 +603,11 @@ function SplitCellView({
   gutterClassName: string
 }) {
   const empty = cell.text === null
+  // Sizing belongs to the grid track, not the cell: a cell that sized itself
+  // could end up narrower than its own `whitespace-pre` line and paint it over
+  // the neighbouring column.
   return (
-    <div
-      className={cn(
-        "flex min-w-[260px] flex-1 basis-0",
-        empty ? "bg-muted/20" : ROW_CLASS[cell.marker]
-      )}
-    >
+    <div className={cn("flex", empty ? "bg-muted/20" : ROW_CLASS[cell.marker])}>
       <span
         className={cn(
           gutterClassName,
@@ -624,18 +622,33 @@ function SplitCellView({
   )
 }
 
+/**
+ * One grid for the whole hunk, so the two columns are laid out by shared
+ * tracks rather than per-row: every row is guaranteed to break at the same
+ * x, and no cell can be sized below the line it holds.
+ *
+ * `w-max` is load-bearing. Without it the grid takes the shrink-to-fit width
+ * of its inline-block parent, which resolves to the tracks' MINIMUM sizes;
+ * `1fr 1fr` then halves that between the columns, so a row whose two sides
+ * differ in length (the normal case — a replaced line rarely keeps its old
+ * width) leaves the longer side overflowing its track and painting under the
+ * opposite column's background and text. Sizing to `max-content` makes the
+ * grid as wide as twice its widest cell, which the enclosing `x="scroll"`
+ * ScrollArea then scrolls; `min-w-full` keeps short diffs filling the host
+ * instead of huddling on the left.
+ */
 function HunkSplitLines({ rows }: { rows: ParsedDiffRow[] }) {
   const splitRows = useMemo(() => toSplitRows(rows), [rows])
   return (
-    <div className="font-mono text-[12px] leading-[20px]">
+    <div className="grid w-max min-w-full grid-cols-[repeat(2,minmax(260px,1fr))] font-mono text-[12px] leading-[20px]">
       {splitRows.map((row, i) => (
-        <div key={i} className="flex">
+        <Fragment key={i}>
           <SplitCellView cell={row.left} gutterClassName="w-[3rem]" />
           <SplitCellView
             cell={row.right}
             gutterClassName="w-[3rem] border-l border-border/40"
           />
-        </div>
+        </Fragment>
       ))}
     </div>
   )

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "مقطع {index}",
       "loadingHunk": "جارٍ تحميل hunk...",
       "noDiffData": "لا توجد بيانات diff",
-      "showRemainingLines": "عرض {count} سطر إضافي"
+      "showRemainingLines": "عرض {count} سطر إضافي",
+      "viewMode": {
+        "split": "التبديل إلى العرض جنباً إلى جنب",
+        "unified": "التبديل إلى العرض المضمّن"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "مجلد العمل",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "Block {index}",
       "loadingHunk": "Hunk wird geladen...",
       "noDiffData": "Keine Diff-Daten",
-      "showRemainingLines": "{count} weitere Zeilen anzeigen"
+      "showRemainingLines": "{count} weitere Zeilen anzeigen",
+      "viewMode": {
+        "split": "Zur Zwei-Spalten-Ansicht wechseln",
+        "unified": "Zur Inline-Ansicht wechseln"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "Arbeitsordner",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "Hunk {index}",
       "loadingHunk": "Loading hunk...",
       "noDiffData": "No diff data",
-      "showRemainingLines": "Show {count} more lines"
+      "showRemainingLines": "Show {count} more lines",
+      "viewMode": {
+        "split": "Switch to side-by-side view",
+        "unified": "Switch to inline view"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "Working folder",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "Bloque {index}",
       "loadingHunk": "Cargando hunk...",
       "noDiffData": "Sin datos de diff",
-      "showRemainingLines": "Mostrar {count} líneas más"
+      "showRemainingLines": "Mostrar {count} líneas más",
+      "viewMode": {
+        "split": "Cambiar a la vista lado a lado",
+        "unified": "Cambiar a la vista en línea"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "Carpeta de trabajo",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "Bloc {index}",
       "loadingHunk": "Chargement du hunk...",
       "noDiffData": "Aucune donnée diff",
-      "showRemainingLines": "Afficher {count} lignes de plus"
+      "showRemainingLines": "Afficher {count} lignes de plus",
+      "viewMode": {
+        "split": "Passer à la vue côte à côte",
+        "unified": "Passer à la vue en ligne"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "Dossier de travail",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "ハンク {index}",
       "loadingHunk": "Hunk を読み込み中...",
       "noDiffData": "Diff データがありません",
-      "showRemainingLines": "残り {count} 行を表示"
+      "showRemainingLines": "残り {count} 行を表示",
+      "viewMode": {
+        "split": "左右分割ビューに切り替え",
+        "unified": "インラインビューに切り替え"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "作業フォルダ",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "청크 {index}",
       "loadingHunk": "Hunk 로딩 중...",
       "noDiffData": "Diff 데이터 없음",
-      "showRemainingLines": "나머지 {count}줄 표시"
+      "showRemainingLines": "나머지 {count}줄 표시",
+      "viewMode": {
+        "split": "나란히 보기로 전환",
+        "unified": "인라인 보기로 전환"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "작업 폴더",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "Bloco {index}",
       "loadingHunk": "Carregando hunk...",
       "noDiffData": "Sem dados de diff",
-      "showRemainingLines": "Mostrar mais {count} linhas"
+      "showRemainingLines": "Mostrar mais {count} linhas",
+      "viewMode": {
+        "split": "Alternar para a visualização lado a lado",
+        "unified": "Alternar para a visualização em linha"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "Pasta de trabalho",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "代码块 {index}",
       "loadingHunk": "正在加载代码块...",
       "noDiffData": "无差异数据",
-      "showRemainingLines": "显示剩余 {count} 行"
+      "showRemainingLines": "显示剩余 {count} 行",
+      "viewMode": {
+        "split": "切换为左右分栏视图",
+        "unified": "切换为内联视图"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "工作文件夹",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -3475,7 +3475,11 @@
       "hunkLabel": "區塊 {index}",
       "loadingHunk": "正在載入區塊...",
       "noDiffData": "無差異資料",
-      "showRemainingLines": "顯示剩餘 {count} 行"
+      "showRemainingLines": "顯示剩餘 {count} 行",
+      "viewMode": {
+        "split": "切換為左右分欄視圖",
+        "unified": "切換為內聯視圖"
+      }
     },
     "conversationContextBar": {
       "folderTitle": "工作資料夾",

--- a/src/lib/diff-view-mode-prefs.ts
+++ b/src/lib/diff-view-mode-prefs.ts
@@ -1,0 +1,75 @@
+// Inline vs. side-by-side layout for the lightweight diff preview
+// (`UnifiedDiffPreview`). Persisted in localStorage; defaults to the inline
+// view so the existing look is unchanged until the user opts in.
+//
+// The preference is GLOBAL, and a single screen routinely mounts several
+// previews at once (one per Edit/Write tool call in a transcript, plus any
+// permission dialog stacked on top). Reading localStorage once per instance
+// would leave every already-mounted sibling on the old layout until it
+// remounted, so the toggle broadcasts and each preview subscribes — the same
+// shape `office-preview-prefs` uses for its cross-surface toggle.
+
+import { useEffect, useState } from "react"
+
+export type DiffViewMode = "unified" | "split"
+
+const DIFF_VIEW_MODE_KEY = "workspace:diff-view-mode"
+const DIFF_VIEW_MODE_EVENT = "codeg:diff-view-mode-changed"
+
+export function loadDiffViewMode(): DiffViewMode {
+  if (typeof window === "undefined") return "unified"
+  try {
+    const raw = localStorage.getItem(DIFF_VIEW_MODE_KEY)
+    if (raw === "split" || raw === "unified") return raw
+  } catch {
+    /* ignore */
+  }
+  return "unified"
+}
+
+export function saveDiffViewMode(mode: DiffViewMode): void {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(DIFF_VIEW_MODE_KEY, mode)
+  } catch {
+    /* ignore */
+  }
+  // Notify every preview mounted in THIS window; other windows/tabs get the
+  // native `storage` event. The new mode rides along on the event so the
+  // toggle still works in a browser where the write above threw (quota,
+  // storage disabled) — it just won't survive a reload.
+  window.dispatchEvent(new CustomEvent(DIFF_VIEW_MODE_EVENT, { detail: mode }))
+}
+
+function modeFromEvent(event: Event): DiffViewMode | null {
+  const detail = (event as CustomEvent<unknown>).detail
+  return detail === "split" || detail === "unified" ? detail : null
+}
+
+/**
+ * Reactive read of the diff view mode, plus the setter that persists it.
+ * Every mounted preview flips together — including ones the user is not
+ * pointing at — because the mode is one preference, not per-preview state.
+ */
+export function useDiffViewMode(): [
+  DiffViewMode,
+  (mode: DiffViewMode) => void,
+] {
+  const [mode, setMode] = useState<DiffViewMode>(loadDiffViewMode)
+  useEffect(() => {
+    // Same-window broadcasts carry the value; a cross-window `storage` event
+    // does not, so re-read for those.
+    const sync = (event: Event) =>
+      setMode(modeFromEvent(event) ?? loadDiffViewMode())
+    window.addEventListener(DIFF_VIEW_MODE_EVENT, sync)
+    window.addEventListener("storage", sync)
+    return () => {
+      window.removeEventListener(DIFF_VIEW_MODE_EVENT, sync)
+      window.removeEventListener("storage", sync)
+    }
+  }, [])
+  // `saveDiffViewMode` writes and then dispatches synchronously, so this
+  // instance updates through the same subscription as its siblings — one path
+  // instead of a local `setState` that could drift from the broadcast one.
+  return [mode, saveDiffViewMode]
+}


### PR DESCRIPTION
## 功能

为 `UnifiedDiffPreview`（聊天消息 diff、权限弹窗、任务详情、文件面板中使用的轻量 diff 预览）增加左右分栏视图，现有内联视图保留为默认。

Closes #537

## 实现说明

- 预览右上角新增 内联 / 分栏 图标切换按钮，选择持久化到 localStorage（`workspace:diff-view-mode`），对所有宿主生效
- 分栏视图将 hunk 行重新配对：context 行两侧同显；删除块与紧随的新增块按位置一一对应（GitHub split 视图的对齐方式），较长一侧的剩余行对面显示留空单元格
- 两栏默认严格等宽（`flex-1 basis-0` + 最小宽度兜底），超长行保持横向滚动；纯新增文件（`NewFileLines`）两种模式下都保持单栏展示
- 默认仍为内联视图，不改变现有用户体验；500 行截断与展开逻辑在两种视图下同样生效

## 手动验证

打开任意一条包含 diff 的聊天消息（或权限弹窗、任务详情的 diff），点击预览右上角的分栏图标：删除行居左、新增行居右、上下文行两侧同显；刷新后选择仍保持。

## 验证

- `npx vitest run src/components/diff/unified-diff-preview.test.tsx` — 11 个测试（新增 7 个：默认内联、持久化读取、切换与写回、配对算法三例）
- `pnpm test` — 353 个测试文件 / 4875 个测试全部通过
- `pnpm build` — 静态导出构建通过（与 CI 一致）
- `npx tsc --noEmit`、`eslint` 通过
