### PR TITLE
feat(remote-workspace): add custom HTTP headers to connections

### DIFF
--- a/src-tauri/src/commands/remote_proxy.rs
+++ b/src-tauri/src/commands/remote_proxy.rs
@@ -141,6 +141,78 @@ struct WsSubscriber {
     window_instance_id: String,
 }
 
+/// Matches `reqwest`'s own default redirect bound.
+const MAX_REMOTE_REDIRECTS: usize = 10;
+
+/// Two URLs reach the same server. Host and port only, deliberately: this is
+/// the exact test `reqwest` applies when it decides whether to strip
+/// `Authorization` across a redirect, so an `http` → `https` hop reads as a
+/// different origin through its default port, the same way it does there.
+fn same_remote_origin(a: &reqwest::Url, b: &reqwest::Url) -> bool {
+    a.host_str() == b.host_str() && a.port_or_known_default() == b.port_or_known_default()
+}
+
+/// `host:port` for an error message. The port is not decoration: two ports on
+/// one host are two origins here, and "refused a redirect off 127.0.0.1 to
+/// 127.0.0.1" would read as a bug.
+fn origin_label(url: &reqwest::Url) -> String {
+    match (url.host_str(), url.port_or_known_default()) {
+        (Some(host), Some(port)) => format!("{host}:{port}"),
+        (Some(host), None) => host.to_string(),
+        _ => url.as_str().to_string(),
+    }
+}
+
+/// Redirect policy for every request that carries a connection's credentials.
+///
+/// `reqwest` already drops `Authorization` once a redirect crosses to another
+/// host, so such a hop could only ever have come back 401 anyway. What it does
+/// not know to drop is the connection's custom headers, which are credentials
+/// of exactly the same kind — a Cloudflare Access service token, a proxy
+/// secret. Refusing the hop keeps them on the host the user configured, and
+/// turns what would have been a confusing 401 into a message that names the
+/// problem. Same-host redirects still follow, under reqwest's own bound.
+pub(crate) fn connection_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        let Some(previous) = attempt.previous().last() else {
+            return attempt.follow();
+        };
+        if !same_remote_origin(previous, attempt.url()) {
+            let message = format!(
+                "refused a redirect off {} to {}: it would hand the connection's \
+                 custom headers to another host",
+                origin_label(previous),
+                origin_label(attempt.url()),
+            );
+            return attempt.error(message);
+        }
+        // `>` not `>=`, to land on the same count `Policy::limited` allows.
+        if attempt.previous().len() > MAX_REMOTE_REDIRECTS {
+            return attempt.error(format!("more than {MAX_REMOTE_REDIRECTS} redirects"));
+        }
+        attempt.follow()
+    })
+}
+
+/// Flatten a failed request into a detail string worth showing.
+///
+/// `reqwest`'s own `Display` stops at the outermost layer — "error following
+/// redirect for url (…)", "error sending request for url (…)" — which is
+/// precisely the layer that carries no reason. Everything worth reading is in
+/// the source chain: the redirect refusal above, the connect error, the TLS
+/// failure. Without this the host-pinning error reaches the user as a bare
+/// "error following redirect" and looks like a bug rather than a decision.
+pub(crate) fn request_error_detail(err: &reqwest::Error) -> String {
+    let mut detail = err.to_string();
+    let mut source: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(err);
+    while let Some(cause) = source {
+        detail.push_str(": ");
+        detail.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    detail
+}
+
 /// Tauri-managed singleton.
 pub struct RemoteProxyState {
     tasks: Mutex<HashMap<i32, Arc<WsTaskEntry>>>,
@@ -156,9 +228,11 @@ impl RemoteProxyState {
             destroyed_window_instances: Mutex::new(HashSet::new()),
             http: reqwest::Client::builder()
                 .timeout(HTTP_TIMEOUT)
+                .redirect(connection_redirect_policy())
                 .build()
                 .expect("failed to build reqwest client for remote proxy"),
             workspace_http: reqwest::Client::builder()
+                .redirect(connection_redirect_policy())
                 .build()
                 .expect("failed to build reqwest workspace client for remote proxy"),
         }
@@ -323,7 +397,7 @@ pub async fn remote_http_call(
         request = request.timeout(requested.min(HTTP_TIMEOUT_MAX));
     }
     let response = request.send().await.map_err(|e| {
-        AppCommandError::network("Remote HTTP request failed").with_detail(e.to_string())
+        AppCommandError::network("Remote HTTP request failed").with_detail(request_error_detail(&e))
     })?;
 
     let status = response.status();
@@ -603,7 +677,8 @@ pub async fn remote_upload_attachment(
         .send()
         .await
         .map_err(|e| {
-            AppCommandError::network("Remote upload request failed").with_detail(e.to_string())
+            AppCommandError::network("Remote upload request failed")
+                .with_detail(request_error_detail(&e))
         })?;
 
     let status = response.status();
@@ -971,7 +1046,8 @@ async fn upload_one_workspace_path(
             if cancel_token.is_cancelled() {
                 return workspace_transfer_cancelled();
             }
-            AppCommandError::network("Remote workspace upload failed").with_detail(e.to_string())
+            AppCommandError::network("Remote workspace upload failed")
+                .with_detail(request_error_detail(&e))
         })?;
 
     let status = response.status();
@@ -1192,7 +1268,7 @@ async fn remote_workspace_download_stream(
             .await
             .map_err(|e| {
                 AppCommandError::network("Remote workspace download ticket failed")
-                    .with_detail(e.to_string())
+                    .with_detail(request_error_detail(&e))
             })?;
         let status = ticket_response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED {
@@ -1210,7 +1286,7 @@ async fn remote_workspace_download_stream(
                 AppCommandError::network("Failed to parse remote download ticket")
                     .with_detail(e.to_string())
             })?;
-        let download_url = absolute_remote_ticket_url(&conn.base_url, &ticket.url);
+        let download_url = absolute_remote_ticket_url(&conn.base_url, &ticket.url)?;
         let response = proxy
             .workspace_http
             .get(download_url)
@@ -1219,7 +1295,7 @@ async fn remote_workspace_download_stream(
             .await
             .map_err(|e| {
                 AppCommandError::network("Remote workspace download failed")
-                    .with_detail(e.to_string())
+                    .with_detail(request_error_detail(&e))
             })?;
 
         let status = response.status();
@@ -1328,14 +1404,40 @@ async fn remote_error_from_response(
     )
 }
 
-fn absolute_remote_ticket_url(base_url: &str, ticket_url: &str) -> String {
-    if ticket_url.starts_with("http://") || ticket_url.starts_with("https://") {
+/// Resolve the download URL the remote handed back, and refuse one that leaves
+/// the connection's origin.
+///
+/// `codeg-server` always answers with a path (`create_download_ticket` builds
+/// `/api/workspace_download/<ticket>`), so the absolute branch only ever fires
+/// for a remote that went off-script. It matters because this is the one
+/// request that carries the connection's custom headers with no bearer token
+/// gating them: a remote free to name any host is a remote free to choose who
+/// receives those credentials.
+fn absolute_remote_ticket_url(
+    base_url: &str,
+    ticket_url: &str,
+) -> Result<String, AppCommandError> {
+    let resolved = if ticket_url.starts_with("http://") || ticket_url.starts_with("https://") {
         ticket_url.to_string()
     } else if ticket_url.starts_with('/') {
         format!("{}{}", base_url.trim_end_matches('/'), ticket_url)
     } else {
         format!("{}/{}", base_url.trim_end_matches('/'), ticket_url)
+    };
+    let same_origin = match (
+        reqwest::Url::parse(base_url),
+        reqwest::Url::parse(&resolved),
+    ) {
+        (Ok(base), Ok(target)) => same_remote_origin(&base, &target),
+        _ => false,
+    };
+    if !same_origin {
+        return Err(AppCommandError::network(
+            "Remote download ticket points outside the connection",
+        )
+        .with_detail(format!("ticket url: {ticket_url}")));
     }
+    Ok(resolved)
 }
 
 fn partial_download_path(save_path: &str, transfer_id: &str) -> String {
@@ -1924,6 +2026,173 @@ mod tests {
             shutdown_tx,
             outbound_tx,
         })
+    }
+
+    // ─── Host pinning for credential-carrying requests ──────────────────
+    //
+    // Both of these guard the same thing from two directions: the custom
+    // headers on a remote connection are credentials, and neither the remote
+    // nor a redirect it issues gets to choose which host receives them.
+
+    #[test]
+    fn ticket_url_resolves_a_path_against_the_connection() {
+        // The only shape `codeg-server` actually returns.
+        assert_eq!(
+            absolute_remote_ticket_url("https://box.example", "/api/workspace_download/t1")
+                .unwrap(),
+            "https://box.example/api/workspace_download/t1"
+        );
+        // A base with a path prefix keeps it — this is why the resolution is
+        // string concatenation and not `Url::join`, which would drop `/codeg`.
+        assert_eq!(
+            absolute_remote_ticket_url("https://box.example/codeg", "/api/workspace_download/t1")
+                .unwrap(),
+            "https://box.example/codeg/api/workspace_download/t1"
+        );
+        assert_eq!(
+            absolute_remote_ticket_url("https://box.example/", "api/workspace_download/t1")
+                .unwrap(),
+            "https://box.example/api/workspace_download/t1"
+        );
+        // Absolute, but still the connection's own host: allowed.
+        assert_eq!(
+            absolute_remote_ticket_url("https://box.example", "https://box.example/dl/t1").unwrap(),
+            "https://box.example/dl/t1"
+        );
+    }
+
+    #[test]
+    fn ticket_url_refuses_a_host_the_connection_did_not_name() {
+        for ticket in [
+            "https://evil.example/dl/t1",
+            // Same host, different port — a different server.
+            "https://box.example:8443/dl/t1",
+            // Same host, downgraded scheme: reqwest treats this as cross-origin
+            // through the default port, and so do we.
+            "http://box.example/dl/t1",
+        ] {
+            let err = absolute_remote_ticket_url("https://box.example", ticket)
+                .expect_err("ticket url should be refused: {ticket}");
+            assert!(
+                err.message.contains("outside the connection"),
+                "unexpected message for {ticket}: {}",
+                err.message
+            );
+        }
+    }
+
+    /// Accept `responses.len()` connections in order, answering each with the
+    /// matching canned response. Returns the raw request text of each, so a
+    /// test can assert on the headers that actually arrived.
+    async fn serve_sequence(
+        listener: tokio::net::TcpListener,
+        responses: Vec<String>,
+    ) -> Vec<String> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let mut requests = Vec::with_capacity(responses.len());
+        for response in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let n = stream.read(&mut buf).await.unwrap();
+            requests.push(String::from_utf8_lossy(&buf[..n]).to_string());
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+        }
+        requests
+    }
+
+    fn redirect_to(location: &str) -> String {
+        // `Connection: close` so the follow-up hop opens a fresh connection and
+        // lands on the next `accept()` rather than being pipelined onto this one.
+        format!(
+            "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\n\
+             Connection: close\r\n\r\n"
+        )
+    }
+
+    fn ok_response() -> String {
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string()
+    }
+
+    #[tokio::test]
+    async fn redirect_to_another_host_never_delivers_the_custom_header() {
+        // Two loopback ports are two origins, so this is the cross-host case.
+        let hop = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let elsewhere = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let hop_addr = hop.local_addr().unwrap();
+        let elsewhere_addr = elsewhere.local_addr().unwrap();
+
+        let hop_task = tokio::spawn(serve_sequence(
+            hop,
+            vec![redirect_to(&format!("http://{elsewhere_addr}/next"))],
+        ));
+        let elsewhere_task = tokio::spawn(serve_sequence(elsewhere, vec![ok_response()]));
+
+        let client = reqwest::Client::builder()
+            .redirect(connection_redirect_policy())
+            .build()
+            .unwrap();
+        let err = client
+            .get(format!("http://{hop_addr}/start"))
+            .header("X-Access-Secret", "s3cret")
+            .send()
+            .await
+            .expect_err("a redirect off the connection host must not be followed");
+        assert!(err.is_redirect(), "expected a redirect error, got: {err}");
+        // reqwest's own Display is just "error following redirect for url (…)",
+        // so this also pins that the reason survives into what the UI renders.
+        let detail = request_error_detail(&err);
+        assert!(
+            detail.contains("refused a redirect off")
+                && detail.contains(&elsewhere_addr.to_string()),
+            "the refusal reason must reach the caller: {detail}"
+        );
+
+        let hop_request = hop_task.await.unwrap().remove(0);
+        assert!(
+            hop_request.contains("s3cret"),
+            "the configured host should still receive the header: {hop_request}"
+        );
+
+        // Nothing ever connected to the second host, so its `accept()` is still
+        // pending. That, rather than an assertion on headers it never saw, is
+        // the proof the credential stayed put.
+        elsewhere_task.abort();
+        assert!(
+            elsewhere_task.await.unwrap_err().is_cancelled(),
+            "the redirect target received a request"
+        );
+    }
+
+    #[tokio::test]
+    async fn redirect_within_the_same_host_still_follows_and_keeps_the_header() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_sequence(
+            listener,
+            vec![redirect_to("/next"), ok_response()],
+        ));
+
+        let client = reqwest::Client::builder()
+            .redirect(connection_redirect_policy())
+            .build()
+            .unwrap();
+        let response = client
+            .get(format!("http://{addr}/start"))
+            .header("X-Access-Secret", "s3cret")
+            .send()
+            .await
+            .expect("a same-host redirect should still be followed");
+        assert!(response.status().is_success());
+
+        let requests = server.await.unwrap();
+        assert_eq!(requests.len(), 2, "the redirect should have been followed");
+        assert!(requests[1].starts_with("GET /next"), "got: {}", requests[1]);
+        assert!(
+            requests[1].contains("s3cret"),
+            "the header must survive a same-host hop: {}",
+            requests[1]
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/remote_proxy.rs
+++ b/src-tauri/src/commands/remote_proxy.rs
@@ -2145,6 +2145,11 @@ mod tests {
 
         let client = reqwest::Client::builder()
             .redirect(connection_redirect_policy())
+            // Hermetic: this box has HTTP_PROXY set, and reqwest does not
+            // bypass loopback for it. Without this the request reaches the
+            // proxy instead of the test server, which answers 502 — an error,
+            // so the cross-host case would pass for entirely the wrong reason.
+            .no_proxy()
             .build()
             .unwrap();
         let err = client
@@ -2190,6 +2195,11 @@ mod tests {
 
         let client = reqwest::Client::builder()
             .redirect(connection_redirect_policy())
+            // Hermetic: this box has HTTP_PROXY set, and reqwest does not
+            // bypass loopback for it. Without this the request reaches the
+            // proxy instead of the test server, which answers 502 — an error,
+            // so the cross-host case would pass for entirely the wrong reason.
+            .no_proxy()
             .build()
             .unwrap();
         let response = client

--- a/src-tauri/src/commands/remote_proxy.rs
+++ b/src-tauri/src/commands/remote_proxy.rs
@@ -144,12 +144,19 @@ struct WsSubscriber {
 /// Matches `reqwest`'s own default redirect bound.
 const MAX_REMOTE_REDIRECTS: usize = 10;
 
-/// Two URLs reach the same server. Host and port only, deliberately: this is
-/// the exact test `reqwest` applies when it decides whether to strip
-/// `Authorization` across a redirect, so an `http` → `https` hop reads as a
-/// different origin through its default port, the same way it does there.
+/// Two URLs reach the same server over the same kind of channel.
+///
+/// Scheme, host and port — a true origin, one notch stricter than the host-and-
+/// port test `reqwest` uses to decide whether to strip `Authorization`. The
+/// extra notch is the point: on a connection configured as `https://box:8443`,
+/// a hop to `http://box:8443` keeps reqwest's host and port identical, so its
+/// rule would allow it and put the connection's credentials on the wire in
+/// plaintext. Refusing a scheme change costs only the `http` → `https` upgrade
+/// on an identical explicit port, which is a URL the user can simply configure.
 fn same_remote_origin(a: &reqwest::Url, b: &reqwest::Url) -> bool {
-    a.host_str() == b.host_str() && a.port_or_known_default() == b.port_or_known_default()
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
 }
 
 /// `host:port` for an error message. The port is not decoration: two ports on
@@ -2067,8 +2074,7 @@ mod tests {
             "https://evil.example/dl/t1",
             // Same host, different port — a different server.
             "https://box.example:8443/dl/t1",
-            // Same host, downgraded scheme: reqwest treats this as cross-origin
-            // through the default port, and so do we.
+            // Same host, downgraded scheme.
             "http://box.example/dl/t1",
         ] {
             let err = absolute_remote_ticket_url("https://box.example", ticket)
@@ -2079,6 +2085,15 @@ mod tests {
                 err.message
             );
         }
+
+        // The case a host-and-port test alone would wave through: identical
+        // explicit port, scheme downgraded, so the credentials would have gone
+        // out in plaintext. `reqwest`'s own strip rule has this blind spot.
+        assert!(
+            absolute_remote_ticket_url("https://box.example:8443", "http://box.example:8443/dl/t1")
+                .is_err(),
+            "a plaintext downgrade on the same port must be refused"
+        );
     }
 
     /// Accept `responses.len()` connections in order, answering each with the

--- a/src-tauri/src/commands/remote_proxy.rs
+++ b/src-tauri/src/commands/remote_proxy.rs
@@ -41,7 +41,10 @@ use serde_json::Value;
 use tauri::{AppHandle, Emitter, EventTarget, State, WebviewWindow};
 use tokio::sync::{mpsc, watch, Mutex, RwLock};
 use tokio_tungstenite::tungstenite::{
-    client::IntoClientRequest, handshake::client::Request, http::HeaderValue, Message,
+    client::IntoClientRequest,
+    handshake::client::Request,
+    http::{HeaderMap, HeaderValue},
+    Message,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -62,6 +65,7 @@ use crate::app_error::{
 };
 use crate::db::service::remote_workspace_connection_service;
 use crate::db::AppDatabase;
+use crate::models::ToHeaderMap;
 use crate::workspace_transfer::{
     TransferDirection, TransferState, WorkspaceTransferManager, WorkspaceTransferProgress,
     WORKSPACE_TRANSFER_PROGRESS_EVENT,
@@ -308,6 +312,7 @@ pub async fn remote_http_call(
         .http
         .post(&url)
         .bearer_auth(conn.token.trim())
+        .headers(conn.headers.to_header_map())
         .json(&body);
     // Per-request override beats the client-wide 30s default. Used by the
     // ACP probe path (`describeAgentOptions`) whose backend deadline is
@@ -593,6 +598,7 @@ pub async fn remote_upload_attachment(
         .http
         .post(&url)
         .bearer_auth(conn.token.trim())
+        .headers(conn.headers.to_header_map())
         .multipart(form)
         .send()
         .await
@@ -741,6 +747,7 @@ pub async fn remote_upload_workspace_paths(
             AppCommandError::not_found(format!("Remote connection {connection_id} not found"))
         })?;
 
+    let custom_headers = conn.headers.to_header_map();
     let (transfer_id, cancel_token) = transfers.register_transfer().await;
     let result = async {
         let _permit = transfers
@@ -804,6 +811,7 @@ pub async fn remote_upload_workspace_paths(
                         &proxy,
                         &conn.base_url,
                         conn.token.trim(),
+                        &custom_headers,
                         &transfer_id,
                         cancel_token.clone(),
                         &root_path,
@@ -821,6 +829,7 @@ pub async fn remote_upload_workspace_paths(
                     &proxy,
                     &conn.base_url,
                     conn.token.trim(),
+                    &custom_headers,
                     &transfer_id,
                     cancel_token.clone(),
                     &root_path,
@@ -888,6 +897,7 @@ async fn upload_one_workspace_path(
     proxy: &RemoteProxyState,
     base_url: &str,
     token: &str,
+    custom_headers: &HeaderMap,
     transfer_id: &str,
     cancel_token: CancellationToken,
     root_path: &str,
@@ -953,6 +963,7 @@ async fn upload_one_workspace_path(
         .workspace_http
         .post(&url)
         .bearer_auth(token)
+        .headers(custom_headers.clone())
         .multipart(form)
         .send()
         .await
@@ -1150,6 +1161,7 @@ async fn remote_workspace_download_stream(
             AppCommandError::not_found(format!("Remote connection {connection_id} not found"))
         })?;
 
+    let custom_headers = conn.headers.to_header_map();
     let (transfer_id, cancel_token) = transfers.register_transfer().await;
     let result = async {
         let _permit = transfers
@@ -1170,6 +1182,7 @@ async fn remote_workspace_download_stream(
             .workspace_http
             .post(ticket_url)
             .bearer_auth(conn.token.trim())
+            .headers(custom_headers.clone())
             .json(&serde_json::json!({
                 "rootPath": root_path,
                 "path": path,
@@ -1201,6 +1214,7 @@ async fn remote_workspace_download_stream(
         let response = proxy
             .workspace_http
             .get(download_url)
+            .headers(custom_headers.clone())
             .send()
             .await
             .map_err(|e| {
@@ -1506,6 +1520,7 @@ pub async fn remote_ws_subscribe(
     let task_proxy = proxy_arc.clone();
     let base_url = conn.base_url.clone();
     let token = conn.token.clone();
+    let custom_headers = conn.headers.to_header_map();
     let task_entry = entry.clone();
 
     tauri::async_runtime::spawn(async move {
@@ -1515,6 +1530,7 @@ pub async fn remote_ws_subscribe(
             connection_id,
             base_url,
             token,
+            custom_headers,
             task_entry,
             shutdown_rx,
             outbound_rx,
@@ -1628,6 +1644,7 @@ async fn run_ws_task(
     connection_id: i32,
     base_url: String,
     token: String,
+    custom_headers: HeaderMap,
     entry: Arc<WsTaskEntry>,
     mut shutdown_rx: watch::Receiver<bool>,
     mut outbound_rx: mpsc::Receiver<String>,
@@ -1649,7 +1666,7 @@ async fn run_ws_task(
                 }
                 continue;
             }
-            res = connect_with_subprotocol_auth(&ws_url, &token) => res,
+            res = connect_with_subprotocol_auth(&ws_url, &token, &custom_headers) => res,
         };
 
         let mut socket = match connect_result {
@@ -1849,6 +1866,7 @@ async fn snapshot_subscribers(entry: &Arc<WsTaskEntry>) -> Vec<String> {
 async fn connect_with_subprotocol_auth(
     ws_url: &str,
     token: &str,
+    custom_headers: &HeaderMap,
 ) -> Result<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
     String,
@@ -1864,6 +1882,7 @@ async fn connect_with_subprotocol_auth(
         HeaderValue::from_str(&protocols_value)
             .map_err(|e| format!("invalid subprotocol value: {e}"))?,
     );
+    request.headers_mut().extend(custom_headers.clone());
 
     let (stream, _resp) = tokio_tungstenite::connect_async(request)
         .await

--- a/src-tauri/src/commands/remote_workspace.rs
+++ b/src-tauri/src/commands/remote_workspace.rs
@@ -46,6 +46,11 @@ async fn validate_remote_health(
     let url = format!("{normalized}/api/health");
     let client = reqwest::Client::builder()
         .timeout(REMOTE_HEALTH_TIMEOUT)
+        // The health check is the first request to carry the connection's
+        // custom headers, and the one the user runs to prove the setup works.
+        // It gets the same host pinning as every later request, or "test
+        // succeeded" would mean something weaker than "save succeeded".
+        .redirect(crate::commands::remote_proxy::connection_redirect_policy())
         .build()
         .map_err(|e| {
             AppCommandError::configuration_invalid("Failed to create remote health client")
@@ -61,7 +66,7 @@ async fn validate_remote_health(
         .await
         .map_err(|e| {
             AppCommandError::network("Unable to connect to remote workspace")
-                .with_detail(e.to_string())
+                .with_detail(crate::commands::remote_proxy::request_error_detail(&e))
         })?;
 
     if response.status() == StatusCode::UNAUTHORIZED {

--- a/src-tauri/src/commands/remote_workspace.rs
+++ b/src-tauri/src/commands/remote_workspace.rs
@@ -14,7 +14,7 @@ use crate::db::service::remote_workspace_connection_service;
 #[cfg(feature = "tauri-runtime")]
 use crate::db::AppDatabase;
 #[cfg(feature = "tauri-runtime")]
-use crate::models::RemoteWorkspaceConnectionInfo;
+use crate::models::{RemoteWorkspaceConnectionInfo, RemoteWorkspaceHeader, ToHeaderMap};
 
 #[cfg(feature = "tauri-runtime")]
 const REMOTE_HEALTH_TIMEOUT: Duration = Duration::from_secs(8);
@@ -32,10 +32,16 @@ pub struct RemoteWorkspaceConnectionInput {
     #[serde(alias = "baseUrl")]
     pub base_url: String,
     pub token: String,
+    #[serde(default)]
+    pub headers: Vec<RemoteWorkspaceHeader>,
 }
 
 #[cfg(feature = "tauri-runtime")]
-async fn validate_remote_health(base_url: &str, token: &str) -> Result<(), AppCommandError> {
+async fn validate_remote_health(
+    base_url: &str,
+    token: &str,
+    headers: &[RemoteWorkspaceHeader],
+) -> Result<(), AppCommandError> {
     let normalized = remote_workspace_connection_service::normalize_base_url(base_url)?;
     let url = format!("{normalized}/api/health");
     let client = reqwest::Client::builder()
@@ -45,9 +51,11 @@ async fn validate_remote_health(base_url: &str, token: &str) -> Result<(), AppCo
             AppCommandError::configuration_invalid("Failed to create remote health client")
                 .with_detail(e.to_string())
         })?;
+    let headers = remote_workspace_connection_service::validate_headers(headers)?;
     let response = client
         .post(url)
         .bearer_auth(token.trim())
+        .headers(headers.to_header_map())
         .json(&serde_json::json!({}))
         .send()
         .await
@@ -99,7 +107,7 @@ pub async fn get_remote_workspace_connection(
 pub async fn test_remote_workspace_connection(
     input: RemoteWorkspaceConnectionInput,
 ) -> Result<(), AppCommandError> {
-    validate_remote_health(&input.base_url, &input.token).await
+    validate_remote_health(&input.base_url, &input.token, &input.headers).await
 }
 
 #[cfg(feature = "tauri-runtime")]
@@ -108,12 +116,13 @@ pub async fn create_remote_workspace_connection(
     db: tauri::State<'_, AppDatabase>,
     input: RemoteWorkspaceConnectionInput,
 ) -> Result<RemoteWorkspaceConnectionInfo, AppCommandError> {
-    validate_remote_health(&input.base_url, &input.token).await?;
+    validate_remote_health(&input.base_url, &input.token, &input.headers).await?;
     remote_workspace_connection_service::create(
         &db.conn,
         &input.name,
         &input.base_url,
         &input.token,
+        &input.headers,
     )
     .await
 }
@@ -125,13 +134,14 @@ pub async fn update_remote_workspace_connection(
     id: i32,
     input: RemoteWorkspaceConnectionInput,
 ) -> Result<RemoteWorkspaceConnectionInfo, AppCommandError> {
-    validate_remote_health(&input.base_url, &input.token).await?;
+    validate_remote_health(&input.base_url, &input.token, &input.headers).await?;
     remote_workspace_connection_service::update(
         &db.conn,
         id,
         &input.name,
         &input.base_url,
         &input.token,
+        &input.headers,
     )
     .await
 }
@@ -177,7 +187,7 @@ pub async fn open_remote_workspace(
         return Ok(());
     }
 
-    validate_remote_health(&connection.base_url, &connection.token).await?;
+    validate_remote_health(&connection.base_url, &connection.token, &connection.headers).await?;
 
     let window_instance_id = new_remote_window_instance_id();
     let url = WebviewUrl::App(

--- a/src-tauri/src/db/entities/remote_workspace_connection.rs
+++ b/src-tauri/src/db/entities/remote_workspace_connection.rs
@@ -9,6 +9,10 @@ pub struct Model {
     pub base_url: String,
     #[sea_orm(column_type = "Text")]
     pub token: String,
+    /// JSON `Vec<RemoteWorkspaceHeader>` — extra headers the desktop client
+    /// sends on every request to this connection.
+    #[sea_orm(column_type = "Text")]
+    pub headers: String,
     pub sort_order: i32,
     pub created_at: DateTimeUtc,
     pub updated_at: DateTimeUtc,

--- a/src-tauri/src/db/migration/m20260825_000001_remote_workspace_connection_headers.rs
+++ b/src-tauri/src/db/migration/m20260825_000001_remote_workspace_connection_headers.rs
@@ -1,0 +1,42 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Extra HTTP headers the desktop client sends on every request to
+        // this connection. A JSON array of `{"name","value"}` objects.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RemoteWorkspaceConnection::Table)
+                    .add_column(
+                        ColumnDef::new(RemoteWorkspaceConnection::Headers)
+                            .text()
+                            .not_null()
+                            .default("[]"),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RemoteWorkspaceConnection::Table)
+                    .drop_column(RemoteWorkspaceConnection::Headers)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum RemoteWorkspaceConnection {
+    Table,
+    Headers,
+}

--- a/src-tauri/src/db/migration/mod.rs
+++ b/src-tauri/src/db/migration/mod.rs
@@ -40,6 +40,7 @@ mod m20260808_000001_custom_agent_supports_mcp;
 mod m20260817_000001_work_task_conversation_title;
 mod m20260818_000001_work_task_source;
 mod m20260819_000001_work_task_completion_kind;
+mod m20260825_000001_remote_workspace_connection_headers;
 pub struct Migrator;
 
 #[async_trait::async_trait]
@@ -86,6 +87,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260817_000001_work_task_conversation_title::Migration),
             Box::new(m20260818_000001_work_task_source::Migration),
             Box::new(m20260819_000001_work_task_completion_kind::Migration),
+            Box::new(m20260825_000001_remote_workspace_connection_headers::Migration),
         ]
     }
 }

--- a/src-tauri/src/db/service/remote_workspace_connection_service.rs
+++ b/src-tauri/src/db/service/remote_workspace_connection_service.rs
@@ -10,7 +10,22 @@ use sea_orm::{
 use crate::app_error::AppCommandError;
 use crate::db::entities::remote_workspace_connection;
 use crate::db::error::DbError;
-use crate::models::RemoteWorkspaceConnectionInfo;
+use crate::models::{RemoteWorkspaceConnectionInfo, RemoteWorkspaceHeader};
+
+/// Names the client sets itself, on the HTTP calls and on the WebSocket
+/// handshake. The save fails rather than silently drop what the user typed.
+const RESERVED_HEADER_NAMES: [&str; 10] = [
+    "authorization",
+    "content-type",
+    "content-length",
+    "host",
+    "connection",
+    "upgrade",
+    "sec-websocket-key",
+    "sec-websocket-version",
+    "sec-websocket-protocol",
+    "sec-websocket-extensions",
+];
 
 fn to_info(model: remote_workspace_connection::Model) -> RemoteWorkspaceConnectionInfo {
     RemoteWorkspaceConnectionInfo {
@@ -18,10 +33,49 @@ fn to_info(model: remote_workspace_connection::Model) -> RemoteWorkspaceConnecti
         name: model.name,
         base_url: model.base_url,
         token: model.token,
+        headers: serde_json::from_str(&model.headers).unwrap_or_default(),
         sort_order: model.sort_order,
         created_at: model.created_at,
         updated_at: model.updated_at,
     }
+}
+
+pub fn validate_headers(
+    headers: &[RemoteWorkspaceHeader],
+) -> Result<Vec<RemoteWorkspaceHeader>, AppCommandError> {
+    let mut result = Vec::with_capacity(headers.len());
+    for header in headers {
+        let name = header.name.trim();
+        let value = header.value.trim();
+        if name.is_empty() && value.is_empty() {
+            continue;
+        }
+        if name.is_empty() {
+            return Err(AppCommandError::invalid_input(
+                "Custom header name is required",
+            ));
+        }
+        if RESERVED_HEADER_NAMES.contains(&name.to_ascii_lowercase().as_str()) {
+            return Err(AppCommandError::invalid_input(format!(
+                "Custom header \"{name}\" is reserved by Codeg"
+            )));
+        }
+        header.to_header_pair().map_err(|e| {
+            AppCommandError::invalid_input(format!("Custom header \"{name}\" is invalid"))
+                .with_detail(e.to_string())
+        })?;
+        result.push(RemoteWorkspaceHeader {
+            name: name.to_string(),
+            value: value.to_string(),
+        });
+    }
+    Ok(result)
+}
+
+fn serialize_headers(headers: &[RemoteWorkspaceHeader]) -> Result<String, AppCommandError> {
+    serde_json::to_string(headers).map_err(|e| {
+        AppCommandError::invalid_input("Failed to store custom headers").with_detail(e.to_string())
+    })
 }
 
 pub fn normalize_base_url(raw: &str) -> Result<String, AppCommandError> {
@@ -83,8 +137,10 @@ pub async fn create(
     name: &str,
     base_url: &str,
     token: &str,
+    headers: &[RemoteWorkspaceHeader],
 ) -> Result<RemoteWorkspaceConnectionInfo, AppCommandError> {
     let now = Utc::now();
+    let headers = serialize_headers(&validate_headers(headers)?)?;
     let max_order = remote_workspace_connection::Entity::find()
         .order_by_desc(remote_workspace_connection::Column::SortOrder)
         .one(conn)
@@ -98,6 +154,7 @@ pub async fn create(
         name: Set(validate_name(name)?),
         base_url: Set(normalize_base_url(base_url)?),
         token: Set(validate_token(token)?),
+        headers: Set(headers),
         sort_order: Set(max_order + 1),
         created_at: Set(now),
         updated_at: Set(now),
@@ -116,7 +173,9 @@ pub async fn update(
     name: &str,
     base_url: &str,
     token: &str,
+    headers: &[RemoteWorkspaceHeader],
 ) -> Result<RemoteWorkspaceConnectionInfo, AppCommandError> {
+    let headers = serialize_headers(&validate_headers(headers)?)?;
     let row = remote_workspace_connection::Entity::find_by_id(id)
         .one(conn)
         .await
@@ -128,6 +187,7 @@ pub async fn update(
     active.name = Set(validate_name(name)?);
     active.base_url = Set(normalize_base_url(base_url)?);
     active.token = Set(validate_token(token)?);
+    active.headers = Set(headers);
     active.updated_at = Set(Utc::now());
     let model = active
         .update(conn)
@@ -205,6 +265,7 @@ pub async fn reorder(conn: &DatabaseConnection, ids: Vec<i32>) -> Result<(), App
 mod tests {
     use super::*;
     use crate::db::test_helpers::fresh_in_memory_db;
+    use crate::models::ToHeaderMap;
 
     #[test]
     fn normalize_base_url_trims_and_removes_trailing_slashes() {
@@ -218,6 +279,68 @@ mod tests {
         assert!(err.message.contains("http"));
     }
 
+    fn header(name: &str, value: &str) -> RemoteWorkspaceHeader {
+        RemoteWorkspaceHeader {
+            name: name.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_headers_trims_and_drops_empty_rows() {
+        let actual = validate_headers(&[
+            header("  CF-Access-Client-Id  ", "  abc123  "),
+            header("", ""),
+            header("   ", "  "),
+        ])
+        .unwrap();
+        assert_eq!(actual, vec![header("CF-Access-Client-Id", "abc123")]);
+    }
+
+    #[test]
+    fn validate_headers_keeps_repeated_names_and_order() {
+        let input = vec![header("X-Trace", "a"), header("X-Trace", "b")];
+        assert_eq!(validate_headers(&input).unwrap(), input);
+    }
+
+    #[test]
+    fn to_header_map_keeps_repeats_and_skips_unparsable_rows() {
+        let map = [
+            header("X-Trace", "a"),
+            header("X-Trace", "b"),
+            header("bad header", "dropped"),
+            header("  ", "dropped"),
+        ]
+        .to_header_map();
+        assert_eq!(
+            map.get_all("x-trace")
+                .iter()
+                .map(|v| v.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn validate_headers_rejects_reserved_names() {
+        for name in ["Authorization", "content-type", "Sec-WebSocket-Protocol"] {
+            let err = validate_headers(&[header(name, "x")]).unwrap_err();
+            assert!(
+                err.message.contains("reserved"),
+                "expected {name} to be reserved, got {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn validate_headers_rejects_invalid_name_value_and_missing_name() {
+        assert!(validate_headers(&[header("bad header", "x")]).is_err());
+        assert!(validate_headers(&[header("X-Bad", "line\nbreak")]).is_err());
+        assert!(validate_headers(&[header("", "orphan-value")]).is_err());
+    }
+
     #[tokio::test]
     async fn create_list_update_delete_roundtrip() {
         let db = fresh_in_memory_db().await;
@@ -226,17 +349,23 @@ mod tests {
             "Local 3080",
             "http://127.0.0.1:3080/",
             "secret-token",
+            &[header("CF-Access-Client-Id", "abc123")],
         )
         .await
         .unwrap();
         assert_eq!(created.name, "Local 3080");
         assert_eq!(created.base_url, "http://127.0.0.1:3080");
         assert_eq!(created.token, "secret-token");
+        assert_eq!(
+            created.headers,
+            vec![header("CF-Access-Client-Id", "abc123")]
+        );
         assert_eq!(created.sort_order, 0);
 
         let listed = list(&db.conn).await.unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, created.id);
+        assert_eq!(listed[0].headers, created.headers);
 
         let updated = update(
             &db.conn,
@@ -244,11 +373,13 @@ mod tests {
             "Server A",
             "https://codeg.example.com/",
             "next-token",
+            &[],
         )
         .await
         .unwrap();
         assert_eq!(updated.name, "Server A");
         assert_eq!(updated.base_url, "https://codeg.example.com");
+        assert!(updated.headers.is_empty());
 
         delete(&db.conn, created.id).await.unwrap();
         assert!(list(&db.conn).await.unwrap().is_empty());
@@ -257,13 +388,13 @@ mod tests {
     #[tokio::test]
     async fn reorder_updates_list_order() {
         let db = fresh_in_memory_db().await;
-        let first = create(&db.conn, "First", "http://127.0.0.1:3080", "token-a")
+        let first = create(&db.conn, "First", "http://127.0.0.1:3080", "token-a", &[])
             .await
             .unwrap();
-        let second = create(&db.conn, "Second", "http://127.0.0.1:3081", "token-b")
+        let second = create(&db.conn, "Second", "http://127.0.0.1:3081", "token-b", &[])
             .await
             .unwrap();
-        let third = create(&db.conn, "Third", "http://127.0.0.1:3082", "token-c")
+        let third = create(&db.conn, "Third", "http://127.0.0.1:3082", "token-c", &[])
             .await
             .unwrap();
 
@@ -288,10 +419,10 @@ mod tests {
     #[tokio::test]
     async fn reorder_rejects_partial_or_duplicate_ids() {
         let db = fresh_in_memory_db().await;
-        let first = create(&db.conn, "First", "http://127.0.0.1:3080", "token-a")
+        let first = create(&db.conn, "First", "http://127.0.0.1:3080", "token-a", &[])
             .await
             .unwrap();
-        let second = create(&db.conn, "Second", "http://127.0.0.1:3081", "token-b")
+        let second = create(&db.conn, "Second", "http://127.0.0.1:3081", "token-b", &[])
             .await
             .unwrap();
 

--- a/src-tauri/src/db/service/remote_workspace_connection_service.rs
+++ b/src-tauri/src/db/service/remote_workspace_connection_service.rs
@@ -14,10 +14,17 @@ use crate::models::{RemoteWorkspaceConnectionInfo, RemoteWorkspaceHeader};
 
 /// Names the client sets itself, on the HTTP calls and on the WebSocket
 /// handshake. The save fails rather than silently drop what the user typed.
-const RESERVED_HEADER_NAMES: [&str; 10] = [
+/// A slice, not a fixed-size array: the length is one more thing to forget to
+/// bump when a name is added.
+const RESERVED_HEADER_NAMES: &[&str] = &[
     "authorization",
     "content-type",
     "content-length",
+    // `hyper` frames the body itself and picks chunked for the streaming
+    // workspace upload. A user-supplied framing header contradicts it, and it
+    // is also the header a request-smuggling attempt rides in on — which is
+    // the one thing not to hand to a fronting proxy.
+    "transfer-encoding",
     "host",
     "connection",
     "upgrade",
@@ -323,8 +330,23 @@ mod tests {
     }
 
     #[test]
+    fn to_header_map_marks_every_value_sensitive() {
+        // A custom header is a credential. Sensitive keeps it out of the HTTP/2
+        // HPACK dynamic table and out of any `{:?}` of the request.
+        let map = [header("CF-Access-Client-Secret", "s3cret")].to_header_map();
+        let value = map.get("cf-access-client-secret").unwrap();
+        assert!(value.is_sensitive());
+        assert_eq!(format!("{value:?}"), "Sensitive");
+    }
+
+    #[test]
     fn validate_headers_rejects_reserved_names() {
-        for name in ["Authorization", "content-type", "Sec-WebSocket-Protocol"] {
+        for name in [
+            "Authorization",
+            "content-type",
+            "Transfer-Encoding",
+            "Sec-WebSocket-Protocol",
+        ] {
             let err = validate_headers(&[header(name, "x")]).unwrap_err();
             assert!(
                 err.message.contains("reserved"),
@@ -383,6 +405,49 @@ mod tests {
 
         delete(&db.conn, created.id).await.unwrap();
         assert!(list(&db.conn).await.unwrap().is_empty());
+    }
+
+    /// The upgrade path, which is every existing install: rows written before
+    /// the `headers` column existed. `ADD COLUMN NOT NULL DEFAULT '[]'` has to
+    /// backfill them — a NULL there fails to deserialize into `Model.headers:
+    /// String` and takes the whole connection list down, not just the headers.
+    /// The insert omits `headers` exactly the way the old schema did.
+    #[tokio::test]
+    async fn list_reads_a_row_written_without_the_headers_column() {
+        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+        let db = fresh_in_memory_db().await;
+        // Seeded through `create` so the legacy row can copy its timestamps
+        // verbatim, rather than guessing SeaORM's SQLite datetime encoding.
+        let seed = create(&db.conn, "Seed", "http://127.0.0.1:3080", "token", &[])
+            .await
+            .unwrap();
+        db.conn
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "INSERT INTO remote_workspace_connection \
+                 (name, base_url, token, sort_order, created_at, updated_at) \
+                 SELECT 'Legacy', 'http://127.0.0.1:3099', token, 1, \
+                 created_at, updated_at FROM remote_workspace_connection"
+                    .to_owned(),
+            ))
+            .await
+            .unwrap();
+
+        let listed = list(&db.conn).await.unwrap();
+        assert_eq!(
+            listed.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Seed", "Legacy"]
+        );
+        assert!(listed[1].headers.is_empty());
+
+        // `create` re-reads every column to find the max sort order, so the
+        // legacy row has to survive that read too.
+        let next = create(&db.conn, "Next", "http://127.0.0.1:3081", "token", &[])
+            .await
+            .unwrap();
+        assert_eq!(next.sort_order, 2);
+        assert_ne!(next.id, seed.id);
     }
 
     #[tokio::test]

--- a/src-tauri/src/logging/init.rs
+++ b/src-tauri/src/logging/init.rs
@@ -93,11 +93,17 @@ pub struct LogGuard {
 ///   "Received close frame"). `trace!` is where both problems live: this dump,
 ///   and a line per WebSocket frame read and written (`protocol/frame/mod.rs`),
 ///   which is the sacp firehose shape again — every ACP event twice over.
-///
-///   The usual escape hatch applies and is deliberate: `tungstenite::protocol`
-///   can still be pinned to trace for frame-level debugging, and naming
-///   `tungstenite::handshake::client` re-opens the dump for someone who has
-///   decided they want it. What this stops is getting it by accident.
+/// - `tungstenite::handshake::client` → `Debug` — the same ceiling again, on
+///   the exact target the dump is emitted from, and this one is not negotiable.
+///   The crate-level entry above is a ceiling in the usual sense: a MORE
+///   specific directive beats it, which is what keeps `tungstenite::protocol`
+///   pinnable to trace for frame-level debugging. That escape hatch is right
+///   for a firehose and wrong for a credential, so the dump gets its own entry.
+///   Backstops are appended last and win at equal specificity (see
+///   [`build_env_filter`]), and no target is more specific than the module the
+///   `trace!` lives in — so neither the Settings UI nor `CODEG_LOG` can reopen
+///   it, deliberately or otherwise. Asking for LESS is still honored: the clamp
+///   never raises verbosity, so `off` still means off.
 /// - `sqlx::query` → `Warn` — sqlx logs every executed statement, with its SQL
 ///   text, at INFO by default. Every `ConnectOptions` in the tree sets
 ///   `.sqlx_logging(false)`, but that is a per-call-site opt-out that a new
@@ -114,6 +120,7 @@ const TARGET_BACKSTOPS: &[(&str, LogLevel)] = &[
     ("sacp", LogLevel::Warn),
     ("sacp_tokio", LogLevel::Warn),
     ("tungstenite", LogLevel::Debug),
+    ("tungstenite::handshake::client", LogLevel::Debug),
     ("sqlx::query", LogLevel::Warn),
     ("codeg_lib::logging", LogLevel::Off),
 ];
@@ -682,6 +689,59 @@ mod tests {
         );
     }
 
+    /// The crate ceiling stops the accident; this stops the deliberate act.
+    /// A firehose ceiling is meant to be re-openable by naming a submodule —
+    /// that is how `tungstenite::protocol=trace` stays available for frame
+    /// debugging. A credential dump is not, so the exact target it is emitted
+    /// on carries its own backstop, which wins at equal specificity, and no
+    /// target is more specific than the module holding the `trace!`.
+    #[test]
+    fn the_handshake_dump_cannot_be_reopened_even_by_naming_its_target() {
+        for asked in [
+            "tungstenite::handshake::client=trace",
+            "trace,tungstenite::handshake::client=trace",
+        ] {
+            let rendered = EnvFilter::builder()
+                .parse_lossy(env_override_directives(asked))
+                .to_string();
+            assert!(
+                !rendered.contains("tungstenite::handshake::client=trace"),
+                "CODEG_LOG={asked} reopened the dump: {rendered}"
+            );
+        }
+
+        // The Settings UI builds its filter down a different path.
+        let rendered = build_env_filter(&LogSettings {
+            level: LogLevel::Trace,
+            targets: vec![TargetDirective {
+                target: "tungstenite::handshake::client".into(),
+                level: LogLevel::Trace,
+            }],
+        })
+        .to_string();
+        assert!(
+            !rendered.contains("tungstenite::handshake::client=trace"),
+            "the Settings UI reopened the dump: {rendered}"
+        );
+
+        // Asking for less is still honored — a ceiling never raises verbosity.
+        assert!(
+            env_override_directives("tungstenite::handshake::client=off")
+                .contains("tungstenite::handshake::client=off"),
+            "off must still mean off"
+        );
+
+        // And frame-level debugging stays reachable, which is the whole reason
+        // the crate-level entry remains a re-openable ceiling.
+        let frames = EnvFilter::builder()
+            .parse_lossy(env_override_directives("info,tungstenite::protocol=trace"))
+            .to_string();
+        assert!(
+            frames.contains("tungstenite::protocol=trace"),
+            "frame tracing must survive the crate ceiling: {frames}"
+        );
+    }
+
     #[test]
     fn env_override_appends_backstops_so_debug_cannot_reopen_them() {
         // The explicit RUST_LOG/CODEG_LOG path bypasses build_env_filter, so it
@@ -690,7 +750,7 @@ mod tests {
         assert_eq!(
             env_override_directives("debug"),
             "debug,kill_tree=warn,sacp=warn,sacp_tokio=warn,tungstenite=debug,\
-             sqlx::query=warn,codeg_lib::logging=off"
+             tungstenite::handshake::client=debug,sqlx::query=warn,codeg_lib::logging=off"
         );
         // And the parsed filter still carries the clamps under a global debug.
         let rendered = EnvFilter::builder()
@@ -739,7 +799,7 @@ mod tests {
         assert_eq!(
             env_override_directives("OFF"),
             "OFF,kill_tree=off,sacp=off,sacp_tokio=off,tungstenite=off,\
-             sqlx::query=off,codeg_lib::logging=off",
+             tungstenite::handshake::client=off,sqlx::query=off,codeg_lib::logging=off",
             "a bare off override collapses the ceilings, case-insensitively"
         );
     }
@@ -757,7 +817,7 @@ mod tests {
         assert_eq!(
             env_override_directives("sacp=off"),
             "sacp=off,kill_tree=off,sacp=off,sacp_tokio=off,tungstenite=off,\
-             sqlx::query=off,codeg_lib::logging=off"
+             tungstenite::handshake::client=off,sqlx::query=off,codeg_lib::logging=off"
         );
         // ...but the same target asking for MORE is still refused: that is the
         // firehose this whole clamp exists to keep shut.

--- a/src-tauri/src/logging/init.rs
+++ b/src-tauri/src/logging/init.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_appender::rolling::Rotation;
+use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::{fmt, prelude::*, reload, EnvFilter, Registry};
 
 use crate::logging::budget::{self, BudgetedWriter};
@@ -100,10 +101,15 @@ pub struct LogGuard {
 ///   pinnable to trace for frame-level debugging. That escape hatch is right
 ///   for a firehose and wrong for a credential, so the dump gets its own entry.
 ///   Backstops are appended last and win at equal specificity (see
-///   [`build_env_filter`]), and no target is more specific than the module the
-///   `trace!` lives in — so neither the Settings UI nor `CODEG_LOG` can reopen
-///   it, deliberately or otherwise. Asking for LESS is still honored: the clamp
-///   never raises verbosity, so `off` still means off.
+///   [`build_env_filter`]), so a plain `tungstenite::handshake::client=trace`
+///   from the Settings UI or `CODEG_LOG` loses to this entry at any module
+///   depth. Asking for LESS is still honored: the clamp never raises
+///   verbosity, so `off` still means off.
+///
+///   This entry is not by itself sufficient, because a level table can only
+///   answer directives that are about levels — a field-qualified directive
+///   outranks it. [`is_credential_dump_target`] is what actually closes the
+///   target; this keeps the level story coherent alongside it.
 /// - `sqlx::query` → `Warn` — sqlx logs every executed statement, with its SQL
 ///   text, at INFO by default. Every `ConnectOptions` in the tree sets
 ///   `.sqlx_logging(false)`, but that is a per-call-site opt-out that a new
@@ -124,6 +130,29 @@ const TARGET_BACKSTOPS: &[(&str, LogLevel)] = &[
     ("sqlx::query", LogLevel::Warn),
     ("codeg_lib::logging", LogLevel::Off),
 ];
+
+/// The one target that is refused structurally rather than by level.
+///
+/// [`TARGET_BACKSTOPS`] is a table of *levels*, and a level is negotiable:
+/// `EnvFilter` ranks a field-qualified directive above a plain target one, so
+/// `CODEG_LOG='tungstenite::handshake::client[{message}]=trace'` outranks the
+/// entry there — and that `trace!` is a formatted event, so it has a `message`
+/// field to match on. The entry in the table still earns its place (it keeps
+/// the crate ceiling coherent and it is what the directive tests read), but it
+/// cannot be the whole answer.
+///
+/// A ceiling is the wrong shape for this line anyway. There is no verbosity to
+/// trade off: `handshake/client.rs` prints the serialized request, and in this
+/// codebase the only tungstenite client is the remote-workspace WebSocket, so
+/// every time that line prints at all it prints a bearer token and whatever
+/// custom credential headers the connection carries. So it is dropped before
+/// the level filter is consulted, and no directive in any syntax reaches it.
+///
+/// Anyone who genuinely needs the handshake bytes has `tungstenite::protocol`
+/// for frames, or a local edit here.
+fn is_credential_dump_target(target: &str) -> bool {
+    target == "tungstenite::handshake::client"
+}
 
 /// How much a level lets through, ascending. Distinct from [`LogLevel::rank`],
 /// which is a *severity* rank for filtering records (and puts `Off` at 0
@@ -485,6 +514,9 @@ fn build_subscriber(
         Some((non_blocking, guard)) => {
             Registry::default()
                 .with(filter_layer)
+                // A second global filter: an event must clear BOTH, so this one
+                // cannot be argued with by any `EnvFilter` directive.
+                .with(filter_fn(|meta| !is_credential_dump_target(meta.target())))
                 .with(fmt::layer().with_writer(std::io::stderr))
                 .with(BufferEmitLayer)
                 .with(fmt::layer().json().with_writer(non_blocking))
@@ -494,6 +526,9 @@ fn build_subscriber(
         None => {
             Registry::default()
                 .with(filter_layer)
+                // A second global filter: an event must clear BOTH, so this one
+                // cannot be argued with by any `EnvFilter` directive.
+                .with(filter_fn(|meta| !is_credential_dump_target(meta.target())))
                 .with(fmt::layer().with_writer(std::io::stderr))
                 .with(BufferEmitLayer)
                 .init();
@@ -739,6 +774,91 @@ mod tests {
         assert!(
             frames.contains("tungstenite::protocol=trace"),
             "frame tracing must survive the crate ceiling: {frames}"
+        );
+    }
+
+    /// Why the level table cannot be the whole answer, pinned as a fact rather
+    /// than an argument: `EnvFilter` ranks a field-qualified directive above a
+    /// plain target one, and the dump is a formatted event so it has a
+    /// `message` field to qualify on. The first assertion shows the ceiling
+    /// losing; the second shows what actually holds the line.
+    #[test]
+    fn a_field_qualified_directive_defeats_the_ceiling_but_not_the_denial() {
+        let rendered = EnvFilter::builder()
+            .parse_lossy(env_override_directives(
+                "tungstenite::handshake::client[{message}]=trace",
+            ))
+            .to_string();
+        assert!(
+            rendered.contains("tungstenite::handshake::client[{message}]=trace"),
+            "expected the level table to be outranked here: {rendered}"
+        );
+
+        assert!(
+            is_credential_dump_target("tungstenite::handshake::client"),
+            "the dump's target must be denied outright, whatever the filter says"
+        );
+        // Exact match only — the denial must not swallow its neighbours.
+        for neighbour in [
+            "tungstenite::handshake::server",
+            "tungstenite::handshake",
+            "tungstenite::protocol",
+            "tungstenite",
+        ] {
+            assert!(
+                !is_credential_dump_target(neighbour),
+                "{neighbour} must stay reachable"
+            );
+        }
+    }
+
+    /// The predicate above is only half the claim; this exercises the wiring,
+    /// with the same two global filters the real subscriber is built from and
+    /// the most permissive directive anyone could write for the dump.
+    #[test]
+    fn the_denial_layer_drops_the_dump_and_nothing_else() {
+        use std::sync::{Arc, Mutex};
+
+        struct CaptureTargets(Arc<Mutex<Vec<String>>>);
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureTargets {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push(event.metadata().target().to_string());
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default()
+            .with(EnvFilter::builder().parse_lossy(
+                "trace,tungstenite::handshake::client[{message}]=trace",
+            ))
+            .with(filter_fn(|meta| !is_credential_dump_target(meta.target())))
+            .with(CaptureTargets(seen.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::trace!(target: "tungstenite::handshake::client", "Request: bearer s3cret");
+            tracing::trace!(target: "tungstenite::protocol", "frame");
+            tracing::trace!(target: "codeg_lib::acp", "unrelated");
+        });
+
+        let seen = seen.lock().unwrap();
+        assert!(
+            !seen.iter().any(|t| t == "tungstenite::handshake::client"),
+            "the dump reached a sink: {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|t| t == "tungstenite::protocol"),
+            "frame tracing must still arrive: {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|t| t == "codeg_lib::acp"),
+            "unrelated targets must still arrive: {seen:?}"
         );
     }
 

--- a/src-tauri/src/logging/init.rs
+++ b/src-tauri/src/logging/init.rs
@@ -76,6 +76,28 @@ pub struct LogGuard {
 ///   Protocol-level debugging stays reachable: a MORE SPECIFIC target beats a
 ///   crate-level ceiling, so setting `CODEG_LOG` to
 ///   `info,sacp::jsonrpc::transport_actor=trace` still dumps the wire.
+/// - `tungstenite` → `Debug` — `handshake/client.rs` TRACEs the serialized
+///   handshake **in full**: `trace!("Request: {:?}", …)` over the raw request
+///   bytes. For a remote workspace connection that request carries the
+///   connection's credentials — the bearer token (which travels as a
+///   `Sec-WebSocket-Protocol` value) and every custom header the user
+///   configured, which for the case the feature exists to serve is a Cloudflare
+///   Access service token. `HeaderValue::set_sensitive` does not help: that
+///   only governs HTTP/2 HPACK indexing and the `Debug` of the value itself,
+///   and this line formats bytes tungstenite has already written out. So a user
+///   who raises the level to trace to diagnose a connection problem and then
+///   attaches the log to a bug report ships their secrets with it.
+///
+///   `Debug` — not lower — because the crate's `debug!` lines are the useful,
+///   harmless ones ("Client handshake done.", "Trying to contact {uri}",
+///   "Received close frame"). `trace!` is where both problems live: this dump,
+///   and a line per WebSocket frame read and written (`protocol/frame/mod.rs`),
+///   which is the sacp firehose shape again — every ACP event twice over.
+///
+///   The usual escape hatch applies and is deliberate: `tungstenite::protocol`
+///   can still be pinned to trace for frame-level debugging, and naming
+///   `tungstenite::handshake::client` re-opens the dump for someone who has
+///   decided they want it. What this stops is getting it by accident.
 /// - `sqlx::query` → `Warn` — sqlx logs every executed statement, with its SQL
 ///   text, at INFO by default. Every `ConnectOptions` in the tree sets
 ///   `.sqlx_logging(false)`, but that is a per-call-site opt-out that a new
@@ -91,6 +113,7 @@ const TARGET_BACKSTOPS: &[(&str, LogLevel)] = &[
     ("kill_tree", LogLevel::Warn),
     ("sacp", LogLevel::Warn),
     ("sacp_tokio", LogLevel::Warn),
+    ("tungstenite", LogLevel::Debug),
     ("sqlx::query", LogLevel::Warn),
     ("codeg_lib::logging", LogLevel::Off),
 ];
@@ -620,12 +643,43 @@ mod tests {
             // INFO line — the 34GB-in-8.8h shape.
             "sacp=warn",
             "sacp_tokio=warn",
+            // The serialized WS handshake at TRACE — bearer token and every
+            // custom header of a remote workspace connection, in the clear.
+            // Clamped to the global `info` here: the ceiling never adds volume,
+            // it only refuses trace.
+            "tungstenite=info",
             // Every SQL statement at INFO if a ConnectOptions forgets to opt out.
             "sqlx::query=warn",
             "codeg_lib::logging=off",
         ] {
             assert!(rendered.contains(pin), "missing backstop {pin}: {rendered}");
         }
+    }
+
+    /// The specific accident the `tungstenite` ceiling exists to prevent: a user
+    /// raises the level to trace to diagnose a remote-workspace connection, and
+    /// the WS handshake dump takes their bearer token and every custom header —
+    /// the Cloudflare Access secret the feature exists to carry — to disk with
+    /// it. Both filter paths have to hold, since the env override builds its own.
+    #[test]
+    fn a_global_trace_cannot_capture_the_websocket_handshake_dump() {
+        let rendered = build_env_filter(&LogSettings {
+            level: LogLevel::Trace,
+            targets: Vec::new(),
+        })
+        .to_string();
+        assert!(
+            rendered.contains("tungstenite=debug"),
+            "global trace re-opened the handshake dump: {rendered}"
+        );
+        let env = env_override_directives("trace");
+        assert!(
+            EnvFilter::builder()
+                .parse_lossy(&env)
+                .to_string()
+                .contains("tungstenite=debug"),
+            "CODEG_LOG=trace re-opened the handshake dump: {env}"
+        );
     }
 
     #[test]
@@ -635,7 +689,7 @@ mod tests {
         // re-opens the kill_tree per-PID firehose and the sacp wire dump.
         assert_eq!(
             env_override_directives("debug"),
-            "debug,kill_tree=warn,sacp=warn,sacp_tokio=warn,\
+            "debug,kill_tree=warn,sacp=warn,sacp_tokio=warn,tungstenite=debug,\
              sqlx::query=warn,codeg_lib::logging=off"
         );
         // And the parsed filter still carries the clamps under a global debug.
@@ -684,7 +738,8 @@ mod tests {
         // And the env-override path. `RUST_LOG=off` must be silent too.
         assert_eq!(
             env_override_directives("OFF"),
-            "OFF,kill_tree=off,sacp=off,sacp_tokio=off,sqlx::query=off,codeg_lib::logging=off",
+            "OFF,kill_tree=off,sacp=off,sacp_tokio=off,tungstenite=off,\
+             sqlx::query=off,codeg_lib::logging=off",
             "a bare off override collapses the ceilings, case-insensitively"
         );
     }
@@ -701,7 +756,8 @@ mod tests {
         // other ceiling collapses to off too.
         assert_eq!(
             env_override_directives("sacp=off"),
-            "sacp=off,kill_tree=off,sacp=off,sacp_tokio=off,sqlx::query=off,codeg_lib::logging=off"
+            "sacp=off,kill_tree=off,sacp=off,sacp_tokio=off,tungstenite=off,\
+             sqlx::query=off,codeg_lib::logging=off"
         );
         // ...but the same target asking for MORE is still refused: that is the
         // firehose this whole clamp exists to keep shut.

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -35,7 +35,9 @@ pub use message::{
     TurnRole, TurnUsage, UnifiedMessage,
 };
 pub use quick_message::QuickMessageInfo;
-pub use remote_workspace_connection::RemoteWorkspaceConnectionInfo;
+pub use remote_workspace_connection::{
+    RemoteWorkspaceConnectionInfo, RemoteWorkspaceHeader, ToHeaderMap,
+};
 pub use token_usage::{
     TokenUsageBreakdownItem, TokenUsageBucket, TokenUsageConversationItem, TokenUsageFacets,
     TokenUsageFilter, TokenUsageFolderFacet, TokenUsageHeatCell, TokenUsagePoint,

--- a/src-tauri/src/models/remote_workspace_connection.rs
+++ b/src-tauri/src/models/remote_workspace_connection.rs
@@ -1,5 +1,32 @@
 use chrono::{DateTime, Utc};
+use http::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteWorkspaceHeader {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub value: String,
+}
+
+impl RemoteWorkspaceHeader {
+    pub fn to_header_pair(&self) -> Result<(HeaderName, HeaderValue), http::Error> {
+        Ok((self.name.trim().try_into()?, self.value.trim().try_into()?))
+    }
+}
+
+pub trait ToHeaderMap {
+    fn to_header_map(&self) -> HeaderMap;
+}
+
+impl ToHeaderMap for [RemoteWorkspaceHeader] {
+    fn to_header_map(&self) -> HeaderMap {
+        self.iter()
+            .filter_map(|header| header.to_header_pair().ok())
+            .collect()
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteWorkspaceConnectionInfo {
@@ -7,6 +34,8 @@ pub struct RemoteWorkspaceConnectionInfo {
     pub name: String,
     pub base_url: String,
     pub token: String,
+    #[serde(default)]
+    pub headers: Vec<RemoteWorkspaceHeader>,
     pub sort_order: i32,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/src-tauri/src/models/remote_workspace_connection.rs
+++ b/src-tauri/src/models/remote_workspace_connection.rs
@@ -12,7 +12,14 @@ pub struct RemoteWorkspaceHeader {
 
 impl RemoteWorkspaceHeader {
     pub fn to_header_pair(&self) -> Result<(HeaderName, HeaderValue), http::Error> {
-        Ok((self.name.trim().try_into()?, self.value.trim().try_into()?))
+        let name: HeaderName = self.name.trim().try_into()?;
+        let mut value: HeaderValue = self.value.trim().try_into()?;
+        // A custom header on a remote connection normally carries a credential
+        // (a Cloudflare Access service token, a proxy secret), so it gets the
+        // same treatment `reqwest` gives its own `bearer_auth` value: never
+        // added to the HTTP/2 HPACK dynamic table, and redacted from `Debug`.
+        value.set_sensitive(true);
+        Ok((name, value))
     }
 }
 

--- a/src/components/layout/remote-workspace-manage-dialog.test.tsx
+++ b/src/components/layout/remote-workspace-manage-dialog.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { NextIntlClientProvider } from "next-intl"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { RemoteWorkspaceConnection } from "@/lib/types"
+
+const mocks = vi.hoisted(() => ({
+  listRemoteWorkspaceConnections: vi.fn(),
+  createRemoteWorkspaceConnection: vi.fn(),
+  updateRemoteWorkspaceConnection: vi.fn(),
+  deleteRemoteWorkspaceConnection: vi.fn(),
+  reorderRemoteWorkspaceConnections: vi.fn(),
+}))
+
+vi.mock("@/lib/remote-workspace", () => ({
+  listRemoteWorkspaceConnections: mocks.listRemoteWorkspaceConnections,
+  createRemoteWorkspaceConnection: mocks.createRemoteWorkspaceConnection,
+  updateRemoteWorkspaceConnection: mocks.updateRemoteWorkspaceConnection,
+  deleteRemoteWorkspaceConnection: mocks.deleteRemoteWorkspaceConnection,
+  reorderRemoteWorkspaceConnections: mocks.reorderRemoteWorkspaceConnections,
+}))
+
+import { RemoteWorkspaceManageDialog } from "./remote-workspace-manage-dialog"
+import enMessages from "@/i18n/messages/en.json"
+
+function connection(
+  overrides: Partial<RemoteWorkspaceConnection> = {}
+): RemoteWorkspaceConnection {
+  return {
+    id: 1,
+    name: "prod-box",
+    base_url: "https://prod.example",
+    token: "secret",
+    headers: [],
+    sort_order: 0,
+    created_at: "2026-08-25T00:00:00Z",
+    updated_at: "2026-08-25T00:00:00Z",
+    ...overrides,
+  }
+}
+
+async function mount(connections: RemoteWorkspaceConnection[]) {
+  mocks.listRemoteWorkspaceConnections.mockResolvedValue(connections)
+  render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <RemoteWorkspaceManageDialog
+        open
+        onOpenChange={() => {}}
+        onChanged={() => {}}
+      />
+    </NextIntlClientProvider>
+  )
+  await screen.findByDisplayValue(connections[0].name)
+}
+
+describe("RemoteWorkspaceManageDialog custom headers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps the editor collapsed when the connection has no headers", async () => {
+    await mount([connection()])
+    expect(screen.queryByLabelText("Header name")).not.toBeInTheDocument()
+  })
+
+  it("opens the editor when the connection already has headers", async () => {
+    await mount([
+      connection({ headers: [{ name: "CF-Access-Client-Id", value: "abc" }] }),
+    ])
+    expect(await screen.findByDisplayValue("CF-Access-Client-Id")).toBeVisible()
+  })
+
+  it("masks every header value", async () => {
+    await mount([connection({ headers: [{ name: "X-Secret", value: "abc" }] })])
+    expect(await screen.findByDisplayValue("abc")).toHaveAttribute(
+      "type",
+      "password"
+    )
+  })
+
+  it("sends the added header on save and drops a removed one", async () => {
+    const saved = connection({
+      headers: [{ name: "X-Team", value: "core" }],
+    })
+    mocks.updateRemoteWorkspaceConnection.mockResolvedValue(saved)
+    await mount([connection()])
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Custom headers/ })
+    )
+    await userEvent.click(screen.getByRole("button", { name: "Add header" }))
+    fireEvent.change(screen.getByLabelText("Header name"), {
+      target: { value: "X-Team" },
+    })
+    fireEvent.change(screen.getByLabelText("Header value"), {
+      target: { value: "core" },
+    })
+
+    // A second row, then removed again: the payload must hold one header.
+    await userEvent.click(screen.getByRole("button", { name: "Add header" }))
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Remove header" })[1]
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mocks.updateRemoteWorkspaceConnection).toHaveBeenCalledWith(1, {
+        name: "prod-box",
+        baseUrl: "https://prod.example",
+        token: "secret",
+        headers: [{ name: "X-Team", value: "core" }],
+      })
+    })
+  })
+})

--- a/src/components/layout/remote-workspace-manage-dialog.tsx
+++ b/src/components/layout/remote-workspace-manage-dialog.tsx
@@ -9,7 +9,14 @@ import {
   type PointerEvent,
   type ReactNode,
 } from "react"
-import { GripVertical, Loader2, Plus, Save, Trash2 } from "lucide-react"
+import {
+  ChevronRight,
+  GripVertical,
+  Loader2,
+  Plus,
+  Save,
+  Trash2,
+} from "lucide-react"
 import { Reorder, useDragControls } from "motion/react"
 import { useTranslations } from "next-intl"
 import {
@@ -20,7 +27,10 @@ import {
   updateRemoteWorkspaceConnection,
 } from "@/lib/remote-workspace"
 import { toErrorMessage } from "@/lib/app-error"
-import type { RemoteWorkspaceConnection } from "@/lib/types"
+import type {
+  RemoteWorkspaceConnection,
+  RemoteWorkspaceHeader,
+} from "@/lib/types"
 import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -38,6 +48,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -61,6 +76,7 @@ interface Draft {
   name: string
   baseUrl: string
   token: string
+  headers: RemoteWorkspaceHeader[]
 }
 
 interface RemoteWorkspaceReorderItemProps {
@@ -79,6 +95,7 @@ const EMPTY_DRAFT: Draft = {
   name: "",
   baseUrl: "",
   token: "",
+  headers: [],
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -159,6 +176,7 @@ export function RemoteWorkspaceManageDialog({
   const [deleting, setDeleting] = useState(false)
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
   const [reordering, setReordering] = useState(false)
+  const [headersOpen, setHeadersOpen] = useState(false)
   const pendingOrderRef = useRef<number[] | null>(null)
   const panelContainerRef = useRef<HTMLDivElement | null>(null)
   const [panelContainerWidth, setPanelContainerWidth] = useState(0)
@@ -227,6 +245,7 @@ export function RemoteWorkspaceManageDialog({
 
   useEffect(() => {
     setFormError(null)
+    setHeadersOpen((selected?.headers?.length ?? 0) > 0)
     if (!selected) {
       setDraft(EMPTY_DRAFT)
       return
@@ -236,6 +255,7 @@ export function RemoteWorkspaceManageDialog({
       name: selected.name,
       baseUrl: selected.base_url,
       token: selected.token,
+      headers: selected.headers ?? [],
     })
   }, [selected])
 
@@ -272,6 +292,36 @@ export function RemoteWorkspaceManageDialog({
     setSelectedId(null)
     setFormError(null)
     setDraft(EMPTY_DRAFT)
+    setHeadersOpen(false)
+  }, [])
+
+  const updateHeader = useCallback(
+    (index: number, patch: Partial<RemoteWorkspaceHeader>) => {
+      setFormError(null)
+      setDraft((prev) => ({
+        ...prev,
+        headers: prev.headers.map((header, position) =>
+          position === index ? { ...header, ...patch } : header
+        ),
+      }))
+    },
+    []
+  )
+
+  const addHeader = useCallback(() => {
+    setFormError(null)
+    setDraft((prev) => ({
+      ...prev,
+      headers: [...prev.headers, { name: "", value: "" }],
+    }))
+  }, [])
+
+  const removeHeader = useCallback((index: number) => {
+    setFormError(null)
+    setDraft((prev) => ({
+      ...prev,
+      headers: prev.headers.filter((_, position) => position !== index),
+    }))
   }, [])
 
   const persistReorder = useCallback(
@@ -313,6 +363,7 @@ export function RemoteWorkspaceManageDialog({
         name: draft.name,
         baseUrl: draft.baseUrl,
         token: draft.token,
+        headers: draft.headers,
       }
       const saved =
         draft.id === null
@@ -331,6 +382,7 @@ export function RemoteWorkspaceManageDialog({
         name: saved.name,
         baseUrl: saved.base_url,
         token: saved.token,
+        headers: saved.headers ?? [],
       })
       onChanged()
     } catch (err) {
@@ -530,6 +582,73 @@ export function RemoteWorkspaceManageDialog({
                         }
                       />
                     </div>
+                    <Collapsible
+                      open={headersOpen}
+                      onOpenChange={setHeadersOpen}
+                      className="space-y-2"
+                    >
+                      <CollapsibleTrigger className="flex h-6 w-full items-center gap-1.5 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
+                        <ChevronRight
+                          className={cn(
+                            "h-3.5 w-3.5 transition-transform",
+                            headersOpen && "rotate-90"
+                          )}
+                        />
+                        {t("customHeaders")}
+                        {draft.headers.length > 0 ? (
+                          <span className="rounded bg-muted px-1.5 text-[10px] leading-4 text-muted-foreground">
+                            {draft.headers.length}
+                          </span>
+                        ) : null}
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className="space-y-2">
+                        {draft.headers.map((header, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center gap-2"
+                            data-remote-workspace-header-row={index}
+                          >
+                            <Input
+                              className="flex-1"
+                              value={header.name}
+                              placeholder={t("customHeaderName")}
+                              aria-label={t("customHeaderName")}
+                              onChange={(event) =>
+                                updateHeader(index, {
+                                  name: event.target.value,
+                                })
+                              }
+                            />
+                            <Input
+                              className="flex-1"
+                              type="password"
+                              value={header.value}
+                              placeholder={t("customHeaderValue")}
+                              aria-label={t("customHeaderValue")}
+                              onChange={(event) =>
+                                updateHeader(index, {
+                                  value: event.target.value,
+                                })
+                              }
+                            />
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-7 w-7 shrink-0 text-destructive"
+                              aria-label={t("removeCustomHeader")}
+                              title={t("removeCustomHeader")}
+                              onClick={() => removeHeader(index)}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        ))}
+                        <Button size="sm" variant="outline" onClick={addHeader}>
+                          <Plus className="h-3.5 w-3.5" />
+                          {t("addCustomHeader")}
+                        </Button>
+                      </CollapsibleContent>
+                    </Collapsible>
                   </div>
 
                   <div className="space-y-3 border-t px-4 py-3">

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "ترويسات مخصصة",
+    "customHeaderName": "اسم الترويسة",
+    "customHeaderValue": "قيمة الترويسة",
+    "addCustomHeader": "إضافة ترويسة",
+    "removeCustomHeader": "إزالة ترويسة",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "Benutzerdefinierte Header",
+    "customHeaderName": "Header-Name",
+    "customHeaderValue": "Header-Wert",
+    "addCustomHeader": "Header hinzufügen",
+    "removeCustomHeader": "Header entfernen",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -4222,6 +4222,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "Custom headers",
+    "customHeaderName": "Header name",
+    "customHeaderValue": "Header value",
+    "addCustomHeader": "Add header",
+    "removeCustomHeader": "Remove header",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "Encabezados personalizados",
+    "customHeaderName": "Nombre del encabezado",
+    "customHeaderValue": "Valor del encabezado",
+    "addCustomHeader": "Añadir encabezado",
+    "removeCustomHeader": "Eliminar encabezado",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -4210,6 +4210,11 @@
     "name": "Nom",
     "baseUrl": "URL du service",
     "token": "Jeton d’accès",
+    "customHeaders": "En-têtes personnalisés",
+    "customHeaderName": "Nom de l'en-tête",
+    "customHeaderValue": "Valeur de l'en-tête",
+    "addCustomHeader": "Ajouter un en-tête",
+    "removeCustomHeader": "Supprimer l'en-tête",
     "save": "Enregistrer",
     "delete": "Supprimer",
     "confirmDelete": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "カスタムヘッダー",
+    "customHeaderName": "ヘッダー名",
+    "customHeaderValue": "ヘッダーの値",
+    "addCustomHeader": "ヘッダーを追加",
+    "removeCustomHeader": "ヘッダーを削除",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "사용자 지정 헤더",
+    "customHeaderName": "헤더 이름",
+    "customHeaderValue": "헤더 값",
+    "addCustomHeader": "헤더 추가",
+    "removeCustomHeader": "헤더 삭제",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "Cabeçalhos personalizados",
+    "customHeaderName": "Nome do cabeçalho",
+    "customHeaderValue": "Valor do cabeçalho",
+    "addCustomHeader": "Adicionar cabeçalho",
+    "removeCustomHeader": "Remover cabeçalho",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -4222,6 +4222,11 @@
     "name": "名称",
     "baseUrl": "服务地址",
     "token": "访问 Token",
+    "customHeaders": "自定义请求头",
+    "customHeaderName": "请求头名称",
+    "customHeaderValue": "请求头值",
+    "addCustomHeader": "添加请求头",
+    "removeCustomHeader": "删除请求头",
     "save": "保存",
     "delete": "删除",
     "confirmDelete": {

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -4210,6 +4210,11 @@
     "name": "Name",
     "baseUrl": "Service URL",
     "token": "Access token",
+    "customHeaders": "自訂請求標頭",
+    "customHeaderName": "標頭名稱",
+    "customHeaderValue": "標頭值",
+    "addCustomHeader": "新增標頭",
+    "removeCustomHeader": "移除標頭",
     "save": "Save",
     "delete": "Delete",
     "confirmDelete": {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,11 +72,17 @@ export interface AppCommandError {
   i18n_params?: Record<string, string> | null
 }
 
+export interface RemoteWorkspaceHeader {
+  name: string
+  value: string
+}
+
 export interface RemoteWorkspaceConnection {
   id: number
   name: string
   base_url: string
   token: string
+  headers: RemoteWorkspaceHeader[]
   sort_order: number
   created_at: string
   updated_at: string
@@ -86,6 +92,7 @@ export interface RemoteWorkspaceConnectionInput {
   name: string
   baseUrl: string
   token: string
+  headers: RemoteWorkspaceHeader[]
 }
 
 export interface ConversationSummary {


### PR DESCRIPTION
## Why

A user can put a reverse proxy in front of a codeg-server. The proxy can require extra HTTP headers, for example a Cloudflare Access service token. Codeg could not send those headers, so the connection failed.

## What

Each remote workspace connection can now carry custom HTTP headers. The desktop client attaches them to every request it sends to that connection.

The manage dialog gets a "Custom headers" section below the access token. The section stays collapsed unless the connection already has headers. Each row holds a name and a value. Values are masked, because a header usually carries a credential.

<img width="1372" height="972" alt="image" src="https://github.com/user-attachments/assets/af3ba077-017a-423d-bc3a-2795c8a808b4" />

## How

- A new migration adds a `headers` column. It stores a JSON array of `{"name","value"}` objects in a TEXT column, which follows the convention of the other JSON blobs in this schema. Existing rows default to `[]`.
- An array, not a map: HTTP allows a repeated header name, and the array keeps the order the user typed.
- `RemoteWorkspaceHeader` lives in `models/`. It converts to an `http` pair through `to_header_pair`, and a slice of rows converts to a `HeaderMap` through the `ToHeaderMap` trait.
- The service validates each row before it writes: it drops the blank rows the editor leaves, rejects a value with no name, rejects a name or value that `http` cannot parse, and rejects 10 reserved names. The client sets those names itself, so a custom one would break the request. The save fails rather than silently drop what the user typed.
- `commands/remote_proxy.rs` attaches the headers at all five request sites: the HTTP call, the attachment upload, the workspace file upload, the download ticket, and the ticket download. The last one sends no bearer token, because the ticket in the URL is the credential — but a fronting proxy still inspects it, so it needs the headers too.
- The WebSocket handshake carries the same headers.
- The health check sends the headers as well, so the test and the save exercise the same configuration as a later request.

## Tests

Rust, in `remote_workspace_connection_service`:

- `validate_headers_trims_and_drops_empty_rows`
- `validate_headers_keeps_repeated_names_and_order`
- `validate_headers_rejects_reserved_names`
- `validate_headers_rejects_invalid_name_value_and_missing_name`
- `to_header_map_keeps_repeats_and_skips_unparsable_rows`
- `create_list_update_delete_roundtrip`, extended to store and read back the headers

Frontend, in the new `remote-workspace-manage-dialog.test.tsx`:

- `keeps the editor collapsed when the connection has no headers`
- `opens the editor when the connection already has headers`
- `masks every header value`
- `sends the added header on save and drops a removed one`