### PR TITLE
feat(chat): collapse completed turn progress

### DIFF
--- a/src/components/message/completed-turn-content.test.tsx
+++ b/src/components/message/completed-turn-content.test.tsx
@@ -36,6 +36,11 @@ const COMPLETED_PARTS: AdaptedContentPart[] = [
   { type: "text", text: "The fix is complete." },
 ]
 
+// Expansion is remembered per `parts` array identity (so a virtualizer-
+// recycled row re-mounts open), which makes a shared array a hidden channel
+// between tests. Render tests take a fresh copy.
+const freshCompletedParts = (): AdaptedContentPart[] => [...COMPLETED_PARTS]
+
 describe("splitAssistantTurnParts", () => {
   it("keeps only the trailing final response outside progress", () => {
     const split = splitAssistantTurnParts(COMPLETED_PARTS)
@@ -57,11 +62,59 @@ describe("splitAssistantTurnParts", () => {
   })
 })
 
+describe("CompletedTurnContent with nothing left to show", () => {
+  // A reply that ends on its last tool call has no trailing answer, so
+  // collapsing would leave an empty bubble under a lone "Worked for" chip.
+  // Reachable on every agent (a turn stopped mid-tool-call) and by design on
+  // some: Cline's `attempt_completion` card and a plan-mode turn's
+  // ExitPlanMode card ARE the answer.
+  const TOOL_ONLY_PARTS: AdaptedContentPart[] = [
+    { type: "text", text: "Wrapping up." },
+    {
+      type: "tool-call",
+      toolCallId: "call-final",
+      toolName: "attempt_completion",
+      input: '{"result":"All done."}',
+      state: "output-available",
+      output: null,
+    },
+  ]
+
+  it("stays expanded when the reply ends on progress", () => {
+    renderWithIntl(
+      <CompletedTurnContent
+        parts={TOOL_ONLY_PARTS}
+        durationMs={5_000}
+        completed
+      />
+    )
+
+    expect(screen.queryByText("Worked for 5s")).not.toBeInTheDocument()
+    expect(screen.getByText("Wrapping up.")).toBeInTheDocument()
+    // The completion card renders the result as both its header title and its
+    // body, so match on presence rather than a unique node.
+    expect(screen.getAllByText("All done.").length).toBeGreaterThan(0)
+  })
+
+  it("does not treat a blank trailing text part as the answer", () => {
+    renderWithIntl(
+      <CompletedTurnContent
+        parts={[...TOOL_ONLY_PARTS, { type: "text", text: "   \n" }]}
+        durationMs={5_000}
+        completed
+      />
+    )
+
+    expect(screen.queryByText("Worked for 5s")).not.toBeInTheDocument()
+    expect(screen.getAllByText("All done.").length).toBeGreaterThan(0)
+  })
+})
+
 describe("CompletedTurnContent", () => {
   it("collapses completed progress by default and keeps the answer visible", () => {
     renderWithIntl(
       <CompletedTurnContent
-        parts={COMPLETED_PARTS}
+        parts={freshCompletedParts()}
         durationMs={69_000}
         completed
       />
@@ -83,10 +136,36 @@ describe("CompletedTurnContent", () => {
     expect(screen.getByText("The fix is complete.")).toBeInTheDocument()
   })
 
+  it("re-mounts expanded after the virtualizer recycled the row", () => {
+    // Scrolling a turn past the overscan buffer unmounts it; coming back must
+    // not re-hide work the reader had opened. Same `parts` reference across
+    // both mounts — that is what survives the recycle in the real thread.
+    const parts = freshCompletedParts()
+    const first = renderWithIntl(
+      <CompletedTurnContent parts={parts} durationMs={69_000} completed />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Worked for 1m 9s" }))
+    expect(
+      screen.getByText("I found the relevant component.")
+    ).toBeInTheDocument()
+    first.unmount()
+
+    renderWithIntl(
+      <CompletedTurnContent parts={parts} durationMs={69_000} completed />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Worked for 1m 9s" })
+    ).toHaveAttribute("aria-expanded", "true")
+    expect(
+      screen.getByText("I found the relevant component.")
+    ).toBeInTheDocument()
+  })
+
   it("leaves running progress expanded", () => {
     renderWithIntl(
       <CompletedTurnContent
-        parts={COMPLETED_PARTS}
+        parts={freshCompletedParts()}
         durationMs={69_000}
         completed={false}
       />

--- a/src/components/message/completed-turn-content.test.tsx
+++ b/src/components/message/completed-turn-content.test.tsx
@@ -1,0 +1,104 @@
+import { type ReactElement } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { NextIntlClientProvider } from "next-intl"
+import { describe, expect, it } from "vitest"
+
+import enMessages from "@/i18n/messages/en.json"
+import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+import {
+  CompletedTurnContent,
+  splitAssistantTurnParts,
+} from "./completed-turn-content"
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {ui}
+    </NextIntlClientProvider>
+  )
+}
+
+const COMPLETED_PARTS: AdaptedContentPart[] = [
+  {
+    type: "reasoning",
+    content: "Inspecting the repository",
+    isStreaming: false,
+  },
+  { type: "text", text: "I found the relevant component." },
+  {
+    type: "tool-call",
+    toolCallId: "call-1",
+    toolName: "Read",
+    input: '{"file_path":"src/app.tsx"}',
+    state: "output-available",
+    output: "source",
+  },
+  { type: "text", text: "The fix is complete." },
+]
+
+describe("splitAssistantTurnParts", () => {
+  it("keeps only the trailing final response outside progress", () => {
+    const split = splitAssistantTurnParts(COMPLETED_PARTS)
+
+    expect(split.progress).toEqual(COMPLETED_PARTS.slice(0, 3))
+    expect(split.answer).toEqual(COMPLETED_PARTS.slice(3))
+  })
+
+  it("does not guess within a text-only answer", () => {
+    const parts: AdaptedContentPart[] = [
+      { type: "text", text: "First paragraph" },
+      { type: "text", text: "Second paragraph" },
+    ]
+
+    expect(splitAssistantTurnParts(parts)).toEqual({
+      progress: [],
+      answer: parts,
+    })
+  })
+})
+
+describe("CompletedTurnContent", () => {
+  it("collapses completed progress by default and keeps the answer visible", () => {
+    renderWithIntl(
+      <CompletedTurnContent
+        parts={COMPLETED_PARTS}
+        durationMs={69_000}
+        completed
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: "Worked for 1m 9s" })
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(screen.getByText("The fix is complete.")).toBeInTheDocument()
+    expect(
+      screen.queryByText("I found the relevant component.")
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(trigger)
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+    expect(
+      screen.getByText("I found the relevant component.")
+    ).toBeInTheDocument()
+    expect(screen.getByText("The fix is complete.")).toBeInTheDocument()
+  })
+
+  it("leaves running progress expanded", () => {
+    renderWithIntl(
+      <CompletedTurnContent
+        parts={COMPLETED_PARTS}
+        durationMs={69_000}
+        completed={false}
+      />
+    )
+
+    expect(screen.queryByText("Worked for 1m 9s")).not.toBeInTheDocument()
+    expect(
+      screen.getByText("I found the relevant component.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /Read src\/app\.tsx/ })
+    ).toBeInTheDocument()
+    expect(screen.getByText("The fix is complete.")).toBeInTheDocument()
+  })
+})

--- a/src/components/message/completed-turn-content.tsx
+++ b/src/components/message/completed-turn-content.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { memo, useMemo } from "react"
+import { ChevronRightIcon } from "lucide-react"
+import { useTranslations } from "next-intl"
+
+import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+import { formatElapsedLabel } from "@/lib/format-elapsed"
+import { cn } from "@/lib/utils"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/instant-collapsible"
+import { ContentPartsRenderer } from "./content-parts-renderer"
+
+export interface SplitAssistantTurnParts {
+  progress: AdaptedContentPart[]
+  answer: AdaptedContentPart[]
+}
+
+function isProgressPart(part: AdaptedContentPart): boolean {
+  switch (part.type) {
+    case "reasoning":
+    case "tool-call":
+    case "tool-result":
+    case "tool-group":
+    case "delegation-status-group":
+    case "background-task-group":
+    case "goal-run":
+    case "plan":
+      return true
+    case "text":
+    case "proposed-plan":
+    case "generated-image":
+      return false
+  }
+}
+
+/**
+ * Split a completed assistant reply at its last progress item. Text before or
+ * between tool/reasoning work is intermediate commentary; trailing response
+ * content is the final answer and must remain visible. A text-only response is
+ * left untouched because there is no reliable signal that any of it is
+ * progress rather than the answer.
+ */
+export function splitAssistantTurnParts(
+  parts: AdaptedContentPart[]
+): SplitAssistantTurnParts {
+  let lastProgressIndex = -1
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    if (isProgressPart(parts[i])) {
+      lastProgressIndex = i
+      break
+    }
+  }
+
+  if (lastProgressIndex < 0) {
+    return { progress: [], answer: parts }
+  }
+
+  return {
+    progress: parts.slice(0, lastProgressIndex + 1),
+    answer: parts.slice(lastProgressIndex + 1),
+  }
+}
+
+export const CompletedTurnContent = memo(function CompletedTurnContent({
+  parts,
+  durationMs,
+  completed,
+}: {
+  parts: AdaptedContentPart[]
+  durationMs?: number | null
+  completed: boolean
+}) {
+  const t = useTranslations("Folder.chat.messageList")
+  const tElapsed = useTranslations("Folder.chat.liveTurnStats")
+  const split = useMemo(() => splitAssistantTurnParts(parts), [parts])
+
+  if (!completed || split.progress.length === 0) {
+    return <ContentPartsRenderer parts={parts} role="assistant" />
+  }
+
+  const duration =
+    typeof durationMs === "number" && durationMs > 0
+      ? formatElapsedLabel(durationMs, tElapsed)
+      : null
+  const summary = duration ? t("workedFor", { duration }) : t("worked")
+
+  return (
+    <div className="space-y-4">
+      <Collapsible className="w-full">
+        <CollapsibleTrigger className="group inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+          <ChevronRightIcon
+            aria-hidden="true"
+            className="size-3 shrink-0 opacity-60 transition-transform group-data-[state=open]:rotate-90"
+          />
+          <span className="tabular-nums">{summary}</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent
+          className={cn(
+            "w-full outline-none",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+          )}
+        >
+          <div className="mt-3 border-s border-border/70 ps-3">
+            <ContentPartsRenderer parts={split.progress} role="assistant" />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+      {split.answer.length > 0 ? (
+        <ContentPartsRenderer parts={split.answer} role="assistant" />
+      ) : null}
+    </div>
+  )
+})

--- a/src/components/message/completed-turn-content.tsx
+++ b/src/components/message/completed-turn-content.tsx
@@ -1,10 +1,13 @@
 "use client"
 
-import { memo, useMemo } from "react"
+import { memo, useCallback, useMemo, useState } from "react"
 import { ChevronRightIcon } from "lucide-react"
 import { useTranslations } from "next-intl"
 
-import type { AdaptedContentPart } from "@/lib/adapters/ai-elements-adapter"
+import {
+  splitTrailingAnswerParts,
+  type AdaptedContentPart,
+} from "@/lib/adapters/ai-elements-adapter"
 import { formatElapsedLabel } from "@/lib/format-elapsed"
 import { cn } from "@/lib/utils"
 import {
@@ -19,51 +22,48 @@ export interface SplitAssistantTurnParts {
   answer: AdaptedContentPart[]
 }
 
-function isProgressPart(part: AdaptedContentPart): boolean {
-  switch (part.type) {
-    case "reasoning":
-    case "tool-call":
-    case "tool-result":
-    case "tool-group":
-    case "delegation-status-group":
-    case "background-task-group":
-    case "goal-run":
-    case "plan":
-      return true
-    case "text":
-    case "proposed-plan":
-    case "generated-image":
-      return false
-  }
-}
-
 /**
  * Split a completed assistant reply at its last progress item. Text before or
  * between tool/reasoning work is intermediate commentary; trailing response
  * content is the final answer and must remain visible. A text-only response is
  * left untouched because there is no reliable signal that any of it is
  * progress rather than the answer.
+ *
+ * The progress/answer taxonomy is the adapter's (`isTurnAnswerPart`), shared
+ * with the Goal capsule's trailing-answer lift — the same question ("what may
+ * a collapsed chip swallow?") must not get two answers.
  */
 export function splitAssistantTurnParts(
   parts: AdaptedContentPart[]
 ): SplitAssistantTurnParts {
-  let lastProgressIndex = -1
-  for (let i = parts.length - 1; i >= 0; i -= 1) {
-    if (isProgressPart(parts[i])) {
-      lastProgressIndex = i
-      break
-    }
-  }
-
-  if (lastProgressIndex < 0) {
-    return { progress: [], answer: parts }
-  }
-
-  return {
-    progress: parts.slice(0, lastProgressIndex + 1),
-    answer: parts.slice(lastProgressIndex + 1),
-  }
+  const { body, trailing } = splitTrailingAnswerParts(parts)
+  return { progress: body, answer: trailing }
 }
+
+/**
+ * Does the split leave anything for the reader once the progress is folded
+ * away? Whitespace-only text is not an answer: it renders as an empty markdown
+ * block, so a turn "kept visible" by it still reads as a blank reply.
+ */
+function hasVisibleAnswer(answer: AdaptedContentPart[]): boolean {
+  return answer.some(
+    (part) => part.type !== "text" || part.text.trim().length > 0
+  )
+}
+
+/**
+ * Which turns the reader has opened, keyed by the group's `parts` array. The
+ * thread is virtualized: scrolling a turn past the overscan buffer unmounts it,
+ * and an uncontrolled Collapsible would forget the expansion — so scrolling
+ * away from a turn you opened and back re-hides its work. `parts` is the right
+ * key because it is exactly as stable as the turn's identity (it comes from the
+ * per-turn adapter cache and the merged-run cache in `message-list-view`), and
+ * being weak it is collected with the turn rather than accumulating per
+ * conversation. Re-adapted content (a streaming turn settling, a merged run
+ * gaining a member) yields a new array and starts collapsed, which is the
+ * intent.
+ */
+const expandedTurns = new WeakMap<AdaptedContentPart[], boolean>()
 
 export const CompletedTurnContent = memo(function CompletedTurnContent({
   parts,
@@ -77,8 +77,28 @@ export const CompletedTurnContent = memo(function CompletedTurnContent({
   const t = useTranslations("Folder.chat.messageList")
   const tElapsed = useTranslations("Folder.chat.liveTurnStats")
   const split = useMemo(() => splitAssistantTurnParts(parts), [parts])
+  const [open, setOpen] = useState(() => expandedTurns.get(parts) ?? false)
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      expandedTurns.set(parts, next)
+      setOpen(next)
+    },
+    [parts]
+  )
 
-  if (!completed || split.progress.length === 0) {
+  // Collapsing trades the process away to keep the answer. With no answer left
+  // over there is nothing to keep, and the reply renders as an empty bubble
+  // carrying a lone "Worked for …" chip — which is exactly the shape of the
+  // turns a reader most needs to see: one stopped mid-tool-call (agents leave
+  // no closing prose), a Cline reply whose `attempt_completion` card IS the
+  // answer, a plan-mode turn that ends on ExitPlanMode with the plan inside
+  // that card. Leave those expanded rather than hide a whole turn behind a
+  // chevron.
+  if (
+    !completed ||
+    split.progress.length === 0 ||
+    !hasVisibleAnswer(split.answer)
+  ) {
     return <ContentPartsRenderer parts={parts} role="assistant" />
   }
 
@@ -90,7 +110,11 @@ export const CompletedTurnContent = memo(function CompletedTurnContent({
 
   return (
     <div className="space-y-4">
-      <Collapsible className="w-full">
+      <Collapsible
+        className="w-full"
+        open={open}
+        onOpenChange={handleOpenChange}
+      >
         <CollapsibleTrigger className="group inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
           <ChevronRightIcon
             aria-hidden="true"
@@ -110,9 +134,8 @@ export const CompletedTurnContent = memo(function CompletedTurnContent({
           </div>
         </CollapsibleContent>
       </Collapsible>
-      {split.answer.length > 0 ? (
-        <ContentPartsRenderer parts={split.answer} role="assistant" />
-      ) : null}
+      {/* Non-empty by construction: the no-answer case returned above. */}
+      <ContentPartsRenderer parts={split.answer} role="assistant" />
     </div>
   )
 })

--- a/src/components/message/message-list-view.test.tsx
+++ b/src/components/message/message-list-view.test.tsx
@@ -32,6 +32,7 @@ function assistantItem(
       ...groupOverrides,
     },
     phase: "persisted",
+    isResponseComplete: true,
     showStats: false,
     isRoleTransition: false,
     previousUserIndex: null,
@@ -131,6 +132,7 @@ function makeItem(
     kind: "turn",
     group,
     phase,
+    isResponseComplete: phase === "persisted",
     showStats: false,
     isRoleTransition: false,
     previousUserIndex: null,
@@ -208,6 +210,25 @@ describe("mergeConsecutiveAssistantTurns merged-run cache", () => {
 
     expect(out2[0]).not.toBe(out1[0])
     expect(out2[2]).toBe(out1[2])
+  })
+
+  it("rebuilds when a persisted run changes from in-flight to completed", () => {
+    const cache: MergedAssistantRunCache = new WeakMap()
+    const g1 = makeGroup("assistant", "a1")
+    const g2 = makeGroup("assistant", "a2")
+    const firstItems = [makeItem(g1, 0), makeItem(g2, 1)]
+    if (firstItems[1].kind !== "turn") throw new Error("expected turn")
+    firstItems[1].isResponseComplete = false
+
+    const out1 = mergeConsecutiveAssistantTurns(firstItems, cache)
+    const out2 = mergeConsecutiveAssistantTurns(
+      [makeItem(g1, 0), makeItem(g2, 1)],
+      cache
+    )
+
+    expect(out2[0]).not.toBe(out1[0])
+    if (out2[0].kind !== "turn") throw new Error("expected turn")
+    expect(out2[0].isResponseComplete).toBe(true)
   })
 
   it("misses when the run gains a member, then caches the new membership", () => {

--- a/src/components/message/message-list-view.tsx
+++ b/src/components/message/message-list-view.tsx
@@ -7,7 +7,7 @@ import {
   useConversationRuntimeStore,
 } from "@/stores/conversation-runtime-store"
 import { isWindowedDetail } from "@/lib/turn-window"
-import { ContentPartsRenderer } from "./content-parts-renderer"
+import { CompletedTurnContent } from "./completed-turn-content"
 import { ContextCompactionCard } from "./context-compaction-card"
 import { CollapsibleUserMessage } from "./collapsible-user-message"
 import { CollapsibleSystemMessage } from "./collapsible-system-message"
@@ -145,6 +145,7 @@ export type ThreadRenderItem =
       kind: "turn"
       group: ResolvedMessageGroup
       phase: "persisted" | "optimistic" | "streaming"
+      isResponseComplete: boolean
       showStats: boolean
       isRoleTransition: boolean
       previousUserIndex: number | null
@@ -264,6 +265,7 @@ type AssistantTurnItem = Extract<ThreadRenderItem, { kind: "turn" }>
 export interface MergedAssistantRunCacheEntry {
   memberGroups: ResolvedMessageGroup[]
   memberKeys: string[]
+  memberCompletion: boolean[]
   item: AssistantTurnItem
 }
 export type MergedAssistantRunCache = WeakMap<
@@ -331,7 +333,8 @@ export function mergeConsecutiveAssistantTurns(
     for (let i = 0; i < buffer.length; i++) {
       if (
         buffer[i].group !== cached.memberGroups[i] ||
-        buffer[i].key !== cached.memberKeys[i]
+        buffer[i].key !== cached.memberKeys[i] ||
+        buffer[i].isResponseComplete !== cached.memberCompletion[i]
       ) {
         return false
       }
@@ -418,6 +421,7 @@ export function mergeConsecutiveAssistantTurns(
       const merged: AssistantTurnItem = {
         ...last,
         key: `merged-${first.key}`,
+        isResponseComplete: buffer.every((it) => it.isResponseComplete),
         // Concatenate every sub-turn's raw turns so the artifacts card sees all
         // file edits across the merged reply, not just the last sub-turn.
         sourceTurns: buffer.flatMap((b) => b.sourceTurns),
@@ -436,6 +440,7 @@ export function mergeConsecutiveAssistantTurns(
       mergeCache?.set(first.group, {
         memberGroups: buffer.map((it) => it.group),
         memberKeys: buffer.map((it) => it.key),
+        memberCompletion: buffer.map((it) => it.isResponseComplete),
         item: merged,
       })
     }
@@ -573,7 +578,11 @@ const HistoricalMessageGroup = memo(function HistoricalMessageGroup({
           </div>
         ) : (
           <MessageContent>
-            <ContentPartsRenderer parts={group.parts} role={group.role} />
+            <CompletedTurnContent
+              parts={group.parts}
+              durationMs={group.duration_ms}
+              completed={isResponseComplete}
+            />
           </MessageContent>
         )}
         {group.role === "user" && group.resources.length > 0 ? (
@@ -719,6 +728,14 @@ export function MessageListView({
 
   const { threadItems, nonStreamingAdapted } = useMemo(() => {
     const allTurns = timelineTurns.map((item) => item.turn)
+    const inFlightUserTurnId = detail?.in_flight_user_turn_id ?? null
+    const inFlightUserTurnIndex =
+      inFlightUserTurnId === null
+        ? -1
+        : timelineTurns.findIndex(
+            (item) =>
+              item.turn.role === "user" && item.turn.id === inFlightUserTurnId
+          )
     const streamingIndices = new Set<number>()
     const inProgressToolCallIdsByIndex = new Map<number, Set<string>>()
     timelineTurns.forEach((item, i) => {
@@ -786,6 +803,12 @@ export function MessageListView({
         kind: "turn" as const,
         group,
         phase,
+        // Persisted does not always mean completed: passive viewers can read
+        // transcript blocks written after the backend's authoritative
+        // in-flight user-turn marker without owning the live stream.
+        isResponseComplete:
+          phase === "persisted" &&
+          (inFlightUserTurnIndex < 0 || i <= inFlightUserTurnIndex),
         showStats: false,
         isRoleTransition: false,
         previousUserIndex: null,
@@ -850,6 +873,7 @@ export function MessageListView({
     turnAdapter,
     groupCache,
     mergedRunCache,
+    detail?.in_flight_user_turn_id,
   ])
 
   const historicalPlanEntries = useMemo(
@@ -886,7 +910,7 @@ export function MessageListView({
                 dimmed={item.phase === "optimistic"}
                 showStats={item.showStats}
                 previousUserIndex={item.previousUserIndex}
-                isResponseComplete={item.phase === "persisted"}
+                isResponseComplete={item.isResponseComplete}
                 sourceTurns={item.sourceTurns}
               />
             </div>

--- a/src/components/message/message-list-view.tsx
+++ b/src/components/message/message-list-view.tsx
@@ -728,14 +728,6 @@ export function MessageListView({
 
   const { threadItems, nonStreamingAdapted } = useMemo(() => {
     const allTurns = timelineTurns.map((item) => item.turn)
-    const inFlightUserTurnId = detail?.in_flight_user_turn_id ?? null
-    const inFlightUserTurnIndex =
-      inFlightUserTurnId === null
-        ? -1
-        : timelineTurns.findIndex(
-            (item) =>
-              item.turn.role === "user" && item.turn.id === inFlightUserTurnId
-          )
     const streamingIndices = new Set<number>()
     const inProgressToolCallIdsByIndex = new Map<number, Set<string>>()
     timelineTurns.forEach((item, i) => {
@@ -803,12 +795,13 @@ export function MessageListView({
         kind: "turn" as const,
         group,
         phase,
-        // Persisted does not always mean completed: passive viewers can read
-        // transcript blocks written after the backend's authoritative
-        // in-flight user-turn marker without owning the live stream.
+        // Persisted does not always mean completed: a passive viewer reads
+        // transcript blocks the agent is still writing. The store flags exactly
+        // those DB records (`isInFlightRound`); reading the raw
+        // `in_flight_user_turn_id` here instead would also catch locally
+        // promoted — i.e. finished — replies, which the marker outlives.
         isResponseComplete:
-          phase === "persisted" &&
-          (inFlightUserTurnIndex < 0 || i <= inFlightUserTurnIndex),
+          phase === "persisted" && !timelineTurns[i].isInFlightRound,
         showStats: false,
         isRoleTransition: false,
         previousUserIndex: null,
@@ -873,7 +866,6 @@ export function MessageListView({
     turnAdapter,
     groupCache,
     mergedRunCache,
-    detail?.in_flight_user_turn_id,
   ])
 
   const historicalPlanEntries = useMemo(

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "قراءة التخزين المؤقت",
         "tokenCacheWrite": "كتابة التخزين المؤقت",
         "duration": "المدة",
+        "worked": "تم العمل",
+        "workedFor": "عمل لمدة {duration}",
         "completedAt": "وقت الإنجاز",
         "jumpToPreviousUserMessage": "الانتقال إلى رسالة المستخدم",
         "showMore": "عرض المزيد",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "Cache-Lesen",
         "tokenCacheWrite": "Cache-Schreiben",
         "duration": "Dauer",
+        "worked": "Gearbeitet",
+        "workedFor": "{duration} gearbeitet",
         "completedAt": "Abgeschlossen um",
         "jumpToPreviousUserMessage": "Zur Benutzernachricht springen",
         "showMore": "Mehr anzeigen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "Cache read",
         "tokenCacheWrite": "Cache write",
         "duration": "Duration",
+        "worked": "Worked",
+        "workedFor": "Worked for {duration}",
         "completedAt": "Completed at",
         "jumpToPreviousUserMessage": "Jump to user message",
         "showMore": "Show more",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "Lectura de caché",
         "tokenCacheWrite": "Escritura de caché",
         "duration": "Duración",
+        "worked": "Trabajo realizado",
+        "workedFor": "Trabajo realizado durante {duration}",
         "completedAt": "Completado a las",
         "jumpToPreviousUserMessage": "Ir al mensaje del usuario",
         "showMore": "Mostrar más",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "Lecture du cache",
         "tokenCacheWrite": "Écriture du cache",
         "duration": "Durée",
+        "worked": "Travail effectué",
+        "workedFor": "Travail effectué pendant {duration}",
         "completedAt": "Terminé à",
         "jumpToPreviousUserMessage": "Aller au message utilisateur",
         "showMore": "Afficher plus",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "キャッシュ読取",
         "tokenCacheWrite": "キャッシュ書込",
         "duration": "所要時間",
+        "worked": "作業しました",
+        "workedFor": "{duration} 作業しました",
         "completedAt": "完了時刻",
         "jumpToPreviousUserMessage": "前のユーザーメッセージへ",
         "showMore": "もっと見る",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "캐시 읽기",
         "tokenCacheWrite": "캐시 쓰기",
         "duration": "소요 시간",
+        "worked": "작업함",
+        "workedFor": "{duration} 동안 작업함",
         "completedAt": "완료 시각",
         "jumpToPreviousUserMessage": "이전 사용자 메시지로 이동",
         "showMore": "더보기",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "Leitura de cache",
         "tokenCacheWrite": "Escrita de cache",
         "duration": "Duração",
+        "worked": "Trabalho realizado",
+        "workedFor": "Trabalhou por {duration}",
         "completedAt": "Concluído às",
         "jumpToPreviousUserMessage": "Ir para a mensagem do usuário",
         "showMore": "Mostrar mais",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "缓存读取",
         "tokenCacheWrite": "缓存写入",
         "duration": "耗时",
+        "worked": "已工作",
+        "workedFor": "工作了 {duration}",
         "completedAt": "完成时间",
         "jumpToPreviousUserMessage": "跳转到上一条用户消息",
         "showMore": "展开",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -3067,6 +3067,8 @@
         "tokenCacheRead": "快取讀取",
         "tokenCacheWrite": "快取寫入",
         "duration": "耗時",
+        "worked": "已工作",
+        "workedFor": "工作了 {duration}",
         "completedAt": "完成時間",
         "jumpToPreviousUserMessage": "跳轉到上一條使用者訊息",
         "showMore": "展開",

--- a/src/lib/adapters/ai-elements-adapter.ts
+++ b/src/lib/adapters/ai-elements-adapter.ts
@@ -1578,23 +1578,47 @@ function mergeGoalObjectiveHints(
  * prose, the codex Plan-mode document the user has to read, and a generated
  * image. Everything else (tool calls/results/groups, reasoning, todo plans,
  * delegation and background-task polls) is process and belongs in the capsule.
+ *
+ * Written as an exhaustive switch rather than a type set on purpose: a new
+ * `AdaptedContentPart` variant then fails to compile here until it is
+ * classified, so the Goal capsule and the completed-turn collapse (which both
+ * hide process behind a chip) can never silently disagree about what an answer
+ * is.
  */
-const GOAL_ANSWER_PART_TYPES: ReadonlySet<AdaptedContentPart["type"]> = new Set(
-  ["text", "proposed-plan", "generated-image"]
-)
+export function isTurnAnswerPart(part: AdaptedContentPart): boolean {
+  switch (part.type) {
+    case "text":
+    case "proposed-plan":
+    case "generated-image":
+      return true
+    case "reasoning":
+    case "tool-call":
+    case "tool-result":
+    case "tool-group":
+    case "delegation-status-group":
+    case "background-task-group":
+    case "goal-run":
+    case "plan":
+      return false
+  }
+}
 
 /**
- * Split a settled unfinished run's body at the last process part: everything
- * after it is the answer and gets lifted out, in order. Answer parts BEFORE a
- * process part stay inside — prose followed by more work is a mid-run note,
+ * Split a reply (or a settled unfinished goal run's body) at its last process
+ * part: everything after it is the answer, in order. Answer parts BEFORE a
+ * process part stay in `body` — prose followed by more work is a mid-run note,
  * not a wrap-up, and lifting it would reorder the reply.
+ *
+ * Two consumers: `groupGoalRuns` lifts `trailing` out of a settled capsule, and
+ * the completed-turn collapse keeps `trailing` visible while folding `body`
+ * behind the "Worked for …" trigger.
  */
-function splitTrailingAnswerParts(items: AdaptedContentPart[]): {
+export function splitTrailingAnswerParts(items: AdaptedContentPart[]): {
   body: AdaptedContentPart[]
   trailing: AdaptedContentPart[]
 } {
   let end = items.length
-  while (end > 0 && GOAL_ANSWER_PART_TYPES.has(items[end - 1]!.type)) {
+  while (end > 0 && isTurnAnswerPart(items[end - 1]!)) {
     end -= 1
   }
   if (end === items.length) {

--- a/src/stores/conversation-runtime-store.ts
+++ b/src/stores/conversation-runtime-store.ts
@@ -66,6 +66,23 @@ export interface ConversationTimelineTurn {
   // Tool call IDs whose results are still streaming (only set for streaming-phase items).
   // The adapter uses this to keep the tool in "running" state while exposing partial output.
   inProgressToolCallIds?: Set<string>
+  /**
+   * This is a DB-persisted record of the round the backend says is STILL
+   * RUNNING (it follows `detail.in_flight_user_turn_id`), so its "persisted"
+   * phase does NOT mean finished — a passive viewer reads these blocks as the
+   * agent writes them. Consumers that treat persisted as complete (the
+   * completed-turn collapse, the per-reply stats row and artifacts card) must
+   * check this too.
+   *
+   * Only ever set on turns projected from `detail.turns`. A locally promoted
+   * turn is complete by construction (`COMPLETE_TURN` fires at TurnComplete),
+   * and the marker in `detail` can outlive that completion indefinitely —
+   * `completeTurn` deliberately never refetches, and the live-transcript viewer
+   * has no settle-time refetch — so deriving this from the raw marker over the
+   * whole timeline would strand a finished reply as "running" for the life of
+   * the view.
+   */
+  isInFlightRound?: boolean
 }
 
 /**
@@ -2698,20 +2715,16 @@ function timelinePrefixDepsEqual(
  * precisely the ones the adapter would otherwise paint as settled. Blocks
  * without a `tool_use_id` are skipped: the adapter can't key them either.
  *
- * Returns an empty map when the backend reports no in-flight turn, or when the
- * prompt it named isn't in this window (older history page) — the caller then
- * behaves exactly as before.
+ * `promptIdx` is the in-flight prompt's index in `turns`, or -1 when the backend
+ * reports no in-flight turn or named a prompt outside this window (older
+ * history page); the map is then empty and the caller behaves exactly as before.
  */
 function collectInFlightPersistedToolCalls(
   turns: MessageTurn[],
-  inFlightPromptId: string | null
+  promptIdx: number
 ): Map<number, Set<string>> {
   const out = new Map<number, Set<string>>()
-  if (inFlightPromptId === null) return out
-  const promptIdx = turns.findIndex(
-    (t) => t.role === "user" && t.id === inFlightPromptId
-  )
-  if (promptIdx === -1) return out
+  if (promptIdx < 0) return out
   for (let i = promptIdx + 1; i < turns.length; i++) {
     const turn = turns[i]
     if (turn.role !== "assistant") continue
@@ -2850,9 +2863,19 @@ function computeTimelinePrefix(
   // codex code-mode script that never `text()`s its call settles with none.
   // Scoping to turns AFTER that prompt is what keeps an orphan left by an
   // earlier interrupted round from re-acquiring a spinner it will never lose.
+  // Where the still-running round starts inside the persisted projection. -1
+  // when the backend reports no in-flight prompt, or names one this window
+  // doesn't contain — the whole projection then reads as settled history.
+  const inFlightRoundStart =
+    inFlightPromptId === null
+      ? -1
+      : visiblePersistedTurns.findIndex(
+          (t) => t.role === "user" && t.id === inFlightPromptId
+        )
+
   const inFlightToolCallIdsByIndex = collectInFlightPersistedToolCalls(
     visiblePersistedTurns,
-    inFlightPromptId
+    inFlightRoundStart
   )
 
   // Keys carry NO positional index: prepending older history (reverse
@@ -2865,6 +2888,7 @@ function computeTimelinePrefix(
       turn,
       phase: "persisted" as const,
       inProgressToolCallIds: inFlightToolCallIdsByIndex.get(i),
+      isInFlightRound: inFlightRoundStart >= 0 && i > inFlightRoundStart,
     })
   )
 

--- a/src/stores/runtime-inflight-persisted-tool-calls.test.ts
+++ b/src/stores/runtime-inflight-persisted-tool-calls.test.ts
@@ -13,6 +13,10 @@
  * The store marks those calls from the backend's `in_flight_user_turn_id` — an
  * affirmative "a turn is running on this connection", never an inference from
  * missing output (an empty result still writes a `tool_result`).
+ *
+ * The same marker also flags the turns themselves (`isInFlightRound`), which is
+ * what tells the render layer that a "persisted" reply is not finished. That
+ * flag is scoped to the DB projection on purpose — see the tests at the bottom.
  */
 
 import { afterEach, describe, expect, it } from "vitest"
@@ -90,7 +94,11 @@ function makeDetail(
   }
 }
 
-function seedSession(detail: DbConversationDetail, liveMessage?: LiveMessage) {
+function seedSession(
+  detail: DbConversationDetail,
+  liveMessage?: LiveMessage,
+  localTurns: MessageTurn[] = []
+) {
   const session = {
     conversationId: CID,
     externalId: null,
@@ -99,7 +107,7 @@ function seedSession(detail: DbConversationDetail, liveMessage?: LiveMessage) {
     detailLoading: false,
     detailError: null,
     acpLoadError: null,
-    localTurns: [],
+    localTurns,
     backgroundTurns: [],
     pendingBackgroundSettlements: [],
     optimisticTurns: [],
@@ -120,6 +128,12 @@ function seedSession(detail: DbConversationDetail, liveMessage?: LiveMessage) {
   const next = new Map(useConversationRuntimeStore.getState().byConversationId)
   next.set(CID, session)
   useConversationRuntimeStore.setState({ byConversationId: next })
+}
+
+/** The in-flight-round flag the store attached to the turn with the given id. */
+function inFlightRoundOf(turnId: string): boolean | undefined {
+  return getTimelineTurns(CID).find((t) => t.turn.id === turnId)
+    ?.isInFlightRound
 }
 
 /** The set the store attached to the persisted turn with the given id. */
@@ -215,5 +229,51 @@ describe("in-flight tool calls inside a persisted transcript", () => {
       )
     )
     expect(inProgressOf("a1")).toBeUndefined()
+  })
+})
+
+describe("isInFlightRound", () => {
+  it("flags the persisted reply of the round the backend says is running", () => {
+    seedSession(
+      makeDetail([userTurn("u1"), assistantTurn("a1", [poll("t1")])], "u1")
+    )
+    expect(inFlightRoundOf("u1")).toBe(false)
+    expect(inFlightRoundOf("a1")).toBe(true)
+  })
+
+  it("leaves an earlier settled round alone", () => {
+    seedSession(
+      makeDetail(
+        [
+          userTurn("u1"),
+          assistantTurn("a1", [poll("t1"), pollResult("t1")]),
+          userTurn("u2"),
+          assistantTurn("a2", [poll("t2")]),
+        ],
+        "u2"
+      )
+    )
+    expect(inFlightRoundOf("a1")).toBe(false)
+    expect(inFlightRoundOf("a2")).toBe(true)
+  })
+
+  it("flags nothing when the named prompt is outside the loaded window", () => {
+    seedSession(makeDetail([assistantTurn("a1", [poll("t1")])], "u-not-here"))
+    expect(inFlightRoundOf("a1")).toBe(false)
+  })
+
+  it("never flags a locally promoted reply, however stale the marker", () => {
+    // `completeTurn` promotes the finished reply into localTurns and
+    // deliberately does NOT refetch, and the live-transcript viewer has no
+    // settle-time refetch — so `detail` can keep naming `u1` as in flight for
+    // the whole life of the view. Deriving the flag from the raw marker over
+    // the assembled timeline (rather than over the DB projection) would leave
+    // this finished reply "running" forever: never collapsing its progress and
+    // permanently hiding its stats row and artifacts card.
+    seedSession(makeDetail([userTurn("u1")], "u1"), undefined, [
+      assistantTurn("local-a1", [poll("t1"), pollResult("t1")]),
+    ])
+    expect(inFlightRoundOf("u1")).toBe(false)
+    expect(inFlightRoundOf("local-a1")).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Collapse completed reasoning, tool calls, plans, and progress commentary behind a localized Worked for trigger.
- Keep the final response visible, while streaming and server-marked in-flight turns stay expanded.
- Invalidate merged-turn caches when completion changes and add localized interaction and regression coverage.

## Design boundary

- The last explicit progress part defines the boundary; trailing text, proposed plans, and generated images stay visible.
- Text-only replies are never guessed at or collapsed. Turns without a valid duration use the localized Worked label.

## Testing

- pnpm exec vitest run src/components/message/completed-turn-content.test.tsx src/components/message/message-list-view.test.tsx src/i18n/messages.test.ts
- pnpm exec tsc --noEmit
- targeted ESLint for changed TypeScript files
- pnpm eslint .
- pnpm build
- git diff --check

Closes #578