### PR TITLE
fix(claude): coalesce adjacent thinking fragments

### DIFF
--- a/src-tauri/src/acp/session_state.rs
+++ b/src-tauri/src/acp/session_state.rs
@@ -1437,6 +1437,21 @@ impl SessionState {
     }
 
     fn append_text_delta(&mut self, text: &str, parent_tool_use_id: Option<&str>) {
+        // An empty text delta has nothing to render, so the only thing it could
+        // contribute is a block boundary — and the frontend reducer never
+        // creates one (it drops an empty `CONTENT_DELTA` outright, before it
+        // would even open a live message). Dropping it here too is what keeps
+        // the two block lists identical; otherwise a snapshot-hydrated client
+        // carries an empty `Text` block that the streaming client never had,
+        // and prose either side of it looks like two separate runs.
+        //
+        // Empty THINKING deltas are deliberately NOT dropped: there the empty
+        // block IS the signal (it renders the "Thinking…" indicator before any
+        // reasoning text arrives, and newer Claude models redact the text
+        // entirely while still emitting the block).
+        if text.is_empty() {
+            return;
+        }
         let live = self.ensure_live_message();
         // Merge only into a trailing block of the same kind AND the same
         // subagent attribution — main text → subagent text → main text must
@@ -2692,6 +2707,49 @@ mod tests {
             }
             other => panic!("expected parented text block, got {other:?}"),
         }
+    }
+
+    /// The frontend reducer drops an empty `CONTENT_DELTA` outright, so a
+    /// streaming client never sees an empty `Text` block. If this side kept
+    /// one, a snapshot-hydrated client would get an extra block the streaming
+    /// one lacks — and prose either side of it would render as two runs
+    /// instead of one (#494 on the snapshot path only).
+    #[test]
+    fn empty_text_delta_adds_no_block_and_never_splits_a_run() {
+        let mut s = fresh_state();
+        s.status = ConnectionStatus::Prompting;
+        s.apply_event(&AcpEvent::Thinking {
+            text: "before".into(),
+            parent_tool_use_id: None,
+        });
+        s.apply_event(&AcpEvent::ContentDelta {
+            text: String::new(),
+            parent_tool_use_id: None,
+        });
+        s.apply_event(&AcpEvent::Thinking {
+            text: " after".into(),
+            parent_tool_use_id: None,
+        });
+        let live = s.live_message.as_ref().expect("live message");
+        assert_eq!(live.content.len(), 1, "no empty Text block was inserted");
+        assert!(
+            matches!(&live.content[0], LiveContentBlock::Thinking { text, .. } if text == "before after"),
+            "the thinking run stayed one block, got {:?}",
+            live.content[0]
+        );
+    }
+
+    /// …and it must not open a live message either — same as the reducer,
+    /// which returns before `ensureLiveMessage`.
+    #[test]
+    fn empty_text_delta_does_not_open_a_live_message() {
+        let mut s = fresh_state();
+        s.status = ConnectionStatus::Prompting;
+        s.apply_event(&AcpEvent::ContentDelta {
+            text: String::new(),
+            parent_tool_use_id: None,
+        });
+        assert!(s.live_message.is_none());
     }
 
     #[test]

--- a/src-tauri/src/acp/session_state.rs
+++ b/src-tauri/src/acp/session_state.rs
@@ -945,6 +945,22 @@ impl SessionState {
                 // call (no concluding text) → empty, which CLEARS the field so a
                 // prior turn's text can't leak as this turn's result; the LLM
                 // reads the full result by opening the child session instead.
+                //
+                // Cleared FIRST, because a turn can end with no live message at
+                // all — cancelled before it produced anything, or one whose only
+                // chunk was an empty text delta (dropped by
+                // `append_text_delta`). Leaving the field alone there would
+                // serve the PREVIOUS turn's answer as this turn's result.
+                //
+                // Guarded on the turn actually being open, because
+                // `TurnComplete` has three emitters (stop-reason message,
+                // prompt response, and the cancel path — which deliberately
+                // does not wait for the agent, so its response can bring a
+                // second one). A repeat must not wipe the text the first one
+                // captured.
+                if self.turn_in_flight || self.live_message.is_some() {
+                    self.last_assistant_text = None;
+                }
                 if let Some(live) = self.live_message.as_ref() {
                     let after_last_tool_call = live
                         .content
@@ -968,11 +984,9 @@ impl SessionState {
                         })
                         .collect::<Vec<&str>>()
                         .join("");
-                    self.last_assistant_text = if assembled.trim().is_empty() {
-                        None
-                    } else {
-                        Some(assembled)
-                    };
+                    if !assembled.trim().is_empty() {
+                        self.last_assistant_text = Some(assembled);
+                    }
                 }
                 self.live_message = None;
                 self.active_tool_calls.clear();
@@ -3370,6 +3384,62 @@ mod tests {
             agent_type: "codex".into(),
         });
         assert_eq!(s.last_assistant_text, None);
+    }
+
+    /// A turn that never opened a live message has no text of its own either.
+    /// An agent whose only output was an empty text chunk reaches exactly that
+    /// state (`append_text_delta` drops it), and the turn still ends on
+    /// `end_turn` — so without clearing, `get_delegation_status` would hand the
+    /// PREVIOUS turn's answer back as this turn's result.
+    #[test]
+    fn turn_complete_clears_stale_text_when_the_turn_produced_nothing() {
+        let mut s = fresh_state();
+        s.status = ConnectionStatus::Prompting;
+        s.turn_in_flight = true;
+        s.last_assistant_text = Some("stale text from an earlier turn".into());
+        s.apply_event(&AcpEvent::ContentDelta {
+            text: String::new(),
+            parent_tool_use_id: None,
+        });
+        assert!(s.live_message.is_none(), "empty chunk opens no live message");
+        s.apply_event(&AcpEvent::TurnComplete {
+            session_id: "ext".into(),
+            stop_reason: "end_turn".into(),
+            agent_type: "codex".into(),
+        });
+        assert_eq!(s.last_assistant_text, None);
+    }
+
+    /// `TurnComplete` is emitted from three places, and the cancel path does
+    /// not wait for the agent — so a second one can land on an already-settled
+    /// turn. It must not wipe the text the first one captured.
+    #[test]
+    fn a_repeat_turn_complete_keeps_the_captured_text() {
+        let mut s = fresh_state();
+        s.status = ConnectionStatus::Prompting;
+        s.turn_in_flight = true;
+        s.live_message = Some(LiveMessage {
+            id: "m1".into(),
+            role: MessageRole::Assistant,
+            content: vec![LiveContentBlock::Text {
+                text: "the answer".into(),
+                parent_tool_use_id: None,
+            }],
+            started_at: Utc::now(),
+        });
+        let complete = AcpEvent::TurnComplete {
+            session_id: "ext".into(),
+            stop_reason: "cancelled".into(),
+            agent_type: "codex".into(),
+        };
+        s.apply_event(&complete);
+        assert_eq!(s.last_assistant_text.as_deref(), Some("the answer"));
+        s.apply_event(&complete);
+        assert_eq!(
+            s.last_assistant_text.as_deref(),
+            Some("the answer"),
+            "the agent's late response must not erase the captured result"
+        );
     }
 
     #[test]

