### PR TITLE
fix: keep add-to-chat pill visible for first-line selections

### DIFF
--- a/src/components/files/file-workspace-panel-add-to-chat-pill.test.ts
+++ b/src/components/files/file-workspace-panel-add-to-chat-pill.test.ts
@@ -11,37 +11,78 @@ const panelSource = readFileSync(
 // The pill's placement only misbehaves against a real Monaco layout (see
 // add-to-chat-pill-placement.test.ts for the decision itself), so these guard
 // the wiring that unit tests cannot reach: that the decision is fed Monaco's
-// own viewport-relative anchor offset, and that it is re-run on the two events
-// that invalidate it.
+// own viewport-relative measurements, and that it is re-run on every event that
+// invalidates it.
 describe("file-workspace-panel add-to-chat pill placement wiring", () => {
+  it("keeps the pill in the editor's overflow layer", () => {
+    // Without this the editor's own scrollbar paints over the pill near the
+    // right edge, and the node shrink-to-fits to min-content.
+    expect(panelSource).toMatch(/allowEditorOverflow: true/)
+  })
+
   it("feeds the placement helper the viewport-relative anchor offset", () => {
     // Not the raw `getTopForPosition`: that is content-relative, and dropping
     // the scrollTop term silently reinstates the bug for every scrolled file.
     expect(panelSource).toMatch(
-      /getTopForPosition\([\s\S]{0,120}getAddToChatPillPlacement\(\s*anchorTop < 0 \? null : anchorTop - editor\.getScrollTop\(\)/
+      /getTopForPosition\([\s\S]{0,200}anchorTop < 0 \? null : anchorTop - editor\.getScrollTop\(\)/
     )
     expect(panelSource).toMatch(
-      /measuredHeight \|\| ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX/
+      /spaceBelowPx:[\s\S]{0,120}editor\.getLayoutInfo\(\)\.height - \(spaceAbovePx \+ lineHeightPx\)/
+    )
+    expect(panelSource).toMatch(
+      /pillHeightPx: measuredHeight \|\| ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX/
     )
   })
 
-  it("re-lays out once the hidden-until-shown pill can finally be measured", () => {
+  it("withholds the widget when the helper reports nowhere to put it", () => {
     expect(panelSource).toMatch(
-      /if \(pill\.remeasure\(\)\) editorInstance\.layoutContentWidget\(pill\.widget\)/
+      /return preference\.length > 0 \? \{ position, preference \} : null/
     )
   })
 
-  it("re-decides the placement when the anchor is scrolled vertically", () => {
+  it("carries the measure-and-correct handshake on every layout path", () => {
+    // Monaco decides the placement while the node is still display:none, so a
+    // layout path without the remeasure re-uses a stale height — that is how a
+    // live zoom (which resizes the pill without touching the selection) put the
+    // pill back behind the path bar.
+    expect(panelSource).toMatch(
+      /const layoutPill = \(\) => \{\s*\n\s*editorInstance\.layoutContentWidget\(pill\.widget\)\s*\n\s*if \(pill\.remeasure\(\)\) editorInstance\.layoutContentWidget\(pill\.widget\)\s*\n\s*\}/
+    )
+    // ...and every listener goes through it rather than laying the widget out
+    // directly, which is what would silently drop the remeasure again.
+    const listenerBody = panelSource.slice(
+      panelSource.indexOf("const refreshPill = ()"),
+      panelSource.indexOf("editorInstance.onDidDispose(")
+    )
+    expect(listenerBody).not.toMatch(/layoutContentWidget/)
+  })
+
+  it("re-decides the placement on vertical scroll and on editor resize", () => {
     // Monaco latches the preference at layout time, so a visible pill keeps a
-    // stale above/below choice until something lays it out again.
+    // stale choice until something lays it out again. Scroll changes the room
+    // above the anchor; a layout change (terminal splitter, zoom) changes the
+    // room below it and the pill's own height.
     expect(panelSource).toMatch(
-      /onDidScrollChange\(\(event\) => \{[\s\S]{0,160}event\.scrollTopChanged && pill\.isVisible\(\)[\s\S]{0,120}layoutContentWidget\(pill\.widget\)/
+      /const relayoutPill = \(\) => \{\s*\n\s*if \(pill\.isVisible\(\)\) layoutPill\(\)/
     )
+    expect(panelSource).toMatch(
+      /onDidScrollChange\(\(event\) => \{\s*\n\s*if \(event\.scrollTopChanged\) relayoutPill\(\)/
+    )
+    expect(panelSource).toMatch(/onDidLayoutChange\(relayoutPill\)/)
   })
 
-  it("disposes the scroll listener with the rest of the add-to-chat teardown", () => {
+  it("does not use Monaco's EXACT preference", () => {
+    // For an overflowing widget Monaco's EXACT coordinate omits the scrollLeft
+    // term, which throws the pill outside a horizontally scrolled editor.
+    expect(panelSource).not.toMatch(/ContentWidgetPositionPreference\.EXACT/)
+  })
+
+  it("disposes both placement listeners with the rest of the teardown", () => {
     expect(panelSource).toMatch(
       /scrollListenerRef\.current\?\.dispose\(\)\s*\n\s*scrollListenerRef\.current = null/
+    )
+    expect(panelSource).toMatch(
+      /layoutListenerRef\.current\?\.dispose\(\)\s*\n\s*layoutListenerRef\.current = null/
     )
   })
 })

--- a/src/components/files/file-workspace-panel-add-to-chat-pill.test.ts
+++ b/src/components/files/file-workspace-panel-add-to-chat-pill.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const panelSource = readFileSync(
+  resolve(process.cwd(), "src/components/files/file-workspace-panel.tsx"),
+  "utf8"
+)
+
+// The pill's placement only misbehaves against a real Monaco layout (see
+// add-to-chat-pill-placement.test.ts for the decision itself), so these guard
+// the wiring that unit tests cannot reach: that the decision is fed Monaco's
+// own viewport-relative anchor offset, and that it is re-run on the two events
+// that invalidate it.
+describe("file-workspace-panel add-to-chat pill placement wiring", () => {
+  it("feeds the placement helper the viewport-relative anchor offset", () => {
+    // Not the raw `getTopForPosition`: that is content-relative, and dropping
+    // the scrollTop term silently reinstates the bug for every scrolled file.
+    expect(panelSource).toMatch(
+      /getTopForPosition\([\s\S]{0,120}getAddToChatPillPlacement\(\s*anchorTop < 0 \? null : anchorTop - editor\.getScrollTop\(\)/
+    )
+    expect(panelSource).toMatch(
+      /measuredHeight \|\| ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX/
+    )
+  })
+
+  it("re-lays out once the hidden-until-shown pill can finally be measured", () => {
+    expect(panelSource).toMatch(
+      /if \(pill\.remeasure\(\)\) editorInstance\.layoutContentWidget\(pill\.widget\)/
+    )
+  })
+
+  it("re-decides the placement when the anchor is scrolled vertically", () => {
+    // Monaco latches the preference at layout time, so a visible pill keeps a
+    // stale above/below choice until something lays it out again.
+    expect(panelSource).toMatch(
+      /onDidScrollChange\(\(event\) => \{[\s\S]{0,160}event\.scrollTopChanged && pill\.isVisible\(\)[\s\S]{0,120}layoutContentWidget\(pill\.widget\)/
+    )
+  })
+
+  it("disposes the scroll listener with the rest of the add-to-chat teardown", () => {
+    expect(panelSource).toMatch(
+      /scrollListenerRef\.current\?\.dispose\(\)\s*\n\s*scrollListenerRef\.current = null/
+    )
+  })
+})

--- a/src/components/files/file-workspace-panel.tsx
+++ b/src/components/files/file-workspace-panel.tsx
@@ -336,7 +336,23 @@ interface AddToChatPill {
   setVisible: (visible: boolean, position: IPosition | null) => void
   /** Re-read the label (e.g. after a locale change) even while already shown. */
   refreshLabel: () => void
+  /**
+   * Re-read the rendered pill height now that Monaco has un-hidden the node.
+   * Returns true when the cached value changed, i.e. when the caller should lay
+   * the widget out once more so the corrected placement lands.
+   */
+  remeasure: () => boolean
 }
+
+/**
+ * Placement fallback for the very first show, before the pill has ever been
+ * measured (Monaco keeps the node at `display: none` until *after* it asks for
+ * a position, so `offsetHeight` reads 0 exactly when the placement is decided).
+ * Deliberately a slight over-estimate of the real box: over-estimating only
+ * demotes ABOVE for one extra line, while under-estimating is what puts the
+ * pill back behind the file path bar.
+ */
+const ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX = 28
 
 /**
  * The floating "Add to Chat" pill shown next to a text selection, built as a
@@ -381,6 +397,7 @@ function createAddToChatPill(
 
   let visible = false
   let position: IPosition | null = null
+  let measuredHeight = 0
 
   const widget: MonacoEditorNs.IContentWidget = {
     getId: () => "codeg.addToChatPill",
@@ -388,11 +405,18 @@ function createAddToChatPill(
     getPosition: () => {
       if (!visible || !position) return null
 
-      const firstVisibleLineNumber =
-        editor.getVisibleRanges()[0]?.startLineNumber ?? null
-      const preference = getAddToChatPillPlacement(
+      // Monaco's own `anchor.top`: the gap between the top edge of the editor
+      // viewport and the anchor line. `getTopForPosition` is wrap-aware (it
+      // converts to a view position first) and costs a layout-model lookup
+      // only — no DOM measurement — so it is safe on the scroll path.
+      // A negative return means "no model", not a real offset.
+      const anchorTop = editor.getTopForPosition(
         position.lineNumber,
-        firstVisibleLineNumber
+        position.column
+      )
+      const preference = getAddToChatPillPlacement(
+        anchorTop < 0 ? null : anchorTop - editor.getScrollTop(),
+        measuredHeight || ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX
       ).map((placement) =>
         placement === "above"
           ? monaco.editor.ContentWidgetPositionPreference.ABOVE
@@ -415,6 +439,12 @@ function createAddToChatPill(
     },
     refreshLabel: () => {
       if (labelSpan) labelSpan.textContent = getLabel()
+    },
+    remeasure: () => {
+      const next = dom.offsetHeight
+      if (next <= 0 || next === measuredHeight) return false
+      measuredHeight = next
+      return true
     },
   }
 }
@@ -1640,6 +1670,11 @@ export function FileWorkspacePanel() {
           show && selection ? selection.getStartPosition() : null
         )
         editorInstance.layoutContentWidget(pill.widget)
+        // Monaco flips the node to `display: block` inside the call above, so
+        // this is the first moment the pill can be measured. When that lands a
+        // new height, redo the layout in the same frame with the real box —
+        // otherwise the first-ever show would place itself off the fallback.
+        if (pill.remeasure()) editorInstance.layoutContentWidget(pill.widget)
       }
       selectionListenerRef.current?.dispose()
       selectionListenerRef.current =
@@ -1652,6 +1687,12 @@ export function FileWorkspacePanel() {
         pill.setVisible(false, null)
         editorInstance.layoutContentWidget(pill.widget)
       })
+      // Monaco latches a widget's placement preference when the widget is laid
+      // out and re-uses it for every later render, so a pill that is already on
+      // screen keeps its old above/below choice while the user scrolls its
+      // anchor line up to the top edge. Re-layout on vertical scroll to
+      // re-decide. Nothing above depends on the horizontal offset, so
+      // `scrollLeft`-only ticks are skipped.
       scrollListenerRef.current?.dispose()
       scrollListenerRef.current = editorInstance.onDidScrollChange((event) => {
         if (event.scrollTopChanged && pill.isVisible()) {

--- a/src/components/files/file-workspace-panel.tsx
+++ b/src/components/files/file-workspace-panel.tsx
@@ -56,7 +56,10 @@ import {
 import { useZoomLevel, useEditorFont } from "@/hooks/use-appearance"
 import { useImeSafeEditorValue } from "@/hooks/use-ime-safe-editor-value"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { getAddToChatPillPlacement } from "@/lib/add-to-chat-pill-placement"
+import {
+  getAddToChatPillPlacement,
+  type AddToChatPillPlacement,
+} from "@/lib/add-to-chat-pill-placement"
 
 import "@/lib/monaco-local"
 
@@ -363,6 +366,14 @@ const ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX = 28
  * returns null while hidden — Monaco unmounts the widget on a null position, so
  * visibility is driven entirely through {@link AddToChatPill.setVisible} +
  * `layoutContentWidget`.
+ *
+ * Keep `allowEditorOverflow`: dropping it moves the node inside the editor's own
+ * scrollable content, where the vertical scrollbar paints over the pill for any
+ * anchor near the right edge (reproduced against monaco 0.55.1 — a hit test on
+ * the pill's right-hand corners resolves to the scrollbar, not the button), and
+ * the node then shrink-to-fits to min-content and wraps to three lines. The cost
+ * of keeping it is that Monaco decides placement from *page* geometry, which
+ * {@link getAddToChatPillPlacement} corrects back to viewport geometry.
  */
 function createAddToChatPill(
   editor: MonacoEditorNs.IStandaloneCodeEditor,
@@ -399,31 +410,44 @@ function createAddToChatPill(
   let position: IPosition | null = null
   let measuredHeight = 0
 
+  const toMonacoPreference = (placement: AddToChatPillPlacement) =>
+    placement === "above"
+      ? monaco.editor.ContentWidgetPositionPreference.ABOVE
+      : monaco.editor.ContentWidgetPositionPreference.BELOW
+
   const widget: MonacoEditorNs.IContentWidget = {
     getId: () => "codeg.addToChatPill",
     getDomNode: () => dom,
     getPosition: () => {
       if (!visible || !position) return null
 
-      // Monaco's own `anchor.top`: the gap between the top edge of the editor
-      // viewport and the anchor line. `getTopForPosition` is wrap-aware (it
-      // converts to a view position first) and costs a layout-model lookup
-      // only — no DOM measurement — so it is safe on the scroll path.
-      // A negative return means "no model", not a real offset.
+      // Rebuild the two measurements Monaco's `_layoutBoxInViewport` works
+      // from. `getTopForPosition` is wrap-aware (it converts to a view position
+      // first) and is a layout-model lookup, not a DOM measurement, so this is
+      // safe on the scroll path. A negative return means "no model", not a real
+      // offset. `getLayoutInfo().height` is exactly Monaco's `viewportHeight`
+      // (the value it hands the scrollable), so the two agree to the pixel.
       const anchorTop = editor.getTopForPosition(
         position.lineNumber,
         position.column
       )
-      const preference = getAddToChatPillPlacement(
-        anchorTop < 0 ? null : anchorTop - editor.getScrollTop(),
-        measuredHeight || ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX
-      ).map((placement) =>
-        placement === "above"
-          ? monaco.editor.ContentWidgetPositionPreference.ABOVE
-          : monaco.editor.ContentWidgetPositionPreference.BELOW
-      )
+      const lineHeightPx = editor.getLineHeightForPosition(position)
+      const spaceAbovePx =
+        anchorTop < 0 ? null : anchorTop - editor.getScrollTop()
+      const preference = getAddToChatPillPlacement({
+        spaceAbovePx,
+        spaceBelowPx:
+          spaceAbovePx === null
+            ? 0
+            : editor.getLayoutInfo().height - (spaceAbovePx + lineHeightPx),
+        lineHeightPx,
+        pillHeightPx: measuredHeight || ADD_TO_CHAT_PILL_FALLBACK_HEIGHT_PX,
+      }).map(toMonacoPreference)
 
-      return { position, preference }
+      // An empty list means "nowhere sensible" — hand Monaco a null position so
+      // it unmounts the pill, the same way {@link AddToChatPill.setVisible}
+      // hides it. It comes back on the next layout once the anchor is in view.
+      return preference.length > 0 ? { position, preference } : null
     },
     allowEditorOverflow: true,
     suppressMouseDown: true,
@@ -1069,6 +1093,7 @@ export function FileWorkspacePanel() {
   const focusListenerRef = useRef<IDisposable | null>(null)
   const blurListenerRef = useRef<IDisposable | null>(null)
   const scrollListenerRef = useRef<IDisposable | null>(null)
+  const layoutListenerRef = useRef<IDisposable | null>(null)
   const tRef = useRef(t)
   const monacoRef = useRef<Monaco | null>(null)
   // The loaded monaco instance, captured at editor mount. Passing it to the
@@ -1303,6 +1328,8 @@ export function FileWorkspacePanel() {
       blurListenerRef.current = null
       scrollListenerRef.current?.dispose()
       scrollListenerRef.current = null
+      layoutListenerRef.current?.dispose()
+      layoutListenerRef.current = null
       if (addToChatPillRef.current) {
         target?.removeContentWidget(addToChatPillRef.current.widget)
         addToChatPillRef.current = null
@@ -1658,6 +1685,17 @@ export function FileWorkspacePanel() {
       addToChatPillRef.current = pill
       editorInstance.addContentWidget(pill.widget)
 
+      // The single way to lay the pill out. Monaco reads `getPosition()` — and
+      // so decides the placement — while the node is still `display: none`, and
+      // only flips it to `block` inside this same call, so this is the first
+      // moment the pill can be measured. Whenever that lands a height we did
+      // not have (the first-ever show, or a zoom that resized the pill), redo
+      // the layout in the same frame with the real box.
+      const layoutPill = () => {
+        editorInstance.layoutContentWidget(pill.widget)
+        if (pill.remeasure()) editorInstance.layoutContentWidget(pill.widget)
+      }
+
       const refreshPill = () => {
         const selection = editorInstance.getSelection()
         const show =
@@ -1669,12 +1707,7 @@ export function FileWorkspacePanel() {
           show,
           show && selection ? selection.getStartPosition() : null
         )
-        editorInstance.layoutContentWidget(pill.widget)
-        // Monaco flips the node to `display: block` inside the call above, so
-        // this is the first moment the pill can be measured. When that lands a
-        // new height, redo the layout in the same frame with the real box —
-        // otherwise the first-ever show would place itself off the fallback.
-        if (pill.remeasure()) editorInstance.layoutContentWidget(pill.widget)
+        layoutPill()
       }
       selectionListenerRef.current?.dispose()
       selectionListenerRef.current =
@@ -1685,20 +1718,27 @@ export function FileWorkspacePanel() {
       blurListenerRef.current?.dispose()
       blurListenerRef.current = editorInstance.onDidBlurEditorText(() => {
         pill.setVisible(false, null)
-        editorInstance.layoutContentWidget(pill.widget)
+        layoutPill()
       })
       // Monaco latches a widget's placement preference when the widget is laid
-      // out and re-uses it for every later render, so a pill that is already on
-      // screen keeps its old above/below choice while the user scrolls its
-      // anchor line up to the top edge. Re-layout on vertical scroll to
-      // re-decide. Nothing above depends on the horizontal offset, so
-      // `scrollLeft`-only ticks are skipped.
+      // out and re-uses it for every later render, so a visible pill keeps a
+      // stale above/below choice until something lays it out again. Every input
+      // to that choice can change while the pill sits on screen: the room above
+      // the anchor (vertical scroll), the viewport height (the user dragging
+      // the terminal splitter up), and the pill's own height (zoom, which
+      // scales the rem-based pill and the editor font together). Refresh on
+      // each — a layout change covers zoom, because the panel feeds the zoomed
+      // font size to Monaco as an option. Nothing in the decision depends on
+      // the horizontal offset, so `scrollLeft`-only ticks are skipped.
+      const relayoutPill = () => {
+        if (pill.isVisible()) layoutPill()
+      }
       scrollListenerRef.current?.dispose()
       scrollListenerRef.current = editorInstance.onDidScrollChange((event) => {
-        if (event.scrollTopChanged && pill.isVisible()) {
-          editorInstance.layoutContentWidget(pill.widget)
-        }
+        if (event.scrollTopChanged) relayoutPill()
       })
+      layoutListenerRef.current?.dispose()
+      layoutListenerRef.current = editorInstance.onDidLayoutChange(relayoutPill)
 
       editorInstance.onDidDispose(() => teardownAddToChat(editorInstance))
 

--- a/src/components/files/file-workspace-panel.tsx
+++ b/src/components/files/file-workspace-panel.tsx
@@ -56,6 +56,7 @@ import {
 import { useZoomLevel, useEditorFont } from "@/hooks/use-appearance"
 import { useImeSafeEditorValue } from "@/hooks/use-ime-safe-editor-value"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { getAddToChatPillPlacement } from "@/lib/add-to-chat-pill-placement"
 
 import "@/lib/monaco-local"
 
@@ -331,6 +332,7 @@ const AUTO_SAVE_DELAY_MS = 5000
 
 interface AddToChatPill {
   widget: MonacoEditorNs.IContentWidget
+  isVisible: () => boolean
   setVisible: (visible: boolean, position: IPosition | null) => void
   /** Re-read the label (e.g. after a locale change) even while already shown. */
   refreshLabel: () => void
@@ -347,6 +349,7 @@ interface AddToChatPill {
  * `layoutContentWidget`.
  */
 function createAddToChatPill(
+  editor: MonacoEditorNs.IStandaloneCodeEditor,
   monaco: Monaco,
   onActivate: () => void,
   getLabel: () => string
@@ -382,22 +385,29 @@ function createAddToChatPill(
   const widget: MonacoEditorNs.IContentWidget = {
     getId: () => "codeg.addToChatPill",
     getDomNode: () => dom,
-    getPosition: () =>
-      visible && position
-        ? {
-            position,
-            preference: [
-              monaco.editor.ContentWidgetPositionPreference.ABOVE,
-              monaco.editor.ContentWidgetPositionPreference.BELOW,
-            ],
-          }
-        : null,
+    getPosition: () => {
+      if (!visible || !position) return null
+
+      const firstVisibleLineNumber =
+        editor.getVisibleRanges()[0]?.startLineNumber ?? null
+      const preference = getAddToChatPillPlacement(
+        position.lineNumber,
+        firstVisibleLineNumber
+      ).map((placement) =>
+        placement === "above"
+          ? monaco.editor.ContentWidgetPositionPreference.ABOVE
+          : monaco.editor.ContentWidgetPositionPreference.BELOW
+      )
+
+      return { position, preference }
+    },
     allowEditorOverflow: true,
     suppressMouseDown: true,
   }
 
   return {
     widget,
+    isVisible: () => visible,
     setVisible: (next, pos) => {
       visible = next
       position = pos
@@ -1028,6 +1038,7 @@ export function FileWorkspacePanel() {
   const selectionListenerRef = useRef<IDisposable | null>(null)
   const focusListenerRef = useRef<IDisposable | null>(null)
   const blurListenerRef = useRef<IDisposable | null>(null)
+  const scrollListenerRef = useRef<IDisposable | null>(null)
   const tRef = useRef(t)
   const monacoRef = useRef<Monaco | null>(null)
   // The loaded monaco instance, captured at editor mount. Passing it to the
@@ -1260,6 +1271,8 @@ export function FileWorkspacePanel() {
       focusListenerRef.current = null
       blurListenerRef.current?.dispose()
       blurListenerRef.current = null
+      scrollListenerRef.current?.dispose()
+      scrollListenerRef.current = null
       if (addToChatPillRef.current) {
         target?.removeContentWidget(addToChatPillRef.current.widget)
         addToChatPillRef.current = null
@@ -1607,6 +1620,7 @@ export function FileWorkspacePanel() {
       )
 
       const pill = createAddToChatPill(
+        editorInstance,
         monaco,
         () => addSelectionToChat(),
         () => tRef.current("addToChat")
@@ -1637,6 +1651,12 @@ export function FileWorkspacePanel() {
       blurListenerRef.current = editorInstance.onDidBlurEditorText(() => {
         pill.setVisible(false, null)
         editorInstance.layoutContentWidget(pill.widget)
+      })
+      scrollListenerRef.current?.dispose()
+      scrollListenerRef.current = editorInstance.onDidScrollChange((event) => {
+        if (event.scrollTopChanged && pill.isVisible()) {
+          editorInstance.layoutContentWidget(pill.widget)
+        }
       })
 
       editorInstance.onDidDispose(() => teardownAddToChat(editorInstance))

--- a/src/lib/add-to-chat-pill-placement.test.ts
+++ b/src/lib/add-to-chat-pill-placement.test.ts
@@ -1,24 +1,75 @@
 import { describe, expect, it } from "vitest"
 import { getAddToChatPillPlacement } from "./add-to-chat-pill-placement"
 
+// Measured in Chrome against monaco-editor 0.55.1 with the shipped defaults
+// (editor font 13 => 20px lines on macOS / 18px on Windows, pill box 25px).
+const PILL_HEIGHT = 25
+const LINE_HEIGHT = 20
+
 describe("getAddToChatPillPlacement", () => {
   it("keeps a first-line selection below the editor chrome", () => {
-    expect(getAddToChatPillPlacement(1, 1)).toEqual(["below", "above"])
+    // Anchor flush with the viewport top: zero room above.
+    expect(getAddToChatPillPlacement(0, PILL_HEIGHT)).toEqual([
+      "below",
+      "above",
+    ])
   })
 
-  it("keeps the existing above-first placement for normal lines", () => {
-    expect(getAddToChatPillPlacement(8, 1)).toEqual(["above", "below"])
+  it("keeps a second-line selection below the editor chrome", () => {
+    // One line of room (20px) is still less than the pill (25px), so ABOVE
+    // would clip the pill's top edge into the file path bar.
+    expect(getAddToChatPillPlacement(LINE_HEIGHT, PILL_HEIGHT)).toEqual([
+      "below",
+      "above",
+    ])
   })
 
-  it("keeps the existing above-first placement near the viewport bottom", () => {
-    expect(getAddToChatPillPlacement(20, 1)).toEqual(["above", "below"])
+  it("keeps the existing above-first placement once the pill clears the top", () => {
+    expect(getAddToChatPillPlacement(2 * LINE_HEIGHT, PILL_HEIGHT)).toEqual([
+      "above",
+      "below",
+    ])
   })
 
-  it("places a scrolled viewport's top line below the chrome", () => {
-    expect(getAddToChatPillPlacement(12, 12)).toEqual(["below", "above"])
+  it("treats an exactly-fitting gap as room enough for above", () => {
+    expect(getAddToChatPillPlacement(PILL_HEIGHT, PILL_HEIGHT)).toEqual([
+      "above",
+      "below",
+    ])
   })
 
-  it("falls back to the existing order before Monaco reports a viewport", () => {
-    expect(getAddToChatPillPlacement(1, null)).toEqual(["above", "below"])
+  it("keeps the existing above-first placement deep in the viewport", () => {
+    expect(getAddToChatPillPlacement(180, PILL_HEIGHT)).toEqual([
+      "above",
+      "below",
+    ])
+  })
+
+  it("goes below for a top line that is only partially scrolled into view", () => {
+    // A 1.5-line scroll leaves 10px above the anchor — Monaco's page-relative
+    // check still says ABOVE fits, but it does not.
+    expect(getAddToChatPillPlacement(10, PILL_HEIGHT)).toEqual([
+      "below",
+      "above",
+    ])
+  })
+
+  it("goes below for an anchor scrolled above the viewport", () => {
+    expect(getAddToChatPillPlacement(-40, PILL_HEIGHT)).toEqual([
+      "below",
+      "above",
+    ])
+  })
+
+  it("falls back to the existing order when the anchor top is unknown", () => {
+    expect(getAddToChatPillPlacement(null, PILL_HEIGHT)).toEqual([
+      "above",
+      "below",
+    ])
+  })
+
+  it("scales with the pill: a taller (zoomed) pill needs more room", () => {
+    expect(getAddToChatPillPlacement(40, 50)).toEqual(["below", "above"])
+    expect(getAddToChatPillPlacement(60, 50)).toEqual(["above", "below"])
   })
 })

--- a/src/lib/add-to-chat-pill-placement.test.ts
+++ b/src/lib/add-to-chat-pill-placement.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { getAddToChatPillPlacement } from "./add-to-chat-pill-placement"
+
+describe("getAddToChatPillPlacement", () => {
+  it("keeps a first-line selection below the editor chrome", () => {
+    expect(getAddToChatPillPlacement(1, 1)).toEqual(["below", "above"])
+  })
+
+  it("keeps the existing above-first placement for normal lines", () => {
+    expect(getAddToChatPillPlacement(8, 1)).toEqual(["above", "below"])
+  })
+
+  it("keeps the existing above-first placement near the viewport bottom", () => {
+    expect(getAddToChatPillPlacement(20, 1)).toEqual(["above", "below"])
+  })
+
+  it("places a scrolled viewport's top line below the chrome", () => {
+    expect(getAddToChatPillPlacement(12, 12)).toEqual(["below", "above"])
+  })
+
+  it("falls back to the existing order before Monaco reports a viewport", () => {
+    expect(getAddToChatPillPlacement(1, null)).toEqual(["above", "below"])
+  })
+})

--- a/src/lib/add-to-chat-pill-placement.test.ts
+++ b/src/lib/add-to-chat-pill-placement.test.ts
@@ -3,73 +3,103 @@ import { getAddToChatPillPlacement } from "./add-to-chat-pill-placement"
 
 // Measured in Chrome against monaco-editor 0.55.1 with the shipped defaults
 // (editor font 13 => 20px lines on macOS / 18px on Windows, pill box 25px).
-const PILL_HEIGHT = 25
-const LINE_HEIGHT = 20
+const PILL = 25
+const LINE = 20
+
+/** A normally-sized editor: only `spaceAbovePx` is ever the deciding factor. */
+function at(spaceAbovePx: number | null, spaceBelowPx = 400) {
+  return getAddToChatPillPlacement({
+    spaceAbovePx,
+    spaceBelowPx,
+    lineHeightPx: LINE,
+    pillHeightPx: PILL,
+  })
+}
 
 describe("getAddToChatPillPlacement", () => {
   it("keeps a first-line selection below the editor chrome", () => {
     // Anchor flush with the viewport top: zero room above.
-    expect(getAddToChatPillPlacement(0, PILL_HEIGHT)).toEqual([
-      "below",
-      "above",
-    ])
+    expect(at(0)).toEqual(["below", "above"])
   })
 
   it("keeps a second-line selection below the editor chrome", () => {
     // One line of room (20px) is still less than the pill (25px), so ABOVE
     // would clip the pill's top edge into the file path bar.
-    expect(getAddToChatPillPlacement(LINE_HEIGHT, PILL_HEIGHT)).toEqual([
-      "below",
-      "above",
-    ])
+    expect(at(LINE)).toEqual(["below", "above"])
   })
 
   it("keeps the existing above-first placement once the pill clears the top", () => {
-    expect(getAddToChatPillPlacement(2 * LINE_HEIGHT, PILL_HEIGHT)).toEqual([
-      "above",
-      "below",
-    ])
+    expect(at(2 * LINE)).toEqual(["above", "below"])
   })
 
   it("treats an exactly-fitting gap as room enough for above", () => {
-    expect(getAddToChatPillPlacement(PILL_HEIGHT, PILL_HEIGHT)).toEqual([
-      "above",
-      "below",
-    ])
+    expect(at(PILL)).toEqual(["above", "below"])
   })
 
   it("keeps the existing above-first placement deep in the viewport", () => {
-    expect(getAddToChatPillPlacement(180, PILL_HEIGHT)).toEqual([
-      "above",
-      "below",
-    ])
+    expect(at(180)).toEqual(["above", "below"])
   })
 
   it("goes below for a top line that is only partially scrolled into view", () => {
     // A 1.5-line scroll leaves 10px above the anchor — Monaco's page-relative
     // check still says ABOVE fits, but it does not.
-    expect(getAddToChatPillPlacement(10, PILL_HEIGHT)).toEqual([
-      "below",
-      "above",
-    ])
+    expect(at(10)).toEqual(["below", "above"])
   })
 
-  it("goes below for an anchor scrolled above the viewport", () => {
-    expect(getAddToChatPillPlacement(-40, PILL_HEIGHT)).toEqual([
-      "below",
-      "above",
-    ])
+  it("goes below for an anchor still half in view at the top", () => {
+    expect(at(-LINE / 2)).toEqual(["below", "above"])
   })
 
   it("falls back to the existing order when the anchor top is unknown", () => {
-    expect(getAddToChatPillPlacement(null, PILL_HEIGHT)).toEqual([
-      "above",
-      "below",
-    ])
+    expect(at(null)).toEqual(["above", "below"])
   })
 
   it("scales with the pill: a taller (zoomed) pill needs more room", () => {
-    expect(getAddToChatPillPlacement(40, 50)).toEqual(["below", "above"])
-    expect(getAddToChatPillPlacement(60, 50)).toEqual(["above", "below"])
+    const zoomed = (spaceAbovePx: number) =>
+      getAddToChatPillPlacement({
+        spaceAbovePx,
+        spaceBelowPx: 400,
+        lineHeightPx: 40,
+        pillHeightPx: 50,
+      })
+    expect(zoomed(40)).toEqual(["below", "above"])
+    expect(zoomed(60)).toEqual(["above", "below"])
+  })
+
+  describe("when the anchor line has scrolled out of the viewport", () => {
+    it("withholds the pill for an anchor wholly above the viewport", () => {
+      expect(at(-LINE)).toEqual([])
+      expect(at(-200)).toEqual([])
+    })
+
+    it("withholds the pill for an anchor wholly below the viewport", () => {
+      // Editor dragged short while a selection further down stayed anchored:
+      // Monaco still renders a little past the viewport, and from out there
+      // both placements land outside the editor.
+      expect(at(300, -LINE)).toEqual([])
+      expect(at(300, -200)).toEqual([])
+    })
+
+    it("still places for an anchor only partially cut at the bottom", () => {
+      expect(at(300, -LINE / 2)).toEqual(["above", "below"])
+    })
+  })
+
+  describe("when the editor is too short to seat the pill on either side", () => {
+    it("takes the roomier side", () => {
+      // ~2-line editor (terminal splitter pulled all the way up). Monaco's
+      // EXACT would be the only never-overflowing answer, but it is unusable
+      // for an overflowing widget, so lose the fewest pixels instead.
+      expect(at(0, LINE)).toEqual(["below", "above"])
+      expect(at(LINE, 0)).toEqual(["above", "below"])
+    })
+
+    it("prefers a fitting below over the roomier-side tie-break", () => {
+      expect(at(0, PILL)).toEqual(["below", "above"])
+    })
+
+    it("never demotes a fitting above just because the bottom is cramped", () => {
+      expect(at(300, 0)).toEqual(["above", "below"])
+    })
   })
 })

--- a/src/lib/add-to-chat-pill-placement.ts
+++ b/src/lib/add-to-chat-pill-placement.ts
@@ -1,0 +1,16 @@
+export type AddToChatPillPlacement = "above" | "below"
+
+/**
+ * Prefer placing the selection action inside the editor when its anchor is on
+ * the top visible line. Monaco's overflow layout otherwise considers space in
+ * the surrounding page valid and can render the pill over the file header.
+ */
+export function getAddToChatPillPlacement(
+  anchorLineNumber: number,
+  firstVisibleLineNumber: number | null
+): AddToChatPillPlacement[] {
+  return firstVisibleLineNumber !== null &&
+    anchorLineNumber <= firstVisibleLineNumber
+    ? ["below", "above"]
+    : ["above", "below"]
+}

--- a/src/lib/add-to-chat-pill-placement.ts
+++ b/src/lib/add-to-chat-pill-placement.ts
@@ -1,33 +1,76 @@
 export type AddToChatPillPlacement = "above" | "below"
 
-/**
- * Orders the placement preferences Monaco walks for the "Add to Chat" pill.
- *
- * The pill is an `allowEditorOverflow` content widget, and for those Monaco
- * runs `_layoutBoxInPage`, which asks whether the widget fits above the anchor
- * *in the page* (`absoluteAboveTop >= 22`) instead of *in the editor viewport*.
- * Every pixel the surrounding app chrome occupies — tab strip, file path bar —
- * therefore reads as free space, ABOVE always "fits", and the pill renders past
- * the editor's top edge where that chrome covers it.
- *
- * So re-run the test Monaco applies to non-overflowing widgets
- * (`_layoutBoxInViewport`: `fitsAbove = anchor.top >= height`) against the
- * editor viewport, and demote ABOVE whenever the anchor line does not have a
- * whole pill's worth of room above it. Monaco still makes the final call — this
- * only reorders the list it walks, so its own BELOW/bottom-edge handling and
- * its force-first-preference second pass are untouched.
- *
- * @param spaceAboveAnchorPx Pixels from the top edge of the editor viewport to
- *   the top of the anchor line — Monaco's own `anchor.top`, i.e.
- *   `editor.getTopForPosition(line, column) - editor.getScrollTop()`. Pass
- *   `null` when it cannot be read; the pre-existing ABOVE-first order is kept.
- * @param pillHeightPx Rendered height of the pill, in px.
- */
-export function getAddToChatPillPlacement(
-  spaceAboveAnchorPx: number | null,
+/** Everything {@link getAddToChatPillPlacement} needs, in editor-viewport px. */
+export interface AddToChatPillGeometry {
+  /**
+   * Top edge of the editor viewport to the top of the anchor line — Monaco's
+   * own `anchor.top`, i.e. `getTopForPosition(line, col) - getScrollTop()`.
+   * Negative once the anchor scrolls above the viewport. `null` when it cannot
+   * be read (no model), which keeps the pre-existing ABOVE-first order.
+   */
+  spaceAbovePx: number | null
+  /**
+   * Bottom of the anchor line to the bottom edge of the editor viewport —
+   * Monaco's `heightAvailableUnderLine`, i.e.
+   * `getLayoutInfo().height - (spaceAbovePx + lineHeightPx)`.
+   */
+  spaceBelowPx: number
+  /** Height of the anchor line — Monaco's `anchor.height`. */
+  lineHeightPx: number
+  /** Rendered height of the pill. */
   pillHeightPx: number
-): AddToChatPillPlacement[] {
-  return spaceAboveAnchorPx === null || spaceAboveAnchorPx >= pillHeightPx
-    ? ["above", "below"]
-    : ["below", "above"]
+}
+
+/**
+ * Orders the placement preferences Monaco walks for the "Add to Chat" pill, or
+ * returns an empty list to mean "do not place it at all".
+ *
+ * The pill is an `allowEditorOverflow` content widget — it has to be, or the
+ * editor's own scrollbars paint over it near the right edge. But that flag also
+ * switches Monaco from `_layoutBoxInViewport` to `_layoutBoxInPage`, which asks
+ * whether the widget fits above/below the anchor *in the page* rather than *in
+ * the editor viewport*. Every pixel the surrounding app chrome occupies — tab
+ * strip, file path bar, terminal panel — then reads as free space, so ABOVE
+ * always "fits" and the pill renders past the editor's edge, behind that chrome.
+ *
+ * So re-run the test Monaco applies to non-overflowing widgets against the
+ * editor viewport, and hand back the answer `_layoutBoxInViewport` would have
+ * produced. Monaco still owns the final decision; this only reorders the list it
+ * walks.
+ *
+ * Monaco's third option, EXACT, is deliberately not used. It is the only
+ * preference that can never leave the viewport vertically, which makes it look
+ * like the obvious last resort — but for an overflowing widget its coordinate is
+ * `anchor.left + contentLeft` with no `scrollLeft` term and no horizontal clamp
+ * (`_prepareRenderWidgetAtExactPositionOverflowing`, versus the
+ * `anchor.left - ctx.scrollLeft + contentLeft` that `_layoutBoxInPage` uses), so
+ * in a horizontally scrolled editor it throws the pill clean outside the editor.
+ * When neither side can seat the pill, lose the fewest pixels instead.
+ */
+export function getAddToChatPillPlacement({
+  spaceAbovePx,
+  spaceBelowPx,
+  lineHeightPx,
+  pillHeightPx,
+}: AddToChatPillGeometry): AddToChatPillPlacement[] {
+  if (spaceAbovePx === null) {
+    return ["above", "below"]
+  }
+  // The anchor line is wholly out of sight — scrolled past, or left behind when
+  // the editor was dragged short. Monaco still renders widgets a little beyond
+  // the viewport, and from out there BOTH placements land outside the editor
+  // (that is how a selection below a shrunken editor put the pill behind the
+  // terminal panel). A pill pointing at an invisible line has nothing to say,
+  // so withhold it until the anchor scrolls back.
+  if (spaceAbovePx <= -lineHeightPx || spaceBelowPx <= -lineHeightPx) {
+    return []
+  }
+  if (spaceAbovePx >= pillHeightPx) {
+    return ["above", "below"]
+  }
+  if (spaceBelowPx >= pillHeightPx) {
+    return ["below", "above"]
+  }
+  // Editor dragged shorter than one pill plus one line: pick the roomier side.
+  return spaceAbovePx >= spaceBelowPx ? ["above", "below"] : ["below", "above"]
 }

--- a/src/lib/add-to-chat-pill-placement.ts
+++ b/src/lib/add-to-chat-pill-placement.ts
@@ -1,16 +1,33 @@
 export type AddToChatPillPlacement = "above" | "below"
 
 /**
- * Prefer placing the selection action inside the editor when its anchor is on
- * the top visible line. Monaco's overflow layout otherwise considers space in
- * the surrounding page valid and can render the pill over the file header.
+ * Orders the placement preferences Monaco walks for the "Add to Chat" pill.
+ *
+ * The pill is an `allowEditorOverflow` content widget, and for those Monaco
+ * runs `_layoutBoxInPage`, which asks whether the widget fits above the anchor
+ * *in the page* (`absoluteAboveTop >= 22`) instead of *in the editor viewport*.
+ * Every pixel the surrounding app chrome occupies — tab strip, file path bar —
+ * therefore reads as free space, ABOVE always "fits", and the pill renders past
+ * the editor's top edge where that chrome covers it.
+ *
+ * So re-run the test Monaco applies to non-overflowing widgets
+ * (`_layoutBoxInViewport`: `fitsAbove = anchor.top >= height`) against the
+ * editor viewport, and demote ABOVE whenever the anchor line does not have a
+ * whole pill's worth of room above it. Monaco still makes the final call — this
+ * only reorders the list it walks, so its own BELOW/bottom-edge handling and
+ * its force-first-preference second pass are untouched.
+ *
+ * @param spaceAboveAnchorPx Pixels from the top edge of the editor viewport to
+ *   the top of the anchor line — Monaco's own `anchor.top`, i.e.
+ *   `editor.getTopForPosition(line, column) - editor.getScrollTop()`. Pass
+ *   `null` when it cannot be read; the pre-existing ABOVE-first order is kept.
+ * @param pillHeightPx Rendered height of the pill, in px.
  */
 export function getAddToChatPillPlacement(
-  anchorLineNumber: number,
-  firstVisibleLineNumber: number | null
+  spaceAboveAnchorPx: number | null,
+  pillHeightPx: number
 ): AddToChatPillPlacement[] {
-  return firstVisibleLineNumber !== null &&
-    anchorLineNumber <= firstVisibleLineNumber
-    ? ["below", "above"]
-    : ["above", "below"]
+  return spaceAboveAnchorPx === null || spaceAboveAnchorPx >= pillHeightPx
+    ? ["above", "below"]
+    : ["below", "above"]
 }


### PR DESCRIPTION
## Summary

- prefer placing the Monaco Add to Chat pill below selections anchored on the top visible line
- refresh the placement while a visible pill is vertically scrolled
- preserve the existing above-first placement for normal and near-bottom selections

## Root cause

With allowEditorOverflow enabled, Monaco checks whether ABOVE fits in the surrounding page rather than the editor viewport. For the editor first line, the file header counts as available page space, so the widget is positioned behind the path bar instead of falling back below the selection.

## Tests

- pnpm exec vitest run src/lib/add-to-chat-pill-placement.test.ts --reporter=dot
- pnpm exec eslint src/components/files/file-workspace-panel.tsx src/lib/add-to-chat-pill-placement.ts src/lib/add-to-chat-pill-placement.test.ts
- pnpm exec tsc --noEmit
- git diff --check

Closes #572