### PR TITLE
fix(acp): surface live connection status in acp_list_connections

### DIFF
--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -1008,7 +1008,19 @@ impl AgentConnection {
         ConnectionInfo {
             id: self.id.clone(),
             agent_type: self.agent_type,
-            status: self.status.clone(),
+            // `AgentConnection.status` is only stamped at construction
+            // (`Connecting`) and never updated afterwards; the authoritative
+            // status lives in `SessionState`, which `emit_with_state` mutates
+            // on every `StatusChanged`/`SessionStarted` event. Surface the
+            // live status so API consumers (mobile clients, remote UIs) don't
+            // see every connection as "connecting" forever. If the state lock
+            // is momentarily held by a writer, fall back to the stored field
+            // rather than blocking the connection-map read path.
+            status: self
+                .state
+                .try_read()
+                .map(|s| s.status.clone())
+                .unwrap_or_else(|_| self.status.clone()),
         }
     }
 }

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -3458,6 +3458,51 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn list_connections_surfaces_live_session_status() {
+        // Production reality: `AgentConnection.status` is the construction-time
+        // snapshot (`Connecting`) and is never updated; the authoritative status
+        // lives in `SessionState`, mutated by `emit_with_state` on every
+        // `StatusChanged`/`SessionStarted` event. Regression for
+        // `acp_list_connections` reporting every live connection as
+        // "connecting" forever.
+        let mgr = ConnectionManager::new();
+        let (tx, _rx) = mpsc::channel(1);
+        let mut state = SessionState::new(
+            "c-status".to_string(),
+            crate::models::agent::AgentType::ClaudeCode,
+            None,
+            "test-window".to_string(),
+            None,
+        );
+        state.status = ConnectionStatus::Connected; // live status
+        let conn = AgentConnection {
+            id: "c-status".to_string(),
+            agent_type: crate::models::agent::AgentType::ClaudeCode,
+            status: ConnectionStatus::Connecting, // stale construction-time field
+            owner_window_label: "test-window".to_string(),
+            cmd_tx: tx,
+            state: Arc::new(RwLock::new(state)),
+            emitter: EventEmitter::Noop,
+            prompt_lock: Arc::new(tokio::sync::Mutex::new(())),
+            config_fingerprint: String::new(),
+            last_observed_fingerprint: String::new(),
+            child_pid: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        mgr.connections
+            .lock()
+            .await
+            .insert("c-status".to_string(), conn);
+
+        let listed = mgr.list_connections().await;
+        assert_eq!(listed.len(), 1, "one connection listed");
+        assert_eq!(
+            listed[0].status,
+            ConnectionStatus::Connected,
+            "list must report the live session status, not the stale construction-time field"
+        );
+    }
+
     /// Spawn a two-level process tree: `sh` (the stand-in for the agent CLI)
     /// backgrounds a `sleep` grandchild (the stand-in for the agent's own
     /// children — an MCP server, a forked `node`) and records its pid. The


### PR DESCRIPTION
## Problem

`/api/acp_list_connections` reports **every** live connection as `"connecting"` — forever.

`AgentConnection.status` is only stamped at construction (`Connecting`, see `AgentConnection::new`) and is **never updated** afterwards. The authoritative status lives in `SessionState`, which `emit_with_state` mutates on every `StatusChanged` / `SessionStarted` event (`SessionState::apply_event`). `ConnectionInfo::info()` reads the stale construction-time field, so any API consumer sees wrong data:

- a fully-initialized connection (session established, `selectors_ready`, actively streaming turns) still shows `connecting`
- mobile clients / remote UIs that gate on this endpoint can't distinguish a live session from one still starting up
- the pet panel and third-party tooling get a permanently-stale signal

This is easy to miss from the desktop UI because the frontend builds its connection state from attach-protocol snapshots + event streams, not from this endpoint — but the API itself is wrong.

## Fix

`info()` now reads the live status from the session state via `try_read`, falling back to the stored field only when the state lock is momentarily held by a writer (never blocking the connection-map read path).

## Test

Added `list_connections_surfaces_live_session_status`, a regression test that reproduces the production shape: `AgentConnection.status == Connecting` (construction-time) while `SessionState.status == Connected` (live). It fails without the fix (`left: Connecting, right: Connected`) and passes with it.

Verified: `cargo check --lib --no-default-features` and the targeted test pass against current `main`.