--- a/src-tauri/src/parsers/claude.rs
+++ b/src-tauri/src/parsers/claude.rs
@@ -1135,6 +1135,11 @@ pub(crate) struct ClaudeRecordAccumulator {
     /// API call's usage. See [`Self::claim_assistant_usage`] for why only one
     /// line of a group may carry it.
     usage_owner_by_message_id: std::collections::HashMap<String, usize>,
+    /// API response id for the immediately preceding assistant record. Claude
+    /// writes each content block on its own JSONL line, so this lets adjacent
+    /// thinking-only fragments from one response share a message without
+    /// crossing text, tool, or user boundaries.
+    pending_assistant_message_id: Option<String>,
 }
 
 impl ClaudeRecordAccumulator {
@@ -1156,6 +1161,7 @@ impl ClaudeRecordAccumulator {
             background_acks: std::collections::HashMap::new(),
             background_notifications: std::collections::HashMap::new(),
             usage_owner_by_message_id: std::collections::HashMap::new(),
+            pending_assistant_message_id: None,
         }
     }
 
@@ -1164,10 +1170,10 @@ impl ClaudeRecordAccumulator {
     /// Claude Code writes **one JSONL line per content block**, not one per API
     /// call: a response that thinks, then answers, then calls two tools becomes
     /// four `assistant` lines sharing a single `message.id` — and every one of
-    /// them repeats that call's *complete* usage object. Each line becomes its
-    /// own [`UnifiedMessage`], its own turn, and (for the dashboard) its own
-    /// fact row, so summing them multiplies one API call's tokens by its block
-    /// count. Measured over a real transcript tree that is a 2.4× over-count
+    /// them repeats that call's *complete* usage object. Most block lines become
+    /// separate [`UnifiedMessage`]s and dashboard fact rows, so summing them
+    /// multiplies one API call's tokens by its block count. Measured over a real
+    /// transcript tree that is a 2.4× over-count
     /// (17.1 B counted vs 7.0 B actually spent), and 74 % of all calls are
     /// affected — a tool-heavy session inflates the most.
     ///
@@ -1184,10 +1190,10 @@ impl ClaudeRecordAccumulator {
     /// reported.
     ///
     /// `owner_index` is the slot the claiming message WILL occupy — normally
-    /// `messages.len()` (a fresh push). `parsers::qoder` merges the fragments of
-    /// one `message.id` into a single bubble, so it claims for
-    /// `messages.len() - 1` instead; passing it explicitly keeps the demotion
-    /// bookkeeping correct for both shapes.
+    /// `messages.len()` (a fresh push). `parsers::qoder` merges all adjacent
+    /// response fragments, while this parser merges adjacent thinking-only
+    /// fragments, so both may claim for `messages.len() - 1`; passing the index
+    /// explicitly keeps the demotion bookkeeping correct for every shape.
     pub(crate) fn claim_assistant_usage(
         messages: &mut [UnifiedMessage],
         usage_owner_by_message_id: &mut std::collections::HashMap<String, usize>,
@@ -1262,9 +1268,16 @@ impl ClaudeRecordAccumulator {
             background_acks,
             background_notifications,
             usage_owner_by_message_id,
+            pending_assistant_message_id,
         } = self;
 
         let msg_type = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        // Even filtered user bookkeeping (for example an interrupt marker) is
+        // a response boundary and must not reconnect thinking on either side.
+        if msg_type == "user" {
+            *pending_assistant_message_id = None;
+        }
 
         if msg_type == "file-history-snapshot" || msg_type == "progress" {
             return;
@@ -1294,6 +1307,10 @@ impl ClaudeRecordAccumulator {
         // matching filter on the batch path).
         if is_meta_message(&value) || is_interrupt_marker(&value) {
             return;
+        }
+
+        if msg_type != "assistant" && msg_type != "user" {
+            *pending_assistant_message_id = None;
         }
 
         // Claude Code records the user-set name (`/rename`) and its own
@@ -1355,6 +1372,7 @@ impl ClaudeRecordAccumulator {
         match msg_type {
             "assistant" if is_synthetic_assistant(&value) => {
                 // Skip synthetic assistant placeholders for local commands
+                *pending_assistant_message_id = None;
             }
             "user" => {
                 // Capture `<task-notification>` payloads for the background
@@ -1539,30 +1557,70 @@ impl ClaudeRecordAccumulator {
                 }
 
                 let content = extract_assistant_content(&value);
+                let message_id = value
+                    .get("message")
+                    .and_then(|m| m.get("id"))
+                    .and_then(|id| id.as_str())
+                    .filter(|id| !id.is_empty());
+                let merges_thinking_fragment = message_id.is_some()
+                    && pending_assistant_message_id.as_deref() == message_id
+                    && matches!(
+                        (messages.last(), content.as_slice()),
+                        (
+                            Some(UnifiedMessage {
+                                role: MessageRole::Assistant,
+                                content: previous,
+                                ..
+                            }),
+                            [ContentBlock::Thinking { .. }]
+                        ) if matches!(previous.last(), Some(ContentBlock::Thinking { .. }))
+                    );
                 // One API call is spread over several lines that each repeat
                 // its full usage; only one of them may keep it.
-                let owner_index = messages.len();
+                let owner_index = if merges_thinking_fragment {
+                    messages.len() - 1
+                } else {
+                    messages.len()
+                };
                 let usage = Self::claim_assistant_usage(
                     messages,
                     usage_owner_by_message_id,
-                    value
-                        .get("message")
-                        .and_then(|m| m.get("id"))
-                        .and_then(|id| id.as_str()),
+                    message_id,
                     extract_usage(&value),
                     owner_index,
                 );
 
-                messages.push(UnifiedMessage {
-                    id: uuid,
-                    role: MessageRole::Assistant,
-                    content,
-                    timestamp,
-                    usage,
-                    duration_ms: None,
-                    model: msg_model,
-                    completed_at: Some(timestamp),
-                });
+                if merges_thinking_fragment {
+                    let last = messages.last_mut().expect("checked non-empty");
+                    let ContentBlock::Thinking { text: fragment } =
+                        content.into_iter().next().expect("checked one block")
+                    else {
+                        unreachable!("checked thinking block")
+                    };
+                    let Some(ContentBlock::Thinking { text }) = last.content.last_mut() else {
+                        unreachable!("checked trailing thinking block")
+                    };
+                    text.push_str(&fragment);
+                    last.completed_at = Some(timestamp);
+                    if usage.is_some() {
+                        last.usage = usage;
+                    }
+                    if msg_model.is_some() {
+                        last.model = msg_model;
+                    }
+                } else {
+                    messages.push(UnifiedMessage {
+                        id: uuid,
+                        role: MessageRole::Assistant,
+                        content,
+                        timestamp,
+                        usage,
+                        duration_ms: None,
+                        model: msg_model,
+                        completed_at: Some(timestamp),
+                    });
+                }
+                *pending_assistant_message_id = message_id.map(str::to_string);
             }
             "attachment" => {
                 // `/goal` transitions ride on attachment records; everything
@@ -3498,6 +3556,288 @@ mod tests {
                     + u.cache_read_input_tokens
             })
             .sum()
+    }
+
+    #[test]
+    fn adjacent_thinking_fragments_from_one_response_share_one_turn() {
+        let usage = json!({
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0
+        });
+        let lines = [
+            assistant_block_line(
+                "first-record",
+                "msg-one-response",
+                "2026-03-01T10:00:00Z",
+                json!({"type": "thinking", "thinking": "inspect"}),
+                usage.clone(),
+            ),
+            assistant_block_line(
+                "second-record",
+                "msg-one-response",
+                "2026-03-01T10:00:02Z",
+                json!({"type": "thinking", "thinking": " result"}),
+                usage,
+            ),
+        ];
+
+        let detail = parse_lines_into_detail(&lines);
+        assert_eq!(detail.turns.len(), 1);
+        assert!(matches!(
+            detail.turns[0].blocks.as_slice(),
+            [ContentBlock::Thinking { text }] if text == "inspect result"
+        ));
+        assert_eq!(
+            detail.turns[0].timestamp.to_rfc3339(),
+            "2026-03-01T10:00:00+00:00"
+        );
+        assert_eq!(
+            detail.turns[0]
+                .completed_at
+                .expect("last fragment completion")
+                .to_rfc3339(),
+            "2026-03-01T10:00:02+00:00"
+        );
+        assert_eq!(total_usage_tokens(&detail), 120);
+
+        let mut acc = ClaudeRecordAccumulator::new(PathBuf::from("/nonexistent.jsonl"));
+        for line in &lines {
+            acc.feed_line(line);
+        }
+        assert_eq!(acc.messages.len(), 1);
+        assert_eq!(acc.messages[0].id, "first-record");
+    }
+
+    #[test]
+    fn thinking_fragments_do_not_cross_response_or_content_boundaries() {
+        let usage = json!({
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0
+        });
+
+        let different_responses = parse_lines_into_detail(&[
+            assistant_block_line(
+                "a1",
+                "msg-first",
+                "2026-03-01T10:00:00Z",
+                json!({"type": "thinking", "thinking": "one"}),
+                usage.clone(),
+            ),
+            assistant_block_line(
+                "a2",
+                "msg-second",
+                "2026-03-01T10:00:01Z",
+                json!({"type": "thinking", "thinking": "two"}),
+                usage.clone(),
+            ),
+        ]);
+        assert_eq!(different_responses.turns.len(), 2);
+
+        let separated_by_text = parse_lines_into_detail(&[
+            assistant_block_line(
+                "a1",
+                "msg-same",
+                "2026-03-01T10:00:00Z",
+                json!({"type": "thinking", "thinking": "one"}),
+                usage.clone(),
+            ),
+            assistant_block_line(
+                "a2",
+                "msg-same",
+                "2026-03-01T10:00:01Z",
+                json!({"type": "text", "text": "answer"}),
+                usage.clone(),
+            ),
+            assistant_block_line(
+                "a3",
+                "msg-same",
+                "2026-03-01T10:00:02Z",
+                json!({"type": "thinking", "thinking": "two"}),
+                usage,
+            ),
+        ]);
+        assert_eq!(separated_by_text.turns.len(), 3);
+        let thinking: Vec<_> = separated_by_text
+            .turns
+            .iter()
+            .flat_map(|turn| &turn.blocks)
+            .filter_map(|block| match block {
+                ContentBlock::Thinking { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(thinking, ["one", "two"]);
+
+        let interrupted = parse_lines_into_detail(&[
+            assistant_block_line(
+                "a1",
+                "msg-interrupted",
+                "2026-03-01T10:00:00Z",
+                json!({"type": "thinking", "thinking": "before"}),
+                json!({}),
+            ),
+            json!({
+                "type": "user",
+                "timestamp": "2026-03-01T10:00:01Z",
+                "uuid": "u-interrupt",
+                "message": {"content": [{
+                    "type": "text",
+                    "text": "[Request interrupted by user]"
+                }]}
+            })
+            .to_string(),
+            assistant_block_line(
+                "a2",
+                "msg-interrupted",
+                "2026-03-01T10:00:02Z",
+                json!({"type": "thinking", "thinking": "after"}),
+                json!({}),
+            ),
+        ]);
+        assert_eq!(interrupted.turns.len(), 2);
+    }
+
+    #[test]
+    fn thinking_fragments_do_not_cross_tool_result_boundaries() {
+        let usage = json!({
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0
+        });
+        let lines = [
+            assistant_block_line(
+                "a1",
+                "msg-same",
+                "2026-03-01T10:00:00Z",
+                json!({"type": "thinking", "thinking": "before"}),
+                usage.clone(),
+            ),
+            assistant_block_line(
+                "a2",
+                "msg-same",
+                "2026-03-01T10:00:01Z",
+                json!({"type": "tool_use", "id": "tu1", "name": "Read", "input": {}}),
+                usage.clone(),
+            ),
+            json!({
+                "type": "user",
+                "timestamp": "2026-03-01T10:00:02Z",
+                "uuid": "u1",
+                "message": {"content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tu1",
+                    "content": "done"
+                }]}
+            })
+            .to_string(),
+            assistant_block_line(
+                "a3",
+                "msg-same",
+                "2026-03-01T10:00:03Z",
+                json!({"type": "thinking", "thinking": "after"}),
+                usage,
+            ),
+        ];
+
+        let detail = parse_lines_into_detail(&lines);
+        let assistant_turns: Vec<_> = detail
+            .turns
+            .iter()
+            .filter(|turn| matches!(turn.role, TurnRole::Assistant))
+            .collect();
+        assert_eq!(assistant_turns.len(), 3);
+        assert!(matches!(
+            assistant_turns[0].blocks.as_slice(),
+            [ContentBlock::Thinking { text }] if text == "before"
+        ));
+        assert!(assistant_turns[1]
+            .blocks
+            .iter()
+            .any(|block| matches!(block, ContentBlock::ToolResult { .. })));
+        assert!(matches!(
+            assistant_turns[2].blocks.as_slice(),
+            [ContentBlock::Thinking { text }] if text == "after"
+        ));
+        assert_eq!(total_usage_tokens(&detail), 15);
+    }
+
+    #[test]
+    fn merged_thinking_keeps_largest_usage_payload() {
+        let zeros = json!({
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0
+        });
+        let real = json!({
+            "input_tokens": 2,
+            "output_tokens": 383,
+            "cache_creation_input_tokens": 418,
+            "cache_read_input_tokens": 177_892
+        });
+
+        for (first, second) in [(zeros.clone(), real.clone()), (real.clone(), zeros.clone())] {
+            let detail = parse_lines_into_detail(&[
+                assistant_block_line(
+                    "a1",
+                    "msg-mixed",
+                    "2026-03-01T10:00:00Z",
+                    json!({"type": "thinking", "thinking": "one"}),
+                    first,
+                ),
+                assistant_block_line(
+                    "a2",
+                    "msg-mixed",
+                    "2026-03-01T10:00:01Z",
+                    json!({"type": "thinking", "thinking": "two"}),
+                    second,
+                ),
+            ]);
+            assert_eq!(detail.turns.len(), 1);
+            assert_eq!(total_usage_tokens(&detail), 178_695);
+        }
+    }
+
+    #[test]
+    fn thinking_merge_state_survives_incremental_feed_calls() {
+        let usage = json!({
+            "input_tokens": 1,
+            "output_tokens": 2,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0
+        });
+        let lines = [
+            assistant_block_line(
+                "a1",
+                "msg-incremental",
+                "2026-03-01T10:00:00Z",
+                json!({"type": "thinking", "thinking": "part one"}),
+                usage.clone(),
+            ),
+            assistant_block_line(
+                "a2",
+                "msg-incremental",
+                "2026-03-01T10:00:01Z",
+                json!({"type": "thinking", "thinking": " part two"}),
+                usage,
+            ),
+        ];
+
+        let whole = parse_lines_into_detail(&lines);
+
+        let mut incremental = ClaudeRecordAccumulator::new(PathBuf::from("/nonexistent.jsonl"));
+        incremental.feed_line(&lines[0]);
+        incremental.feed_line(&lines[1]);
+
+        assert_eq!(
+            serde_json::to_value(group_into_turns(incremental.messages)).unwrap(),
+            serde_json::to_value(whole.turns).unwrap()
+        );
     }
 
     #[test]

--- a/src/contexts/conversation-runtime-context.test.tsx
+++ b/src/contexts/conversation-runtime-context.test.tsx
@@ -2064,6 +2064,24 @@ describe("buildStreamingTurnsFromLiveMessage — subagent transcript routing (cl
     ).toEqual(["before", "after"])
   })
 
+  it("keeps a boundary the PLAN_UPDATE reducer relocated away", () => {
+    // `thinking → plan(v1) → thinking → plan(v2)` reaches the builder as two
+    // adjacent thinking blocks: PLAN_UPDATE keeps one plan and moves it to the
+    // end. The split predicate never leaves same-kind main prose adjacent, so
+    // that shape means a boundary was removed — do not fuse across it.
+    const result = build([
+      { type: "thinking", text: "before" },
+      { type: "thinking", text: "after" },
+      { type: "plan", entries: [] },
+    ])
+    expect(
+      result.turns
+        .flatMap((t) => t.blocks)
+        .filter((b) => b.type === "thinking")
+        .map((b) => b.text)
+    ).toEqual(["before", "after"])
+  })
+
   it("keeps a plan block between two thinking blocks from fusing them", () => {
     const result = build([
       { type: "thinking", text: "before" },

--- a/src/contexts/conversation-runtime-context.test.tsx
+++ b/src/contexts/conversation-runtime-context.test.tsx
@@ -1911,6 +1911,106 @@ describe("buildStreamingTurnsFromLiveMessage — subagent transcript routing (cl
       }
     }
   })
+
+  // #494: the wire splits blocks at kind AND attribution boundaries, so a
+  // sub-agent chunk landing between two main-thread deltas ends the main
+  // block. Once the parented blocks are routed out, what remains is one
+  // uninterrupted run of the main agent's output — rendering it as N cards
+  // torn mid-word (`先看 cli` ⁄ `.py 怎么起 server`) is the reported bug, and
+  // it scales with the number of sub-agents streaming at once.
+  it("rejoins main-thread thinking torn apart by interleaved subagent chunks", () => {
+    const result = build([
+      agentCall("toolu_agent"),
+      { type: "thinking", text: "先看 cli" },
+      {
+        type: "thinking",
+        text: "子代理在读文件",
+        parentToolUseId: "toolu_agent",
+      },
+      { type: "thinking", text: ".py 怎么起 server、token 放哪。" },
+      {
+        type: "thinking",
+        text: "子代理还在读",
+        parentToolUseId: "toolu_agent",
+      },
+      { type: "thinking", text: "注意不要和子代理冲突——" },
+    ])
+    const thinking = result.turns
+      .flatMap((t) => t.blocks)
+      .filter((b) => b.type === "thinking")
+    expect(thinking).toEqual([
+      {
+        type: "thinking",
+        text: "先看 cli.py 怎么起 server、token 放哪。注意不要和子代理冲突——",
+      },
+    ])
+  })
+
+  it("rejoins main-thread text torn apart by interleaved subagent chunks", () => {
+    const result = build([
+      agentCall("toolu_agent"),
+      { type: "text", text: "C" },
+      { type: "text", text: "sub prose", parentToolUseId: "toolu_agent" },
+      { type: "text", text: "airn 的 agent 更换机制" },
+    ])
+    const text = result.turns
+      .flatMap((t) => t.blocks)
+      .filter((b) => b.type === "text")
+    expect(text).toEqual([{ type: "text", text: "Cairn 的 agent 更换机制" }])
+  })
+
+  it("rejoins one subagent's transcript split by a second subagent's chunks", () => {
+    const result = build([
+      agentCall("toolu_a"),
+      agentCall("toolu_b"),
+      { type: "thinking", text: "A 想了", parentToolUseId: "toolu_a" },
+      { type: "thinking", text: "B 也在想", parentToolUseId: "toolu_b" },
+      { type: "thinking", text: "一半", parentToolUseId: "toolu_a" },
+      { type: "text", text: "A 说完了", parentToolUseId: "toolu_a" },
+    ])
+    const carriers = result.turns
+      .flatMap((t) => t.blocks)
+      .filter((b) => b.type === "tool_result")
+    // Attribution still holds: A's run is one entry, B's is its own card.
+    expect(carriers.map((c) => c.agent_transcript)).toEqual([
+      [
+        { type: "thinking", text: "A 想了一半" },
+        { type: "text", text: "A 说完了" },
+      ],
+      [{ type: "thinking", text: "B 也在想" }],
+    ])
+  })
+
+  it("keeps a main-thread run split across a turn boundary", () => {
+    // A completed tool between two thinking blocks opens a new turn group —
+    // rejoining must not reach back across it.
+    const result = build([
+      { type: "thinking", text: "before" },
+      {
+        type: "tool_call",
+        info: toolInfo({ tool_call_id: "toolu_done", status: "completed" }),
+      },
+      { type: "thinking", text: "after" },
+    ])
+    expect(
+      result.turns.map((t) =>
+        t.blocks.filter((b) => b.type === "thinking").map((b) => b.text)
+      )
+    ).toEqual([["before"], ["after"]])
+  })
+
+  it("keeps a plan block between two thinking blocks from fusing them", () => {
+    const result = build([
+      { type: "thinking", text: "before" },
+      { type: "plan", entries: [] },
+      { type: "thinking", text: "after" },
+    ])
+    expect(
+      result.turns
+        .flatMap((t) => t.blocks)
+        .map((b) => (b.type === "thinking" ? b.text : b.type))
+    ).toEqual(["before", "plan", "after"])
+  })
 })
 
 describe("buildStreamingTurnsFromLiveMessage — Kimi TodoList suppression", () => {

--- a/src/contexts/conversation-runtime-context.test.tsx
+++ b/src/contexts/conversation-runtime-context.test.tsx
@@ -2064,6 +2064,23 @@ describe("buildStreamingTurnsFromLiveMessage — subagent transcript routing (cl
     ).toEqual(["before", "after"])
   })
 
+  it("does not let a stale snapshot's empty text block re-split a run", () => {
+    // An empty text block renders nothing (Phase 2 drops it), so it is not a
+    // boundary. Neither producer emits one any more, but a snapshot taken by
+    // an older backend can still carry it.
+    const result = build([
+      { type: "thinking", text: "before" },
+      { type: "text", text: "" },
+      { type: "thinking", text: " after" },
+    ])
+    expect(
+      result.turns
+        .flatMap((t) => t.blocks)
+        .filter((b) => b.type === "thinking")
+        .map((b) => b.text)
+    ).toEqual(["before after"])
+  })
+
   it("keeps a boundary the PLAN_UPDATE reducer relocated away", () => {
     // `thinking → plan(v1) → thinking → plan(v2)` reaches the builder as two
     // adjacent thinking blocks: PLAN_UPDATE keeps one plan and moves it to the

--- a/src/contexts/conversation-runtime-context.test.tsx
+++ b/src/contexts/conversation-runtime-context.test.tsx
@@ -1981,6 +1981,33 @@ describe("buildStreamingTurnsFromLiveMessage — subagent transcript routing (cl
     ])
   })
 
+  it("keeps a subagent's own tool call as a boundary in its transcript", () => {
+    // Another agent's chunks do not interrupt A's run, but A stopping to run
+    // a tool does — fusing across it would run two paragraphs together.
+    const result = build([
+      agentCall("toolu_a"),
+      { type: "thinking", text: "before", parentToolUseId: "toolu_a" },
+      {
+        type: "tool_call",
+        info: toolInfo({
+          tool_call_id: "toolu_child",
+          title: "Read",
+          meta: { claudeCode: { parentToolUseId: "toolu_a" } },
+        }),
+      },
+      { type: "thinking", text: "after", parentToolUseId: "toolu_a" },
+    ])
+    const carrier = result.turns
+      .flatMap((t) => t.blocks)
+      .find((b) => b.type === "tool_result")
+    expect(
+      carrier?.type === "tool_result" ? carrier.agent_transcript : null
+    ).toEqual([
+      { type: "thinking", text: "before" },
+      { type: "thinking", text: "after" },
+    ])
+  })
+
   it("keeps a main-thread run split across a turn boundary", () => {
     // A completed tool between two thinking blocks opens a new turn group —
     // rejoining must not reach back across it.
@@ -1997,6 +2024,44 @@ describe("buildStreamingTurnsFromLiveMessage — subagent transcript routing (cl
         t.blocks.filter((b) => b.type === "thinking").map((b) => b.text)
       )
     ).toEqual([["before"], ["after"]])
+  })
+
+  it("keeps a boundary that preprocessing removed (codex collab close)", () => {
+    // collapseLiveCollabBlocks folds a completed `closeAgent` into the spawn
+    // capsule, so by Phase 2 the two texts look adjacent. They are not: a real
+    // top-level tool call stood between them on the wire.
+    const collab = (id: string, title: string): LiveContentBlock => ({
+      type: "tool_call",
+      info: {
+        tool_call_id: id,
+        title,
+        kind: "other",
+        status: "completed",
+        content: null,
+        raw_input: JSON.stringify({
+          senderThreadId: "main",
+          receiverThreadIds: ["a1"],
+          agentsStates: { a1: { status: "completed", message: null } },
+        }),
+        raw_output_chunks: [],
+        raw_output_total_bytes: 0,
+        locations: null,
+        meta: null,
+        images: [],
+      },
+    })
+    const result = build([
+      collab("collab-spawn", "spawnAgent"),
+      { type: "text", text: "before" },
+      collab("collab-close", "closeAgent"),
+      { type: "text", text: "after" },
+    ])
+    expect(
+      result.turns
+        .flatMap((t) => t.blocks)
+        .filter((b) => b.type === "text")
+        .map((b) => b.text)
+    ).toEqual(["before", "after"])
   })
 
   it("keeps a plan block between two thinking blocks from fusing them", () => {

--- a/src/stores/conversation-runtime-store.ts
+++ b/src/stores/conversation-runtime-store.ts
@@ -846,6 +846,36 @@ function resolveLiveToolInput(
   return info.raw_input
 }
 
+/**
+ * Append a main-thread prose block, re-joining it with the trailing block when
+ * that block is the same kind.
+ *
+ * `liveMessage.content` is split at kind AND subagent-attribution boundaries
+ * (the reducer and the backend's `append_text_delta` share that predicate, so
+ * a snapshot-hydrated client sees the same block list a streaming one does).
+ * Attribution is a wire-level property, though, not a rendering one: parented
+ * blocks are routed out to their Agent capsule above, and what is left is one
+ * uninterrupted run of the main agent's own output that only *looks* split
+ * because a sub-agent chunk landed between two of its deltas.
+ *
+ * Rejoining is therefore a display concern and belongs here, not in the split
+ * predicate — moving it there would merge a sub-agent's prose into the main
+ * thread's. Without it, one thought renders as a wall of separate reasoning
+ * cards torn mid-word whenever sub-agents stream concurrently (#494).
+ */
+function appendProse(
+  blocks: MessageTurn["blocks"],
+  type: "text" | "thinking",
+  text: string
+): void {
+  const tail = blocks[blocks.length - 1]
+  if (tail && tail.type === type) {
+    blocks[blocks.length - 1] = { type, text: tail.text + text }
+    return
+  }
+  blocks.push({ type, text })
+}
+
 export function buildStreamingTurnsFromLiveMessage(
   conversationId: number,
   liveMessage: LiveMessage,
@@ -987,15 +1017,30 @@ export function buildStreamingTurnsFromLiveMessage(
       // tool_call and attaches it. A parented block whose parent is not a
       // classified agent (snapshot-path orphan — the reducer's
       // parent-presence gate does not cover snapshot-sourced content) is
-      // dropped by the `agentIds` check. Entries arrive pre-merged (the
-      // reducer splits blocks only at kind/attribution boundaries).
+      // dropped by the `agentIds` check.
+      //
+      // The reducer splits blocks at kind/attribution boundaries, so ONE
+      // subagent's prose arrives pre-merged only while nothing else streams:
+      // with two sub-agents running (or any main-thread chunk in between),
+      // sub-A → sub-B → sub-A is three blocks, and this transcript would show
+      // A's single paragraph as two entries torn at a chunk boundary. Re-join
+      // consecutive same-kind entries here — after attribution filtering, they
+      // were always one run of that agent's output. See #494.
       if (
         (block.type === "text" || block.type === "thinking") &&
         block.parentToolUseId
       ) {
         if (agentIds.has(block.parentToolUseId)) {
           const list = agentTranscripts.get(block.parentToolUseId) ?? []
-          list.push({ type: block.type, text: block.text })
+          const tail = list[list.length - 1]
+          if (tail && tail.type === block.type) {
+            list[list.length - 1] = {
+              type: tail.type,
+              text: tail.text + block.text,
+            }
+          } else {
+            list.push({ type: block.type, text: block.text })
+          }
           agentTranscripts.set(block.parentToolUseId, list)
         }
       } else if (positionalAgentId) {
@@ -1046,7 +1091,7 @@ export function buildStreamingTurnsFromLiveMessage(
     switch (block.type) {
       case "text":
         if (block.text.length > 0) {
-          currentBlocks.push({ type: "text", text: block.text })
+          appendProse(currentBlocks, "text", block.text)
         }
         break
       case "thinking":
@@ -1054,7 +1099,7 @@ export function buildStreamingTurnsFromLiveMessage(
         // can show its "Thinking..." indicator before any reasoning text
         // arrives (and for newer Claude models that redact reasoning text
         // entirely while still emitting thinking blocks).
-        currentBlocks.push({ type: "thinking", text: block.text })
+        appendProse(currentBlocks, "thinking", block.text)
         break
       case "plan": {
         // Carry the live plan through as a first-class `plan` block so it

--- a/src/stores/conversation-runtime-store.ts
+++ b/src/stores/conversation-runtime-store.ts
@@ -926,9 +926,15 @@ function mainProseContinuations(
         bridgedBySubAgent = true
         continue
       }
-      // Phase 2 drops an empty main-thread text block, so it is neither a
-      // boundary nor a bridge here.
-      if (block.type === "text" && block.text.length === 0) continue
+      // Phase 2 drops an empty main-thread text block, so it renders nothing
+      // and cannot be a boundary — it bridges, like a sub-agent block. Neither
+      // producer of `content` should emit one (the reducer drops empty
+      // `CONTENT_DELTA`, and so does `append_text_delta`), but a snapshot from
+      // a build that predates that symmetry would otherwise re-split a run.
+      if (block.type === "text" && block.text.length === 0) {
+        bridgedBySubAgent = true
+        continue
+      }
       if (run === block.type && bridgedBySubAgent) continues.add(block)
       run = block.type
       bridgedBySubAgent = false

--- a/src/stores/conversation-runtime-store.ts
+++ b/src/stores/conversation-runtime-store.ts
@@ -884,16 +884,33 @@ function appendProse(
 }
 
 /**
- * The main-thread prose blocks that continue the previous one — i.e. every
- * block between them belongs to a sub-agent and is therefore out-of-band for
- * the main thread: parented prose (routed to the Agent capsule) and the
- * sub-agent's own child tool calls (nested into the Agent card).
+ * The main-thread prose blocks that continue the previous one — i.e. the wire
+ * put at least one SUB-AGENT block between them (parented prose, routed to the
+ * Agent capsule; or the sub-agent's own child tool calls, nested into the Agent
+ * card) and nothing else. Those are out-of-band for the main thread, so the
+ * split they caused is an artifact, not a boundary.
  *
- * Computed over `liveMessage.content`, NOT over the array Phase 2 walks: by
- * then `collapseLiveCollabBlocks` has already dropped a completed codex
- * `closeAgent` tool call, and prose on either side of a dropped boundary must
- * stay two blocks. Prose is never dropped or rewritten by that collapse, so
- * the surviving blocks are identity-stable across it.
+ * Two rules keep this from fusing across a real boundary that something
+ * upstream erased:
+ *
+ * 1. Computed over `liveMessage.content`, NOT the array Phase 2 walks: by then
+ *    `collapseLiveCollabBlocks` has dropped a completed codex `closeAgent`,
+ *    and prose on either side of it must stay two blocks. That collapse never
+ *    drops or rewrites prose and preserves order, so prose blocks are
+ *    identity-stable across it.
+ * 2. A sub-agent block must ACTUALLY sit between the two. The split predicate
+ *    (`applyStreamingAction` / `append_text_delta`) merges same-kind same-
+ *    attribution deltas, so it can never leave two same-kind main-thread prose
+ *    blocks directly adjacent — that shape means something was removed. The
+ *    `PLAN_UPDATE` reducer is one such remover: it keeps at most one plan block
+ *    and relocates it to the end, so `thinking → plan(v1) → thinking → plan(v2)`
+ *    reaches us as two adjacent thinking blocks.
+ *
+ * Rule 2 is positional, so it cannot recover a plan that was relocated out from
+ * between two prose blocks that ALSO have a sub-agent block between them; the
+ * plan's original position is simply not in the state we are given. Closing
+ * that would mean making `PLAN_UPDATE` replace in place instead of relocating —
+ * a deliberate, separately-specified invariant on both sides of the wire.
  */
 function mainProseContinuations(
   content: LiveContentBlock[],
@@ -901,24 +918,31 @@ function mainProseContinuations(
 ): Set<LiveContentBlock> {
   const continues = new Set<LiveContentBlock>()
   let run: "text" | "thinking" | null = null
+  let bridgedBySubAgent = false
   for (const block of content) {
     if (block.type === "text" || block.type === "thinking") {
       // A sub-agent's own prose: out-of-band, and not a boundary either.
-      if (block.parentToolUseId) continue
-      // Phase 2 drops an empty main-thread text block, so it is not a
-      // boundary here either.
+      if (block.parentToolUseId) {
+        bridgedBySubAgent = true
+        continue
+      }
+      // Phase 2 drops an empty main-thread text block, so it is neither a
+      // boundary nor a bridge here.
       if (block.type === "text" && block.text.length === 0) continue
-      if (run === block.type) continues.add(block)
+      if (run === block.type && bridgedBySubAgent) continues.add(block)
       run = block.type
+      bridgedBySubAgent = false
       continue
     }
     if (
       block.type === "tool_call" &&
       childToolCallIds.has(block.info.tool_call_id)
     ) {
+      bridgedBySubAgent = true
       continue
     }
     run = null
+    bridgedBySubAgent = false
   }
   return continues
 }

--- a/src/stores/conversation-runtime-store.ts
+++ b/src/stores/conversation-runtime-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 import type {
+  LiveContentBlock,
   LiveMessage,
   ToolCallInfo,
 } from "@/contexts/acp-connections-context"
@@ -848,7 +849,7 @@ function resolveLiveToolInput(
 
 /**
  * Append a main-thread prose block, re-joining it with the trailing block when
- * that block is the same kind.
+ * `continuesRun` says the two were one run the wire happened to tear apart.
  *
  * `liveMessage.content` is split at kind AND subagent-attribution boundaries
  * (the reducer and the backend's `append_text_delta` share that predicate, so
@@ -862,18 +863,64 @@ function resolveLiveToolInput(
  * predicate — moving it there would merge a sub-agent's prose into the main
  * thread's. Without it, one thought renders as a wall of separate reasoning
  * cards torn mid-word whenever sub-agents stream concurrently (#494).
+ *
+ * The tail check is a guard, not the decision: `continuesRun` is computed
+ * against the ORIGINAL event stream by `mainProseContinuations`, because a
+ * same-kind tail alone cannot tell a sub-agent tear from a real boundary that
+ * something upstream removed.
  */
 function appendProse(
   blocks: MessageTurn["blocks"],
   type: "text" | "thinking",
-  text: string
+  text: string,
+  continuesRun: boolean
 ): void {
   const tail = blocks[blocks.length - 1]
-  if (tail && tail.type === type) {
+  if (continuesRun && tail && tail.type === type) {
     blocks[blocks.length - 1] = { type, text: tail.text + text }
     return
   }
   blocks.push({ type, text })
+}
+
+/**
+ * The main-thread prose blocks that continue the previous one — i.e. every
+ * block between them belongs to a sub-agent and is therefore out-of-band for
+ * the main thread: parented prose (routed to the Agent capsule) and the
+ * sub-agent's own child tool calls (nested into the Agent card).
+ *
+ * Computed over `liveMessage.content`, NOT over the array Phase 2 walks: by
+ * then `collapseLiveCollabBlocks` has already dropped a completed codex
+ * `closeAgent` tool call, and prose on either side of a dropped boundary must
+ * stay two blocks. Prose is never dropped or rewritten by that collapse, so
+ * the surviving blocks are identity-stable across it.
+ */
+function mainProseContinuations(
+  content: LiveContentBlock[],
+  childToolCallIds: Set<string>
+): Set<LiveContentBlock> {
+  const continues = new Set<LiveContentBlock>()
+  let run: "text" | "thinking" | null = null
+  for (const block of content) {
+    if (block.type === "text" || block.type === "thinking") {
+      // A sub-agent's own prose: out-of-band, and not a boundary either.
+      if (block.parentToolUseId) continue
+      // Phase 2 drops an empty main-thread text block, so it is not a
+      // boundary here either.
+      if (block.type === "text" && block.text.length === 0) continue
+      if (run === block.type) continues.add(block)
+      run = block.type
+      continue
+    }
+    if (
+      block.type === "tool_call" &&
+      childToolCallIds.has(block.info.tool_call_id)
+    ) {
+      continue
+    }
+    run = null
+  }
+  return continues
 }
 
 export function buildStreamingTurnsFromLiveMessage(
@@ -926,9 +973,11 @@ export function buildStreamingTurnsFromLiveMessage(
   // Live subagent transcripts, keyed by the launching Agent tool call's id.
   // Fed by parented text/thinking blocks (claude-agent-acp ≥0.63 subagent
   // transcripts); attached to the in-progress Agent card's tool_result as
-  // `agent_transcript`. Entries arrive pre-merged (the reducer splits blocks
-  // only at kind/attribution boundaries), so they are pushed as-is.
+  // `agent_transcript`.
   const agentTranscripts = new Map<string, AgentTranscriptEntry[]>()
+  // Agent id → the kind of prose that agent is currently in the middle of, or
+  // absent once its own tool call ended that run. Drives the rejoin above.
+  const transcriptRun = new Map<string, "text" | "thinking">()
 
   // Cache inferred tool names — inferLiveToolName is called per tool_call
   // in both Phase 1 and Phase 2; caching avoids redundant computation.
@@ -1008,6 +1057,9 @@ export function buildStreamingTurnsFromLiveMessage(
           agentChildren
             .get(resolvedParent)
             ?.push({ info: block.info, toolName })
+          // This agent stopped talking to run a tool: its next chunk starts a
+          // new transcript entry rather than rejoining the previous one.
+          transcriptRun.delete(resolvedParent)
         }
       }
     } else {
@@ -1024,8 +1076,10 @@ export function buildStreamingTurnsFromLiveMessage(
       // with two sub-agents running (or any main-thread chunk in between),
       // sub-A → sub-B → sub-A is three blocks, and this transcript would show
       // A's single paragraph as two entries torn at a chunk boundary. Re-join
-      // consecutive same-kind entries here — after attribution filtering, they
-      // were always one run of that agent's output. See #494.
+      // them via `transcriptRun`, which tracks each agent's OWN run: another
+      // agent's chunk (or the main thread's) never interrupts it, but this
+      // agent's own tool call does — that is a real boundary in its output,
+      // and fusing across it would run two paragraphs together. See #494.
       if (
         (block.type === "text" || block.type === "thinking") &&
         block.parentToolUseId
@@ -1033,7 +1087,11 @@ export function buildStreamingTurnsFromLiveMessage(
         if (agentIds.has(block.parentToolUseId)) {
           const list = agentTranscripts.get(block.parentToolUseId) ?? []
           const tail = list[list.length - 1]
-          if (tail && tail.type === block.type) {
+          if (
+            transcriptRun.get(block.parentToolUseId) === block.type &&
+            tail &&
+            tail.type === block.type
+          ) {
             list[list.length - 1] = {
               type: tail.type,
               text: tail.text + block.text,
@@ -1042,6 +1100,7 @@ export function buildStreamingTurnsFromLiveMessage(
             list.push({ type: block.type, text: block.text })
           }
           agentTranscripts.set(block.parentToolUseId, list)
+          transcriptRun.set(block.parentToolUseId, block.type)
         }
       } else if (positionalAgentId) {
         // A non-tool block (text/thinking/plan) means the main agent is
@@ -1062,6 +1121,12 @@ export function buildStreamingTurnsFromLiveMessage(
   const groups: MessageTurn["blocks"][] = [[]]
   let currentGroupHasCompletedTool = false
   const inProgressToolCallIds = new Set<string>()
+  // Which main-thread prose blocks are a continuation of the previous one
+  // (computed against the pre-collapse stream — see mainProseContinuations).
+  const continuesProse = mainProseContinuations(
+    liveMessage.content,
+    childToolCallIds
+  )
 
   for (const block of content) {
     // Parented subagent text/thinking never enters the main thread: it was
@@ -1091,7 +1156,12 @@ export function buildStreamingTurnsFromLiveMessage(
     switch (block.type) {
       case "text":
         if (block.text.length > 0) {
-          appendProse(currentBlocks, "text", block.text)
+          appendProse(
+            currentBlocks,
+            "text",
+            block.text,
+            continuesProse.has(block)
+          )
         }
         break
       case "thinking":
@@ -1099,7 +1169,12 @@ export function buildStreamingTurnsFromLiveMessage(
         // can show its "Thinking..." indicator before any reasoning text
         // arrives (and for newer Claude models that redact reasoning text
         // entirely while still emitting thinking blocks).
-        appendProse(currentBlocks, "thinking", block.text)
+        appendProse(
+          currentBlocks,
+          "thinking",
+          block.text,
+          continuesProse.has(block)
+        )
         break
       case "plan": {
         // Carry the live plan through as a first-class `plan` block so it


### PR DESCRIPTION
## Summary

- coalesce adjacent Claude JSONL thinking fragments that share one response message.id
- preserve text, tool, user, interrupt, synthetic-assistant, and response-id boundaries
- keep the first record identity and timestamp while updating completion time and existing largest-usage ownership

## Why

Claude Code writes one assistant JSONL record per content block. Adjacent thinking records from one API response were parsed as separate assistant turns, so history rendered several reasoning cards for a single thought process.

## Testing

- cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib (3032 passed, 1 ignored)
- cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --lib parsers::claude::tests (54 passed)
- cargo clippy --manifest-path src-tauri/Cargo.toml --no-default-features --bin codeg-server --lib -- -D warnings
- pnpm vitest run src/contexts/acp-connections-context.test.tsx (85 passed)
- git diff --check

Fixes #494
