### PR TITLE
feat(hermes): add OrcaRouter as a first-class Hermes provider

### DIFF
--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -6497,6 +6497,15 @@ const HERMES_PROVIDERS: &[HermesProvider] = &[
         needs_base_url: false,
         base_url_env_var: "OPENROUTER_BASE_URL",
     },
+    // OrcaRouter — OpenAI-compatible AI gateway (models.dev catalog, env var
+    // `ORCAROUTER_API_KEY`). Resolved by Hermes through the same models.dev
+    // fallback as openrouter (`get_provider`), so no auth.py entry exists.
+    HermesProvider {
+        id: "orcarouter",
+        key_env_var: "ORCAROUTER_API_KEY",
+        needs_base_url: false,
+        base_url_env_var: "ORCAROUTER_BASE_URL",
+    },
     HermesProvider {
         id: "openai-api",
         key_env_var: "OPENAI_API_KEY",
@@ -17044,6 +17053,7 @@ wire_api = "chat"
         // of GLM_API_KEY) fails CI rather than silently sending the wrong key var.
         let expected: &[(&str, &str)] = &[
             ("openrouter", "OPENROUTER_API_KEY"),
+            ("orcarouter", "ORCAROUTER_API_KEY"),
             ("openai-api", "OPENAI_API_KEY"),
             ("anthropic", "ANTHROPIC_API_KEY"),
             ("gemini", "GOOGLE_API_KEY"),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -785,6 +785,12 @@ export const HERMES_PROVIDERS: HermesProviderOption[] = [
     kind: "apiKey",
   },
   {
+    id: "orcarouter",
+    label: "OrcaRouter",
+    needsBaseUrl: false,
+    kind: "apiKey",
+  },
+  {
     id: "openai-api",
     label: "OpenAI / Compatible",
     needsBaseUrl: true,


### PR DESCRIPTION
## Summary

Codeg drives a curated set of Hermes providers through structured fields: the settings panel writes the chosen provider's API key into `~/.hermes/.env` and sets `model.provider` in `config.yaml`, so a named provider works without treating it as an anonymous custom base URL. This PR registers **OrcaRouter** as a first-class provider in both mirrored tables — the Rust source of truth in `commands/acp.rs` and the TypeScript table the panel binds to in `src/lib/types.ts` — mirroring the existing `openrouter` entry.

## Changes

- `src-tauri/src/commands/acp.rs`: added `orcarouter` to `HERMES_PROVIDERS` (right after `openrouter`) with `key_env_var: "ORCAROUTER_API_KEY"` and no user-supplied base URL — its endpoint is fixed, exactly like OpenRouter. Also added the entry to the `hermes_provider_key_env_vars_match_authoritative_registry` test's expected list, which locks the table down against drift.
- `src/lib/types.ts`: added the matching `orcarouter` entry to the TS `HERMES_PROVIDERS` table (`label: "OrcaRouter"`, `kind: "apiKey"`, `needsBaseUrl: false`). The Rust↔TS parity test (`src/lib/hermes-providers.test.ts`) asserts the two tables stay in lockstep on id order and key-presence.

## How it resolves

Hermes resolves `orcarouter` through its models.dev fallback — the same path it already uses for `openrouter`, which also has no entry in `auth.py`'s `PROVIDER_REGISTRY`. `hermes_cli/providers.py::get_provider` finds `orcarouter` in the models.dev catalog (`ORCAROUTER_API_KEY`, `https://api.orcarouter.ai/v1`, 117 models), so `model.provider: orcarouter` works end to end with no application-level changes in Hermes.

## Verification

- Rust↔TS parity test logic runs green (id order + key presence across both tables).
- `tsc --strict` on `src/lib/types.ts` passes; Prettier check passes.
- Live L3 check against the new provider path: `POST https://api.orcarouter.ai/v1/chat/completions` with model `orcarouter/fusion-mini` returned HTTP 200 with a normal completion (routed to `openai/gpt-oss-120b`), confirming the endpoint and model namespace work exactly as OpenRouter-style aggregators do.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means Codeg's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
