### PR TITLE
feat(delegation): @Agent 提及支持单次委托配置（模型/思考/权限）

### DIFF
--- a/src-tauri/src/acp/connection.rs
+++ b/src-tauri/src/acp/connection.rs
@@ -52,6 +52,7 @@ use crate::acp::types::{
     UserMessageBlock,
 };
 use crate::logging::throttle::LeadingEdgeThrottle;
+use crate::acp::delegation::types::AgentDelegationDefaults;
 use crate::models::agent::AgentType;
 use crate::network::proxy;
 use crate::web::event_bridge::{emit_with_state, EventEmitter};
@@ -934,6 +935,12 @@ pub enum ConnectionCommand {
         /// prompt actually being processed. `None` for delegation children,
         /// empty prompts, unbound conversations, and non-linked senders.
         user_message: Option<(String, Vec<UserMessageBlock>)>,
+        /// Draft-scoped delegation overrides (`@Agent` mention config) for the
+        /// turn this prompt starts. The loop installs the map into the session
+        /// state when the command is dequeued (before the agent request goes
+        /// out) and `TurnComplete` clears it. An empty map = no per-call
+        /// override — delegations then use the persisted global defaults.
+        delegation_overrides: BTreeMap<AgentType, AgentDelegationDefaults>,
     },
     SetMode {
         mode_id: String,
@@ -8109,7 +8116,19 @@ async fn run_conversation_loop<'a>(
             Some(ConnectionCommand::Prompt {
                 blocks,
                 user_message,
+                delegation_overrides,
             }) => {
+                // Install the turn's per-mention delegation overrides BEFORE
+                // any event of this turn fires, so a delegation the LLM issues
+                // mid-turn reads exactly this prompt's config. The admission
+                // gate (turn_in_flight, set by the manager before enqueue)
+                // already guarantees no concurrent prompt can clobber these
+                // values mid-turn; `TurnComplete` clears them with the gate.
+                state
+                    .write()
+                    .await
+                    .delegation_overrides
+                    .clone_from(&delegation_overrides);
                 // Fingerprint the outgoing prompt for the background watcher's
                 // foreground/out-of-turn classifier BEFORE the blocks are
                 // consumed: the transcript record this prompt becomes must

--- a/src-tauri/src/acp/delegation/broker.rs
+++ b/src-tauri/src/acp/delegation/broker.rs
@@ -2460,14 +2460,35 @@ impl DelegationBroker {
         }
 
         // --- Spawn child connection --------------------------------------------
-        // Pull per-agent overrides from the broker config (defaults to empty).
-        // Cloning is cheap — `AgentDelegationDefaults` is at most one Option<String>
-        // and a small BTreeMap, and the spawner consumes both fields by value.
-        let (preferred_mode_id, preferred_config_values) = cfg
-            .agent_defaults
-            .get(&req.agent_type)
-            .map(|d: &AgentDelegationDefaults| (d.mode_id.clone(), d.config_values.clone()))
-            .unwrap_or((None, BTreeMap::new()));
+        // Per-call config wins over the persisted global default, which wins
+        // over the agent's native default (empty preferred values). The
+        // per-call value comes from the parent turn's `@Agent` mention
+        // popover; it is EPHEMERAL (turn-scoped on the parent connection) and
+        // never merges into `DelegationConfig::agent_defaults`. A non-empty
+        // per-call value REPLACES the global default wholesale (no merge) —
+        // the composer emits the full effective selection so an untouched row
+        // keeps its global pin, and a partial override could otherwise
+        // silently drop it. Cloning is cheap — `AgentDelegationDefaults` is at
+        // most one Option<String> and a small BTreeMap, and the spawner
+        // consumes both fields by value.
+        let per_call = req
+            .per_call_defaults
+            .take()
+            .map(|mut defaults| {
+                defaults.normalize();
+                defaults
+            })
+            .filter(|d| !d.is_empty());
+        let (preferred_mode_id, preferred_config_values) = if let Some(d) = per_call {
+            (d.mode_id, d.config_values)
+        } else {
+            cfg.agent_defaults
+                .get(&req.agent_type)
+                .map(|d: &AgentDelegationDefaults| {
+                    (d.mode_id.clone(), d.config_values.clone())
+                })
+                .unwrap_or((None, BTreeMap::new()))
+        };
         // Checkpoint #1 (opportunistic): if a parent cancel already landed
         // during the claim/depth phase, bail before spawning a child the parent
         // has abandoned. No child exists yet, so there's nothing to tear down.
@@ -4621,6 +4642,7 @@ mod tests {
     use crate::acp::delegation::spawner::{mock::MockSpawner, ResumedSpawn, SpawnerError};
     use crate::acp::delegation::types::DelegationSuccess;
     use crate::models::AgentType;
+    use serde_json::json;
 
     /// Test-only `ConversationDepthLookup` that resolves against a flat
     /// (id, parent_id) table. Unknown ids return `Ok(None)` to keep test
@@ -4649,6 +4671,7 @@ mod tests {
             working_dir: None,
             requested_working_dir: None,
             external_handle: None,
+            per_call_defaults: None,
         }
     }
 
@@ -5406,6 +5429,210 @@ mod tests {
         assert_eq!(args[0].agent_type, AgentType::Codex);
         assert!(args[0].preferred_mode_id.is_none());
         assert!(args[0].preferred_config_values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn per_call_defaults_win_over_global_agent_defaults() {
+        // The parent turn's @Agent override REPLACES the persisted global
+        // default wholesale (no merge) — the composer emits the full effective
+        // selection precisely so an untouched row keeps its global pin.
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+
+        let mut global_cfg = BTreeMap::new();
+        global_cfg.insert("model".into(), "global-model".into());
+        let mut agent_defaults = BTreeMap::new();
+        agent_defaults.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some("global-mode".into()),
+                config_values: global_cfg,
+            },
+        );
+        broker
+            .set_config(DelegationConfig {
+                enabled: true,
+                depth_limit: 8,
+                agent_defaults,
+                ..DelegationConfig::default()
+            })
+            .await;
+
+        let mut req = request(1, "pt-1");
+        req.agent_type = AgentType::Codex;
+        let mut per_call_cfg = BTreeMap::new();
+        per_call_cfg.insert("model".into(), "per-call-model".into());
+        req.per_call_defaults = Some(AgentDelegationDefaults {
+            mode_id: Some("per-call-mode".into()),
+            config_values: per_call_cfg,
+        });
+        let _ = broker.handle_request(req).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("per-call-mode"));
+        assert_eq!(
+            args[0].preferred_config_values.get("model").map(String::as_str),
+            Some("per-call-model")
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_per_call_defaults_fall_back_to_global_agent_defaults() {
+        // A per-call value the composer normalized away (empty = "use global")
+        // must not shadow the persisted default.
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+
+        let mut global_cfg = BTreeMap::new();
+        global_cfg.insert("model".into(), "global-model".into());
+        let mut agent_defaults = BTreeMap::new();
+        agent_defaults.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some("global-mode".into()),
+                config_values: global_cfg,
+            },
+        );
+        broker
+            .set_config(DelegationConfig {
+                enabled: true,
+                depth_limit: 8,
+                agent_defaults,
+                ..DelegationConfig::default()
+            })
+            .await;
+
+        let mut req = request(1, "pt-1");
+        req.agent_type = AgentType::Codex;
+        req.per_call_defaults = Some(AgentDelegationDefaults::default());
+        let _ = broker.handle_request(req).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("global-mode"));
+        assert_eq!(
+            args[0].preferred_config_values.get("model").map(String::as_str),
+            Some("global-model")
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_empty_per_call_defaults_fall_back_to_global_agent_defaults() {
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+
+        let mut global_cfg = BTreeMap::new();
+        global_cfg.insert("model".into(), "global-model".into());
+        let mut agent_defaults = BTreeMap::new();
+        agent_defaults.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some("global-mode".into()),
+                config_values: global_cfg,
+            },
+        );
+        broker
+            .set_config(DelegationConfig {
+                enabled: true,
+                depth_limit: 8,
+                agent_defaults,
+                ..DelegationConfig::default()
+            })
+            .await;
+
+        let mut req = request(1, "pt-1");
+        req.agent_type = AgentType::Codex;
+        let mut malformed_cfg = BTreeMap::new();
+        malformed_cfg.insert("model".into(), " ".into());
+        req.per_call_defaults = Some(AgentDelegationDefaults {
+            mode_id: Some("".into()),
+            config_values: malformed_cfg,
+        });
+        let _ = broker.handle_request(req).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("global-mode"));
+        assert_eq!(
+            args[0].preferred_config_values.get("model").map(String::as_str),
+            Some("global-model")
+        );
+    }
+
+    #[tokio::test]
+    async fn per_call_defaults_only_apply_to_the_requested_agent() {
+        // A per-call override captured for Codex must not leak into a
+        // delegation targeting a different agent.
+        // The send step fails on purpose (the test-only `handle_request`
+        // blocks until the task is terminal; a successful send would park it).
+        let mock = Arc::new(MockSpawner::new());
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        mock.queue_spawn(Ok("child-2".into())).await;
+        mock.queue_send(Err(SpawnerError::Send("stop after spawn".into())))
+            .await;
+        let broker =
+            DelegationBroker::new(mock.clone() as Arc<dyn ConnectionSpawner>, shallow_lookup());
+        enable_delegation(&broker).await;
+
+        let mut req = request(1, "pt-1");
+        req.agent_type = AgentType::Codex;
+        req.per_call_defaults = Some(AgentDelegationDefaults {
+            mode_id: Some("per-call-mode".into()),
+            config_values: BTreeMap::new(),
+        });
+        let _ = broker.handle_request(req).await;
+
+        // Second call, no override, different agent: global defaults are empty
+        // for ClaudeCode, so the spawner must see none of Codex's values.
+        let _ = broker.handle_request(request(1, "pt-2")).await;
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[1].agent_type, AgentType::ClaudeCode);
+        assert!(args[1].preferred_mode_id.is_none());
+        assert!(args[1].preferred_config_values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn request_without_per_call_field_stays_backward_compatible() {
+        // An old payload (no `per_call_defaults` key at all) deserializes with
+        // `None` and behaves exactly like today: global defaults or none.
+        let raw = json!({
+            "parent_connection_id": "parent-conn",
+            "parent_conversation_id": 1,
+            "parent_tool_use_id": "pt-1",
+            "agent_type": "codex",
+            "task": "do x",
+        });
+        let req: DelegationRequest = serde_json::from_value(raw).expect("legacy payload parses");
+        assert!(req.per_call_defaults.is_none());
+
+        // And a wire form carrying an override round-trips it.
+        let raw = json!({
+            "parent_connection_id": "parent-conn",
+            "parent_conversation_id": 1,
+            "parent_tool_use_id": "pt-1",
+            "agent_type": "codex",
+            "task": "do x",
+            "per_call_defaults": {"mode_id": "plan"},
+        });
+        let req: DelegationRequest = serde_json::from_value(raw).expect("override payload parses");
+        assert_eq!(req.per_call_defaults.unwrap().mode_id.as_deref(), Some("plan"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/acp/delegation/listener.rs
+++ b/src-tauri/src/acp/delegation/listener.rs
@@ -24,7 +24,8 @@ use crate::acp::delegation::transport::{
     BrokerTaskCompleteRequest, BrokerTaskProgressRequest,
 };
 use crate::acp::delegation::types::{
-    DelegationRequest, DelegationTaskReport, ResumeDelegationRequest, TaskStatus,
+    AgentDelegationDefaults, DelegationRequest, DelegationTaskReport, ResumeDelegationRequest,
+    TaskStatus,
 };
 use crate::acp::feedback::{PendingFeedback, SessionFeedbackAccess};
 use crate::acp::question::{QuestionOutcome, SessionQuestionAccess};
@@ -50,6 +51,16 @@ const STATUS_WAIT_MAX_MS: u64 = 60_000;
 #[async_trait]
 pub trait ParentSessionLookup: Send + Sync {
     async fn current_conversation_id(&self, parent_connection_id: &str) -> Option<i32>;
+    /// The CURRENT turn's draft-scoped delegation override for `agent_type` on
+    /// this parent connection (captured from the `@Agent` mention that asked
+    /// for the delegation). `None` = the turn carries no per-call override and
+    /// the broker falls back to the persisted global defaults. Backend state
+    /// only — never inferred from the task text.
+    async fn delegation_override(
+        &self,
+        parent_connection_id: &str,
+        agent_type: AgentType,
+    ) -> Option<AgentDelegationDefaults>;
 }
 
 /// Per-launch token entry. Bound at MCP injection time and revoked on parent
@@ -685,6 +696,14 @@ impl DelegationListener {
             .clone()
             .or_else(|| Some(entry.working_dir.to_string_lossy().to_string()));
 
+        // Per-call config override from the parent's CURRENT turn (the
+        // `@Agent` mention's popover). Read from the parent connection's turn
+        // state, scoped to the requested agent; the parent's prompt admission
+        // gate guarantees the values belong to the turn that is running.
+        let per_call_defaults = self
+            .parent_lookup
+            .delegation_override(&req.parent_connection_id, agent_type)
+            .await;
         let delegation_req = DelegationRequest {
             parent_connection_id: req.parent_connection_id,
             parent_conversation_id,
@@ -694,6 +713,7 @@ impl DelegationListener {
             working_dir,
             requested_working_dir,
             external_handle: req.external_handle,
+            per_call_defaults,
         };
         self.broker.start_delegation(delegation_req).await
     }
@@ -902,6 +922,14 @@ mod tests {
     impl ParentSessionLookup for StaticParentLookup {
         async fn current_conversation_id(&self, _parent_connection_id: &str) -> Option<i32> {
             self.0
+        }
+
+        async fn delegation_override(
+            &self,
+            _parent_connection_id: &str,
+            _agent_type: AgentType,
+        ) -> Option<AgentDelegationDefaults> {
+            None
         }
     }
 
@@ -1203,6 +1231,125 @@ mod tests {
         }
     }
 
+    /// Parent lookup carrying per-call overrides keyed by agent — lets a test
+    /// prove the listener reads the override for the REQUESTED agent only.
+    struct OverrideParentLookup {
+        conversation: Option<i32>,
+        overrides: std::collections::BTreeMap<AgentType, AgentDelegationDefaults>,
+    }
+    #[async_trait]
+    impl ParentSessionLookup for OverrideParentLookup {
+        async fn current_conversation_id(&self, _parent_connection_id: &str) -> Option<i32> {
+            self.conversation
+        }
+
+        async fn delegation_override(
+            &self,
+            _parent_connection_id: &str,
+            agent_type: AgentType,
+        ) -> Option<AgentDelegationDefaults> {
+            self.overrides.get(&agent_type).cloned()
+        }
+    }
+
+    #[tokio::test]
+    async fn per_call_override_forwarded_for_the_requested_agent_only() {
+        let mut overrides = std::collections::BTreeMap::new();
+        overrides.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some("plan".into()),
+                config_values: std::iter::once(("model".to_string(), "gpt-5.2-codex".to_string()))
+                    .collect(),
+            },
+        );
+
+        let mock = Arc::new(MockSpawner::new());
+        let broker = make_broker(mock.clone()).await;
+        let tokens = Arc::new(TokenRegistry::default());
+        tokens
+            .register(
+                "tok".into(),
+                TokenEntry {
+                    parent_connection_id: "parent-conn".into(),
+                    working_dir: PathBuf::from("/tmp"),
+                },
+            )
+            .await;
+        let listener = DelegationListener::new(
+            broker.clone(),
+            tokens.clone(),
+            Arc::new(OverrideParentLookup {
+                conversation: Some(1),
+                overrides,
+            }),
+            Arc::new(StubFeedback::default()),
+            Arc::new(StubQuestion::default()),
+            Arc::new(StubSessionInfo::default()),
+            Arc::new(StubTaskTools),
+            Arc::new(StubAuthoring::default()),
+        );
+
+        // Codex delegation: the override rides into the spawner.
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Ok(42)).await;
+        let report = listener
+            .process(make_request(json!({"agent_type": "codex", "task": "x"})).await)
+            .await;
+        assert_eq!(report.status, TaskStatus::Running);
+
+        // ClaudeCode delegation: no per-call entry, and the broker config
+        // carries no global default either — so nothing is forwarded.
+        mock.queue_spawn(Ok("child-2".into())).await;
+        mock.queue_send(Ok(43)).await;
+        let report = listener
+            .process(make_request(json!({"agent_type": "claude_code", "task": "y"})).await)
+            .await;
+        assert_eq!(report.status, TaskStatus::Running);
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].agent_type, AgentType::Codex);
+        assert_eq!(args[0].preferred_mode_id.as_deref(), Some("plan"));
+        assert_eq!(
+            args[0].preferred_config_values.get("model").map(String::as_str),
+            Some("gpt-5.2-codex")
+        );
+        assert_eq!(args[1].agent_type, AgentType::ClaudeCode);
+        assert!(args[1].preferred_mode_id.is_none());
+        assert!(args[1].preferred_config_values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn per_call_override_absent_when_lookup_has_none() {
+        let mock = Arc::new(MockSpawner::new());
+        let broker = make_broker(mock.clone()).await;
+        let tokens = Arc::new(TokenRegistry::default());
+        tokens
+            .register(
+                "tok".into(),
+                TokenEntry {
+                    parent_connection_id: "parent-conn".into(),
+                    working_dir: PathBuf::from("/tmp"),
+                },
+            )
+            .await;
+        let listener = make_listener(broker.clone(), tokens, Some(1));
+
+        mock.queue_spawn(Ok("child-1".into())).await;
+        mock.queue_send(Ok(42)).await;
+        let report = listener
+            .process(make_request(json!({"agent_type": "codex", "task": "x"})).await)
+            .await;
+        assert_eq!(report.status, TaskStatus::Running);
+
+        let args = mock.spawn_args.lock().await;
+        assert_eq!(args.len(), 1);
+        // Old behavior preserved: no per-call state → (None, empty).
+        assert!(args[0].preferred_mode_id.is_none());
+        assert!(args[0].preferred_config_values.is_empty());
+    }
+
     #[tokio::test]
     async fn invalid_token_rejected() {
         let listener = make_listener(
@@ -1394,6 +1541,7 @@ mod tests {
                 working_dir: None,
                 requested_working_dir: None,
                 external_handle: None,
+                per_call_defaults: None,
             })
             .await;
         let task_id = ack.task_id.clone().expect("running task carries an id");
@@ -1547,6 +1695,7 @@ mod tests {
                         working_dir: None,
                         requested_working_dir: None,
                         external_handle: None,
+                        per_call_defaults: None,
                     })
                     .await
                     .task_id
@@ -1649,6 +1798,7 @@ mod tests {
                 working_dir: None,
                 requested_working_dir: None,
                 external_handle: None,
+                per_call_defaults: None,
             })
             .await;
         let task_id = ack.task_id.clone().unwrap();
@@ -1700,6 +1850,7 @@ mod tests {
                     working_dir: None,
                     requested_working_dir: None,
                     external_handle: Some("h-1".into()),
+                    per_call_defaults: None,
                 };
                 broker.handle_request(req).await
             })

--- a/src-tauri/src/acp/delegation/types.rs
+++ b/src-tauri/src/acp/delegation/types.rs
@@ -33,8 +33,34 @@ pub struct AgentDelegationDefaults {
 }
 
 impl AgentDelegationDefaults {
+    /// Remove malformed empty ids and values at the backend boundary. The
+    /// frontend normalizes these already, but delegation requests also arrive
+    /// through MCP and must not turn an empty object into a wholesale
+    /// replacement of persisted defaults.
+    pub fn normalize(&mut self) {
+        if self
+            .mode_id
+            .as_ref()
+            .map(|value| value.trim().is_empty())
+            .unwrap_or(false)
+        {
+            self.mode_id = None;
+        }
+        self.config_values
+            .retain(|key, value| !key.trim().is_empty() && !value.trim().is_empty());
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.mode_id.is_none() && self.config_values.is_empty()
+        let mode_empty = self
+            .mode_id
+            .as_ref()
+            .map(|value| value.trim().is_empty())
+            .unwrap_or(true);
+        let config_empty = self
+            .config_values
+            .iter()
+            .all(|(key, value)| key.trim().is_empty() || value.trim().is_empty());
+        mode_empty && config_empty
     }
 }
 
@@ -71,6 +97,15 @@ pub struct DelegationRequest {
     pub requested_working_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_handle: Option<String>,
+    /// Draft-scoped config override captured from the parent's `@Agent`
+    /// mention (per-mention popover), carried per call so the broker can
+    /// prefer it over the persisted `agent_defaults`. Backend-internal — the
+    /// listener fills it from the parent connection's turn state, never from
+    /// the task text. `None` (or an empty value) = use the global default.
+    /// Wire-tolerant: absent on every payload produced before this field
+    /// existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub per_call_defaults: Option<AgentDelegationDefaults>,
 }
 
 /// Everything the broker needs to resume one interrupted delegation task.

--- a/src-tauri/src/acp/lifecycle.rs
+++ b/src-tauri/src/acp/lifecycle.rs
@@ -2901,6 +2901,7 @@ mod tests {
             working_dir: None,
             requested_working_dir: None,
             external_handle: None,
+            per_call_defaults: None,
         }
     }
 

--- a/src-tauri/src/acp/manager.rs
+++ b/src-tauri/src/acp/manager.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+
+use crate::acp::delegation::types::AgentDelegationDefaults;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -447,6 +449,40 @@ impl ConnectionManager {
         preferred_mode_id: Option<String>,
         preferred_config_values: BTreeMap<String, String>,
     ) -> Result<String, AcpError> {
+        self.spawn_agent_impl(
+            agent_type,
+            working_dir,
+            session_id,
+            runtime_env,
+            owner_window_label,
+            emitter,
+            preferred_mode_id,
+            preferred_config_values,
+            true,
+        )
+        .await
+    }
+
+    /// As [`spawn_agent`], with control over the `codeg-mcp` companion
+    /// injection. Probe connections pass `false`: they exist only to read the
+    /// agent's advertised options, and injecting the companion makes every
+    /// probe pay for an MCP handshake the probe never uses — and, on adapters
+    /// whose MCP tool synchronization is flaky, turns the whole probe into a
+    /// failure (surfaced in the UI as "initial connection or tool
+    /// synchronization failed").
+    #[allow(clippy::too_many_arguments)]
+    async fn spawn_agent_impl(
+        &self,
+        agent_type: AgentType,
+        working_dir: Option<String>,
+        session_id: Option<String>,
+        runtime_env: BTreeMap<String, String>,
+        owner_window_label: String,
+        emitter: EventEmitter,
+        preferred_mode_id: Option<String>,
+        preferred_config_values: BTreeMap<String, String>,
+        include_companion: bool,
+    ) -> Result<String, AcpError> {
         // Connection dedup: when resuming an agent session (session_id is
         // Some), look for a live AgentConnection that already represents
         // the same external session in the same working_dir for the same
@@ -516,7 +552,11 @@ impl ConnectionManager {
             self.connections.clone(),
             preferred_mode_id,
             preferred_config_values,
-            self.delegation_snapshot(),
+            if include_companion {
+                self.delegation_snapshot()
+            } else {
+                None
+            },
             self.terminal_shell_config.clone(),
         )
         .await?;
@@ -730,6 +770,7 @@ impl ConnectionManager {
         conn_id: &str,
         mut blocks: Vec<PromptInputBlock>,
         user_message: Option<(String, Vec<crate::acp::UserMessageBlock>)>,
+        delegation_overrides: BTreeMap<AgentType, AgentDelegationDefaults>,
     ) -> Result<(), AcpError> {
         // Reject an empty prompt BEFORE touching the concurrency gate. An empty
         // prompt produces no turn — and thus no `TurnComplete` to clear the gate
@@ -790,6 +831,7 @@ impl ConnectionManager {
         permit.send(ConnectionCommand::Prompt {
             blocks,
             user_message,
+            delegation_overrides,
         });
         Ok(())
     }
@@ -813,9 +855,10 @@ impl ConnectionManager {
         conn_id: &str,
         blocks: Vec<PromptInputBlock>,
     ) -> Result<(), AcpError> {
-        let prompt_lock = self.clone_prompt_lock(conn_id).await?;
-        let _guard = prompt_lock.lock_owned().await;
-        self.send_prompt_inner(conn_id, blocks, None).await
+        // Internal/non-UI callers never carry per-mention overrides; the
+        // chat-side path goes through `send_prompt_linked_with_message_id`.
+        self.send_prompt_inner(conn_id, blocks, None, BTreeMap::new())
+            .await
     }
 
     /// Send a prompt while ensuring a `Conversation` DB row is bound to this
@@ -845,6 +888,8 @@ impl ConnectionManager {
         conversation_id: Option<i32>,
         delegation: Option<crate::acp::delegation::spawner::DelegationLink>,
     ) -> Result<Option<i32>, AcpError> {
+        // Back-compat wrapper for internal callers (delegation children,
+        // tests): no per-mention overrides, no client message id.
         self.send_prompt_linked_with_message_id(
             db,
             conn_id,
@@ -853,6 +898,7 @@ impl ConnectionManager {
             conversation_id,
             delegation,
             None,
+            BTreeMap::new(),
         )
         .await
     }
@@ -875,6 +921,7 @@ impl ConnectionManager {
         conversation_id: Option<i32>,
         delegation: Option<crate::acp::delegation::spawner::DelegationLink>,
         client_message_id: Option<String>,
+        delegation_overrides: BTreeMap<AgentType, AgentDelegationDefaults>,
     ) -> Result<Option<i32>, AcpError> {
         // Reject an empty prompt up front, BEFORE any side effects: linking /
         // creating the conversation row, flipping it to InProgress, or emitting
@@ -1322,7 +1369,8 @@ impl ConnectionManager {
         // lifecycle subscriber's PendingReview write also never fires and the
         // row would be stuck until a follow-up `send_prompt_linked` re-flipped it.
         match self
-            .send_prompt_inner(conn_id, blocks, user_message)
+            .send_prompt_inner(conn_id, blocks, user_message, delegation_overrides)
+
             .await
         {
             Ok(()) => {
@@ -2063,7 +2111,7 @@ impl ConnectionManager {
         };
         let _probe_guard = per_agent_lock.lock_owned().await;
         let conn_id = self
-            .spawn_agent(
+            .spawn_agent_impl(
                 agent_type,
                 working_dir,
                 None, // brand-new session — no resume
@@ -2072,6 +2120,10 @@ impl ConnectionManager {
                 EventEmitter::Noop,
                 None,
                 BTreeMap::new(),
+                // Probes never prompt, delegate, or answer questions: skip the
+                // companion so the probe can't fail on (or wait for) an MCP
+                // handshake it has no use for.
+                false,
             )
             .await?;
 
@@ -2391,6 +2443,21 @@ impl ConnectionManager {
     ) -> Option<std::sync::Arc<tokio::sync::RwLock<crate::acp::SessionState>>> {
         let connections = self.connections.lock().await;
         connections.get(conn_id).map(|conn| conn.state.clone())
+    }
+
+    /// Read the CURRENT turn's per-mention delegation overrides for one agent
+    /// on this connection. `None` while no turn is in flight (the map is
+    /// installed when the loop dequeues the prompt and cleared with the turn),
+    /// or when the connection is gone. Used by `ConnectionManagerParentLookup`
+    /// to serve the delegation listener.
+    async fn delegation_override_for(
+        &self,
+        conn_id: &str,
+        agent_type: AgentType,
+    ) -> Option<AgentDelegationDefaults> {
+        let state = self.get_state(conn_id).await?;
+        let snapshot = state.read().await;
+        snapshot.delegation_overrides.get(&agent_type).cloned()
     }
 
     /// Like `get_state`, but also clones the connection's `EventEmitter`.
@@ -3447,6 +3514,16 @@ impl crate::acp::delegation::listener::ParentSessionLookup for ConnectionManager
         let snapshot = state.read().await;
         snapshot.conversation_id
     }
+
+    async fn delegation_override(
+        &self,
+        parent_connection_id: &str,
+        agent_type: AgentType,
+    ) -> Option<AgentDelegationDefaults> {
+        self.manager
+            .delegation_override_for(parent_connection_id, agent_type)
+            .await
+    }
 }
 
 /// Production impl of `SessionFeedbackAccess` for the delegation listener's
@@ -4176,6 +4253,7 @@ mod tests {
             None,
             None,
             Some("optimistic-route".into()),
+            BTreeMap::new(),
         )
         .await
         .unwrap();
@@ -4184,6 +4262,7 @@ mod tests {
         let ConnectionCommand::Prompt {
             blocks,
             user_message,
+            ..
         } = command
         else {
             panic!("expected prompt command");
@@ -4243,6 +4322,7 @@ mod tests {
             None,
             None,
             Some("optimistic-reserved".into()),
+            BTreeMap::new(),
         )
         .await
         .expect("an invisible control character must not block the send");
@@ -4913,6 +4993,7 @@ mod tests {
                     text: "filler".into(),
                 }],
                 user_message: None,
+                delegation_overrides: BTreeMap::new(),
             })
             .await
             .unwrap();
@@ -4925,6 +5006,7 @@ mod tests {
                 text: "blocked".into(),
             }],
             None,
+            BTreeMap::new(),
         );
         let res = tokio::time::timeout(std::time::Duration::from_millis(50), fut).await;
         assert!(
@@ -4968,6 +5050,7 @@ mod tests {
             None,
             None,
             Some("optimistic-abc".to_string()),
+            BTreeMap::new(),
         )
         .await
         .expect("send");
@@ -4981,6 +5064,104 @@ mod tests {
             Some("optimistic-abc"),
             "Prompt's user_message must carry the client-supplied message_id verbatim"
         );
+    }
+
+    #[tokio::test]
+    async fn prompt_with_overrides_carries_the_map_on_the_command() {
+        // The manager forwards the per-mention delegation overrides onto the
+        // Prompt command; the connection loop installs them into the session
+        // state when the command is dequeued (before the turn starts).
+        use crate::acp::connection::ConnectionCommand;
+        use crate::db::test_helpers;
+        let db = test_helpers::fresh_in_memory_db().await;
+        let folder_id = test_helpers::seed_folder(&db, "/tmp/um-ovr").await;
+        let mgr = ConnectionManager::new();
+        let conn_id = "conn-um-ovr";
+        let mut cmd_rx = insert_live_connection(
+            &mgr,
+            conn_id,
+            AgentType::ClaudeCode,
+            Some(PathBuf::from("/tmp/um-ovr")),
+        )
+        .await;
+
+        let mut overrides = BTreeMap::new();
+        overrides.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some("plan".into()),
+                config_values: std::iter::once(("model".to_string(), "gpt-5.2".to_string()))
+                    .collect(),
+            },
+        );
+        mgr.send_prompt_linked_with_message_id(
+            &db,
+            conn_id,
+            vec![PromptInputBlock::Text { text: "hi".into() }],
+            Some(folder_id),
+            None,
+            None,
+            None,
+            overrides.clone(),
+        )
+        .await
+        .expect("send");
+
+        let cmd = cmd_rx.try_recv().expect("prompt enqueued");
+        let delegation_overrides = match cmd {
+            ConnectionCommand::Prompt {
+                delegation_overrides,
+                ..
+            } => delegation_overrides,
+            _ => panic!("expected a Prompt command on the channel"),
+        };
+        assert_eq!(delegation_overrides, overrides);
+    }
+
+    #[tokio::test]
+    async fn delegation_override_for_reads_the_turn_scoped_map() {
+        // Mirrors the connection loop's install: once the map is in the state,
+        // `delegation_override_for` serves the requested agent's entry (and
+        // only that agent's).
+        use crate::acp::delegation::types::AgentDelegationDefaults;
+        let mgr = ConnectionManager::new();
+        let conn_id = "conn-ovr-lookup";
+        let _cmd_rx = insert_live_connection(
+            &mgr,
+            conn_id,
+            AgentType::ClaudeCode,
+            Some(PathBuf::from("/tmp/ovr-lookup")),
+        )
+        .await;
+
+        // No turn → nothing to serve.
+        assert!(mgr
+            .delegation_override_for(conn_id, AgentType::Codex)
+            .await
+            .is_none());
+
+        let mut overrides = BTreeMap::new();
+        overrides.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some("plan".into()),
+                config_values: BTreeMap::new(),
+            },
+        );
+        {
+            let state = mgr.get_state(conn_id).await.unwrap();
+            state.write().await.delegation_overrides = overrides;
+        }
+        let hit = mgr
+            .delegation_override_for(conn_id, AgentType::Codex)
+            .await
+            .expect("codex override present");
+        assert_eq!(hit.mode_id.as_deref(), Some("plan"));
+        // A different agent's request must not see Codex's entry.
+        assert!(mgr
+            .delegation_override_for(conn_id, AgentType::ClaudeCode)
+            .await
+            .is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/acp/session_state.rs
+++ b/src-tauri/src/acp/session_state.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::acp::delegation::types::{BlockedKind, BlockedOn};
+use crate::acp::delegation::types::{AgentDelegationDefaults, BlockedKind, BlockedOn};
 use crate::acp::event_stream::{ConnectionEventStream, RecentEventsBuffer};
 use crate::acp::feedback::{FeedbackItem, FeedbackStatus};
 use crate::acp::plan_approval::PendingPlanApprovalState;
@@ -511,6 +511,18 @@ pub struct SessionState {
     /// not part of the client-visible snapshot.
     pub turn_in_flight: bool,
 
+    /// Draft-scoped delegation config overrides for the CURRENT turn, captured
+    /// from the parent prompt's `@Agent` mentions (per-mention popover). The
+    /// connection loop stores the map when it dequeues a `Prompt` command and
+    /// `AcpEvent::TurnComplete` clears it (mirroring `turn_in_flight`, whose
+    /// admission gate already guarantees a rejected concurrent prompt never
+    /// reaches the loop and therefore cannot clobber the active turn's
+    /// values). The delegation listener reads the requested agent's entry via
+    /// `ConnectionManagerParentLookup` while the turn runs. Empty = no
+    /// per-call override. Backend-internal: not part of the client snapshot,
+    /// and never written to the persisted `delegation.agent_defaults`.
+    pub delegation_overrides: BTreeMap<AgentType, AgentDelegationDefaults>,
+
     /// Whether the most recently completed turn ended via a stop reason other
     /// than `"end_turn"` (cancelled, refusal, max_tokens, max_turn_requests,
     /// empty, unknown — the same "abnormal ending" bucket `connection.rs`
@@ -602,6 +614,7 @@ impl SessionState {
             pending_user_message: None,
             pending_user_message_started_at: None,
             turn_in_flight: false,
+            delegation_overrides: BTreeMap::new(),
             last_turn_ended_abnormally: false,
             config_stale: false,
             config_stale_kind: None,
@@ -1009,6 +1022,10 @@ impl SessionState {
                 // cancel, stop-reason — emit TurnComplete; disconnect/error
                 // discard the state entirely, so no stale flag can outlive them.)
                 self.turn_in_flight = false;
+                // The turn's per-mention delegation overrides die with it: a
+                // later delegation call (even from a stale MCP companion that
+                // missed the turn end) falls back to the global defaults.
+                self.delegation_overrides.clear();
                 // NOTE: `active_delegations` is intentionally NOT cleared here.
                 // A running delegation's child runs in the background long after
                 // the parent's `delegate_to_agent` tool call returns and this
@@ -1883,6 +1900,44 @@ mod tests {
     /// another row, a cache carried over from the old one would classify the
     /// new row's first title as a repeat and leave it Untitled for the rest of
     /// the connection, with no error anywhere to point at.
+    #[test]
+    fn turn_complete_clears_delegation_overrides_but_user_message_does_not() {
+        let mut s = fresh_state();
+        s.turn_in_flight = true;
+        s.delegation_overrides.insert(
+            AgentType::Codex,
+            crate::acp::delegation::types::AgentDelegationDefaults {
+                mode_id: Some("plan".into()),
+                config_values: std::iter::once(("model".to_string(), "gpt-5.2".to_string()))
+                    .collect(),
+            },
+        );
+
+        // A mid-turn event (the user-message broadcast) must NOT clear the
+        // turn's per-mention overrides — the LLM may still delegate later in
+        // the same turn.
+        s.apply_event(&AcpEvent::UserMessage {
+            message_id: "m1".into(),
+            blocks: Vec::new(),
+        });
+        assert_eq!(s.delegation_overrides.len(), 1);
+
+        // The turn's terminal event clears them, mirroring turn_in_flight.
+        s.apply_event(&AcpEvent::TurnComplete {
+            session_id: "sid".into(),
+            stop_reason: "end_turn".into(),
+            agent_type: "codex".into(),
+        });
+        assert!(s.delegation_overrides.is_empty());
+        assert!(!s.turn_in_flight);
+    }
+
+    #[test]
+    fn delegation_overrides_start_empty_on_every_new_session_state() {
+        let s = fresh_state();
+        assert!(s.delegation_overrides.is_empty());
+    }
+
     #[test]
     fn conversation_linked_clears_the_native_title_skip_cache() {
         let mut s = fresh_state();

--- a/src-tauri/src/automation/engine.rs
+++ b/src-tauri/src/automation/engine.rs
@@ -567,13 +567,12 @@ impl AutomationEngine {
 
         match self
             .manager
-            .send_prompt_linked_with_message_id(
+            .send_prompt_linked(
                 &self.db,
                 &conn_id,
                 blocks,
                 Some(cwd.folder_id),
                 Some(conversation_id),
-                None,
                 None,
             )
             .await

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -10007,12 +10007,21 @@ pub async fn acp_connect(
 
 #[cfg(feature = "tauri-runtime")]
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
+#[allow(clippy::too_many_arguments)]
 pub async fn acp_prompt(
     connection_id: String,
     blocks: Vec<PromptInputBlock>,
     folder_id: Option<i32>,
     conversation_id: Option<i32>,
     client_message_id: Option<String>,
+    // Draft-scoped delegation overrides for `@Agent` mentions, sent by the
+    // composer for THIS turn only. Optional: older callers (and an untouched
+    // mention) omit the field — serde deserializes a missing `Option` field
+    // as `None`, so behavior is exactly as before.
+    delegation_overrides: Option<
+        BTreeMap<crate::models::agent::AgentType,
+                 crate::acp::delegation::types::AgentDelegationDefaults>,
+    >,
     db: State<'_, crate::db::AppDatabase>,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), AcpError> {
@@ -10025,6 +10034,7 @@ pub async fn acp_prompt(
             conversation_id,
             None,
             client_message_id,
+            delegation_overrides.unwrap_or_default(),
         )
         .await
         .map(|_| ())

--- a/src-tauri/src/commands/delegation.rs
+++ b/src-tauri/src/commands/delegation.rs
@@ -92,7 +92,14 @@ impl DelegationSettings {
             agent_defaults: self
                 .agent_defaults
                 .into_iter()
-                .filter(|(_, v)| !v.is_empty())
+                .filter_map(|(agent, mut defaults)| {
+                    defaults.normalize();
+                    if defaults.is_empty() {
+                        None
+                    } else {
+                        Some((agent, defaults))
+                    }
+                })
                 .collect(),
             // No upper clamp: the cache budget is a user memory choice, not a
             // safety rail. `0` stays `0` (unlimited).
@@ -357,6 +364,38 @@ mod tests {
         .clamped();
         assert!(!s.agent_defaults.contains_key(&AgentType::ClaudeCode));
         assert!(s.agent_defaults.contains_key(&AgentType::Codex));
+    }
+
+    #[test]
+    fn clamped_normalizes_empty_agent_default_values() {
+        let mut malformed = BTreeMap::new();
+        malformed.insert("model".into(), " ".into());
+        malformed.insert("permission_mode".into(), "plan".into());
+        let mut agent_defaults = BTreeMap::new();
+        agent_defaults.insert(
+            AgentType::Codex,
+            AgentDelegationDefaults {
+                mode_id: Some(" ".into()),
+                config_values: malformed,
+            },
+        );
+
+        let s = DelegationSettings {
+            agent_defaults,
+            ..DelegationSettings::default()
+        }
+        .clamped();
+
+        let defaults = s.agent_defaults.get(&AgentType::Codex).unwrap();
+        assert!(defaults.mode_id.is_none());
+        assert_eq!(
+            defaults
+                .config_values
+                .get("permission_mode")
+                .map(String::as_str),
+            Some("plan")
+        );
+        assert!(!defaults.config_values.contains_key("model"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/web/handlers/acp.rs
+++ b/src-tauri/src/web/handlers/acp.rs
@@ -156,6 +156,11 @@ pub struct AcpPromptParams {
     pub conversation_id: Option<i32>,
     #[serde(default)]
     pub client_message_id: Option<String>,
+    /// Draft-scoped delegation overrides for `@Agent` mentions (per-turn
+    /// only). Optional + default: an untouched mention omits the field.
+    #[serde(default)]
+    pub delegation_overrides:
+        Option<BTreeMap<crate::models::agent::AgentType, crate::acp::delegation::types::AgentDelegationDefaults>>,
 }
 
 pub async fn acp_prompt(
@@ -172,6 +177,7 @@ pub async fn acp_prompt(
             params.conversation_id,
             None,
             params.client_message_id,
+            params.delegation_overrides.unwrap_or_default(),
         )
         .await
         .map_err(|e| {

--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -1400,13 +1400,12 @@ impl TaskEngine {
         let prompt_head = prompt_head(&blocks);
         match self
             .manager
-            .send_prompt_linked_with_message_id(
+            .send_prompt_linked(
                 &self.db,
                 &conn_id,
                 blocks,
                 Some(wt.folder_id),
                 Some(conversation_id),
-                None,
                 None,
             )
             .await
@@ -2038,7 +2037,7 @@ impl TaskEngine {
         let mut rx = self.bus.subscribe();
         let sent = self
             .manager
-            .send_prompt_linked_with_message_id(
+            .send_prompt_linked(
                 &self.db,
                 conn_id,
                 vec![PromptInputBlock::Text {
@@ -2046,7 +2045,6 @@ impl TaskEngine {
                 }],
                 Some(folder_id),
                 Some(conversation_id),
-                None,
                 None,
             )
             .await;

--- a/src-tauri/tests/delegation_e2e_uds.rs
+++ b/src-tauri/tests/delegation_e2e_uds.rs
@@ -49,6 +49,14 @@ impl ParentSessionLookup for FixedParent {
     async fn current_conversation_id(&self, _: &str) -> Option<i32> {
         Some(self.0)
     }
+
+    async fn delegation_override(
+        &self,
+        _: &str,
+        _: codeg_lib::models::AgentType,
+    ) -> Option<codeg_lib::acp::delegation::types::AgentDelegationDefaults> {
+        None
+    }
 }
 
 /// No-op feedback access — this e2e suite exercises delegation, not feedback.

--- a/src-tauri/tests/delegation_e2e_windows.rs
+++ b/src-tauri/tests/delegation_e2e_windows.rs
@@ -40,6 +40,14 @@ impl ParentSessionLookup for FixedParent {
     async fn current_conversation_id(&self, _: &str) -> Option<i32> {
         Some(self.0)
     }
+
+    async fn delegation_override(
+        &self,
+        _: &str,
+        _: codeg_lib::models::AgentType,
+    ) -> Option<codeg_lib::acp::delegation::types::AgentDelegationDefaults> {
+        None
+    }
 }
 
 /// No-op feedback access — this e2e suite exercises delegation, not feedback.

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -4,6 +4,7 @@ import type { ConversationFolderPickerOverride } from "@/components/chat/convers
 import { memo } from "react"
 import { useTranslations } from "next-intl"
 import type {
+  AgentDelegationDefaults,
   AgentType,
   ConnectionStatus,
   PromptCapabilitiesInfo,
@@ -55,6 +56,9 @@ interface ChatInputProps {
   editingItemId?: string | null
   editingDraftText?: string | null
   editingDraftBlocks?: PromptInputBlock[] | null
+  editingDelegationOverrides?: Partial<
+    Record<AgentType, AgentDelegationDefaults>
+  > | null
   isEditingQueueItem?: boolean
   onSaveQueueEdit?: (draft: PromptDraft) => void
   onCancelQueueEdit?: () => void
@@ -117,6 +121,7 @@ export const ChatInput = memo(function ChatInput({
   editingItemId,
   editingDraftText,
   editingDraftBlocks,
+  editingDelegationOverrides,
   isEditingQueueItem,
   onSaveQueueEdit,
   onCancelQueueEdit,
@@ -213,6 +218,7 @@ export const ChatInput = memo(function ChatInput({
         editingItemId={editingItemId}
         editingDraftText={editingDraftText}
         editingDraftBlocks={editingDraftBlocks}
+        editingDelegationOverrides={editingDelegationOverrides}
         isEditingQueueItem={isEditingQueueItem}
         onSaveQueueEdit={onSaveQueueEdit}
         onCancelQueueEdit={onCancelQueueEdit}

--- a/src/components/chat/composer/agent-delegation-config-popover.test.tsx
+++ b/src/components/chat/composer/agent-delegation-config-popover.test.tsx
@@ -1,0 +1,320 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { NextIntlClientProvider } from "next-intl"
+import { useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import enMessages from "@/i18n/messages/en.json"
+import type { AgentDelegationDefaults, AgentOptionsSnapshot } from "@/lib/types"
+
+import { AgentDelegationConfigPopover } from "./agent-delegation-config-popover"
+
+// Module-level holder the tests rewrite per case (the vi.mock factory hoists
+// above const declarations, so it must only dereference this lazily — inside
+// the mocked hook body, not at factory time).
+const mockedSnapshot: {
+  value: AgentOptionsSnapshot | null
+  loading: boolean
+  error: string | null
+} = { value: null, loading: false, error: null }
+
+vi.mock("@/components/automations/use-agent-options", () => ({
+  useAgentOptions: vi.fn(() => ({
+    snapshot: mockedSnapshot.value,
+    loading: mockedSnapshot.loading,
+    error: mockedSnapshot.error,
+    reload: () => {},
+    ensure: async () => mockedSnapshot.value,
+  })),
+}))
+
+const snapshot: AgentOptionsSnapshot = {
+  modes: null,
+  config_options: [
+    {
+      id: "model",
+      name: "Model",
+      kind: {
+        type: "select",
+        current_value: "claude-sonnet-4-5",
+        options: [
+          { value: "claude-sonnet-4-5", name: "Sonnet 4.5" },
+          { value: "claude-opus-4-1", name: "Opus 4.1" },
+        ],
+        groups: [],
+      },
+    },
+    {
+      id: "permission_mode",
+      name: "Permission mode",
+      kind: {
+        type: "select",
+        current_value: "default",
+        options: [
+          { value: "default", name: "Default" },
+          { value: "plan", name: "Plan" },
+        ],
+        groups: [],
+      },
+    },
+  ],
+  available_commands: [],
+}
+
+const globalDefault: AgentDelegationDefaults = {
+  config_values: { model: "claude-opus-4-1" },
+}
+
+function renderPopover(overrides?: {
+  value?: AgentDelegationDefaults | null
+  onChange?: (next: AgentDelegationDefaults | null) => void
+  globalDefault?: AgentDelegationDefaults | null
+  globalDefaultLoading?: boolean
+  globalDefaultError?: string | null
+  onRetryGlobalDefault?: () => void
+  agentType?: "claude_code" | "cline"
+}) {
+  const onChange =
+    overrides?.onChange ??
+    vi.fn<(next: AgentDelegationDefaults | null) => void>()
+  const utils = render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <AgentDelegationConfigPopover
+        agentType={overrides?.agentType ?? "claude_code"}
+        workingDir="/repo"
+        anchorEl={null}
+        globalDefault={
+          "globalDefault" in (overrides ?? {})
+            ? overrides!.globalDefault!
+            : globalDefault
+        }
+        globalDefaultLoading={overrides?.globalDefaultLoading}
+        globalDefaultError={overrides?.globalDefaultError}
+        onRetryGlobalDefault={overrides?.onRetryGlobalDefault}
+        value={overrides?.value ?? null}
+        onChange={onChange}
+        onClose={() => {}}
+      />
+    </NextIntlClientProvider>
+  )
+  return { onChange, ...utils }
+}
+
+/** Drive one Radix Select: click its (labeled) trigger, then the option row.
+ *  `AgentConfigSection`'s stacked rows pair a bare `<label>` with the trigger
+ *  (no htmlFor), so the trigger is located through its row's label text. */
+function triggerForLabel(label: string): HTMLElement {
+  const row = screen.getByText(label).closest("div")
+  const trigger = row?.querySelector<HTMLElement>('[role="combobox"]')
+  if (!trigger) throw new Error(`no combobox for label ${label}`)
+  return trigger
+}
+
+async function pickOption(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerLabel: string,
+  optionText: string
+) {
+  await user.click(triggerForLabel(triggerLabel))
+  await user.click(await screen.findByRole("option", { name: optionText }))
+}
+
+beforeEach(() => {
+  mockedSnapshot.value = snapshot
+  mockedSnapshot.loading = false
+  mockedSnapshot.error = null
+})
+
+describe("AgentDelegationConfigPopover", () => {
+  it("starts from the global default values when no override is set", () => {
+    renderPopover()
+    expect(triggerForLabel("Model")).toHaveTextContent("Opus 4.1")
+    // Rows the global default does not pin show the "Agent default" sentinel.
+    expect(triggerForLabel("Permission mode")).toHaveTextContent(
+      "Agent default"
+    )
+    // Nothing overridden yet → the reset action is inert.
+    expect(screen.getByRole("button", { name: /use global/i })).toBeDisabled()
+  })
+
+  it("emits the full effective selection when one row changes", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderPopover({ onChange })
+    await pickOption(user, "Permission mode", "Plan")
+    expect(onChange).toHaveBeenCalledTimes(1)
+    // The untouched model row keeps the global pin — a per-call value replaces
+    // the global wholesale, so a partial override would silently drop it.
+    expect(onChange).toHaveBeenCalledWith({
+      config_values: { model: "claude-opus-4-1", permission_mode: "plan" },
+    })
+  })
+
+  it("seeds from an existing override and lets a row reset drop that field", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderPopover({
+      value: {
+        mode_id: null,
+        config_values: { model: "claude-sonnet-4-5", permission_mode: "plan" },
+      },
+      onChange,
+    })
+    expect(triggerForLabel("Model")).toHaveTextContent("Sonnet 4.5")
+    await pickOption(user, "Model", "Agent default")
+    expect(onChange).toHaveBeenCalledWith({
+      config_values: { permission_mode: "plan" },
+    })
+  })
+
+  it("reset button emits null (back to the global default)", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderPopover({
+      value: { config_values: { model: "claude-sonnet-4-5" } },
+      onChange,
+    })
+    await user.click(screen.getByRole("button", { name: /use global/i }))
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("keeps the popover shell usable while the probe is still loading", () => {
+    mockedSnapshot.loading = true
+    renderPopover()
+    expect(screen.getByText("Loading options…")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /use global/i })
+    ).toBeInTheDocument()
+  })
+
+  it("reports a failed probe instead of inventing options", async () => {
+    const { useAgentOptions } =
+      await import("@/components/automations/use-agent-options")
+    // One-shot override — mockReturnValue would leak into later tests.
+    vi.mocked(useAgentOptions).mockReturnValueOnce({
+      snapshot: null,
+      loading: false,
+      error: "agent CLI not installed",
+      reload: () => {},
+      ensure: async () => null,
+    } as never)
+    renderPopover()
+    expect(screen.getByText("agent CLI not installed")).toBeInTheDocument()
+  })
+})
+
+/** Local state harness replicating the host's value wiring. */
+describe("AgentDelegationConfigPopover host wiring", () => {
+  it("stays open across edits so several rows can be tweaked", async () => {
+    const user = userEvent.setup()
+    function Host() {
+      const [value, setValue] = useState<AgentDelegationDefaults | null>(null)
+      return (
+        <NextIntlClientProvider locale="en" messages={enMessages}>
+          <AgentDelegationConfigPopover
+            agentType="claude_code"
+            workingDir="/repo"
+            anchorEl={null}
+            globalDefault={globalDefault}
+            value={value}
+            onChange={setValue}
+            onClose={() => {}}
+          />
+        </NextIntlClientProvider>
+      )
+    }
+    render(<Host />)
+    await pickOption(user, "Permission mode", "Plan")
+    await pickOption(user, "Model", "Sonnet 4.5")
+    expect(triggerForLabel("Model")).toHaveTextContent("Sonnet 4.5")
+    expect(triggerForLabel("Permission mode")).toHaveTextContent("Plan")
+  })
+})
+
+// ── Reviewer regressions ──────────────────────────────────────────────────
+
+describe("AgentDelegationConfigPopover global-baseline race", () => {
+  it("holds the option rows back until the global default baseline lands", () => {
+    // The baseline load is async; editing against an empty baseline would emit
+    // a partial override, and the backend REPLACES the global default with it
+    // (no merge) — dropping pins the user never touched. So: rows hidden.
+    mockedSnapshot.value = snapshot
+    renderPopover({ globalDefaultLoading: true })
+    expect(screen.getByText("Loading settings...")).toBeInTheDocument()
+    expect(document.querySelector('[role="combobox"]')).toBeNull()
+
+    // Baseline lands → rows become editable.
+    renderPopover({ globalDefaultLoading: false })
+    expect(triggerForLabel("Model")).toBeTruthy()
+  })
+
+  it("keeps option rows disabled when the global baseline fails and allows retry", async () => {
+    const onRetryGlobalDefault = vi.fn()
+    renderPopover({
+      globalDefaultError: "database offline",
+      onRetryGlobalDefault,
+    })
+    expect(
+      screen.getByText("Failed to load delegation settings: database offline")
+    ).toBeInTheDocument()
+    expect(document.querySelector('[role="combobox"]')).toBeNull()
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Retry" }))
+    expect(onRetryGlobalDefault).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("AgentDelegationConfigPopover boolean config options", () => {
+  const clineSnapshot: AgentOptionsSnapshot = {
+    modes: null,
+    config_options: [
+      {
+        id: "auto_approve",
+        name: "Auto-approve tools",
+        kind: { type: "boolean", current_value: false },
+      },
+    ],
+    available_commands: [],
+  }
+
+  it('renders a boolean option as a toggle and emits "true" on flip', async () => {
+    mockedSnapshot.value = clineSnapshot
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderPopover({ agentType: "cline", onChange })
+    const toggle = screen.getByRole("button", {
+      name: "Auto-approve tools: Off",
+    })
+    await user.click(toggle)
+    // The global default's model pin survives: the emit is the FULL effective
+    // selection, because the backend replaces (not merges) the global default.
+    expect(onChange).toHaveBeenCalledWith({
+      config_values: { model: "claude-opus-4-1", auto_approve: "true" },
+    })
+  })
+
+  it("displays the override's pinned value instead of the live current_value", () => {
+    mockedSnapshot.value = clineSnapshot
+    renderPopover({
+      agentType: "cline",
+      value: { config_values: { auto_approve: "true" } },
+    })
+    expect(
+      screen.getByRole("button", { name: "Auto-approve tools: On" })
+    ).toBeInTheDocument()
+  })
+
+  it("pins a flipped boolean even when every select is left on Agent default", async () => {
+    // A user who only wants to flip the permission toggle must still get a
+    // per-call value — the toggle alone satisfies the non-empty override.
+    mockedSnapshot.value = clineSnapshot
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    renderPopover({ agentType: "cline", onChange })
+    await user.click(
+      screen.getByRole("button", { name: "Auto-approve tools: Off" })
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).not.toHaveBeenCalledWith(null)
+  })
+})

--- a/src/components/chat/composer/agent-delegation-config-popover.tsx
+++ b/src/components/chat/composer/agent-delegation-config-popover.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import { useMemo } from "react"
+import { useTranslations } from "next-intl"
+import { Loader2, RotateCcw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover"
+import { AgentConfigSection } from "@/components/automations/agent-config-section"
+import { InlineSessionConfigToggle } from "@/components/chat/session-config-selector"
+import { useAgentOptions } from "@/components/automations/use-agent-options"
+import { getAgentLabel } from "@/lib/custom-agents"
+import type {
+  AgentDelegationDefaults,
+  AgentType,
+  SessionConfigOptionInfo,
+} from "@/lib/types"
+
+interface AgentDelegationConfigPopoverProps {
+  /** The mentioned agent this popover configures. */
+  agentType: AgentType
+  /** Working dir for the ACP probe (the composer's folder path). */
+  workingDir: string | null
+  /**
+   * DOM element the popover points at — the mention badge that opened it.
+   * Null falls back to Radix's default positioning.
+   */
+  anchorEl: HTMLElement | null
+  /**
+   * The agent's persisted global delegation default — the baseline the
+   * selectors start from when this mention carries no override yet. Read-only
+   * here: nothing in this popover ever writes to global settings.
+   */
+  globalDefault: AgentDelegationDefaults | null
+  /**
+   * True while the global default is still being fetched. The rows stay
+   * uneditable until it lands: an edit emitted against a not-yet-loaded
+   * baseline would contain ONLY the touched row, and the backend applies a
+   * per-call value INSTEAD of the global default (no merge), so the global's
+   * other pins would be silently dropped.
+   */
+  globalDefaultLoading?: boolean
+  /** Failure loading the global baseline; editing stays disabled until retry. */
+  globalDefaultError?: string | null
+  /** Retries the global baseline fetch after an error. */
+  onRetryGlobalDefault?: () => void
+  /** The mention's current draft-local override; null = following global. */
+  value: AgentDelegationDefaults | null
+  /**
+   * Emits the next draft-local override. `null` resets the mention to the
+   * global default (removes the entry) — it never touches global settings.
+   */
+  onChange: (next: AgentDelegationDefaults | null) => void
+  onClose: () => void
+}
+
+/**
+ * Per-mention delegation config: the popover an `@Agent` mention opens so the
+ * user can pin a model / mode / permission for THIS one delegation.
+ *
+ * The option rows are the same `AgentConfigSection` surface the settings page
+ * and the automation editor use, fed by the same transient ACP probe
+ * (`describeAgentOptions` via `useAgentOptions`) — only options the agent
+ * actually advertises are selectable, and nothing is written to the agent's
+ * native config or environment. Boolean config options (e.g. Cline's
+ * `auto_approve`) render as toggles beside the selects. Initial selections
+ * come from the mention's override, falling back to the agent's persisted
+ * global delegation default, so an untouched popover shows exactly what a
+ * delegation would use today.
+ *
+ * Edits emit the FULL effective selection, not just the changed row: the
+ * backend applies a per-call value INSTEAD of the global default (per-call >
+ * global > agent native, no merge), so a partial override that dropped the
+ * global's model pin would silently change rows the user never touched.
+ */
+export function AgentDelegationConfigPopover({
+  agentType,
+  workingDir,
+  anchorEl,
+  globalDefault,
+  globalDefaultLoading = false,
+  globalDefaultError = null,
+  onRetryGlobalDefault,
+  value,
+  onChange,
+  onClose,
+}: AgentDelegationConfigPopoverProps) {
+  const t = useTranslations("Folder.chat.messageInput")
+  const tAutomations = useTranslations("Automations")
+  const tDelegation = useTranslations("AcpAgentSettings.multiAgent")
+  // Same transient probe the settings page uses; the module cache dedups
+  // rapid re-opens of the same (agent, folder) pair.
+  const { snapshot, loading, error, reload } = useAgentOptions(
+    agentType,
+    workingDir
+  )
+
+  // Displayed selection: the mention's override first, then the global
+  // default — the popover never shows an empty state that would suggest the
+  // delegation runs with nothing pinned while the global default actually is.
+  const effectiveModeId = value?.mode_id ?? globalDefault?.mode_id ?? null
+  const effectiveConfigValues =
+    value?.config_values ?? globalDefault?.config_values ?? {}
+
+  // Any row edit emits the whole displayed picture (see doc comment), then the
+  // popover stays open so the user can keep tweaking; dismissal is Radix's.
+  // Rows left on "Agent default" are NOT pinned — they inherit the agent's
+  // native default at spawn time, exactly what the row's sentinel displays.
+  const emit = (
+    modeId: string | null,
+    configValues: Record<string, string>
+  ) => {
+    const modeEmpty = modeId == null || modeId.length === 0
+    const config: Record<string, string> = {}
+    for (const [id, v] of Object.entries(configValues)) {
+      if (v.length > 0) config[id] = v
+    }
+    if (modeEmpty && Object.keys(config).length === 0) {
+      onChange(null)
+      return
+    }
+    // `mode_id` is omitted (not nulled) when unpinned, matching the shape the
+    // Rust `AgentDelegationDefaults` treats as "no mode override".
+    onChange({
+      ...(modeEmpty ? {} : { mode_id: modeId as string }),
+      config_values: config,
+    })
+  }
+
+  const virtualRef = useMemo(
+    () => ({
+      current: {
+        getBoundingClientRect: () =>
+          anchorEl?.getBoundingClientRect() ?? new DOMRect(0, 0, 0, 0),
+      },
+    }),
+    [anchorEl]
+  )
+
+  // Boolean config options don't fit a select — they render as toggles below
+  // the selects (same chip the live composer uses), reading/writing the same
+  // effective `config_values` map. Opaque strings end to end: the backend
+  // encodes `"true"` as a real JSON boolean on the wire.
+  const booleanOptions =
+    snapshot?.config_options.filter(
+      (option: SessionConfigOptionInfo) => option.kind.type === "boolean"
+    ) ?? []
+
+  return (
+    <Popover
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <PopoverAnchor virtualRef={virtualRef} />
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-[20rem] max-w-[calc(100vw-1rem)] gap-3 p-3"
+        aria-label={t("mentionConfigTitle", {
+          agent: getAgentLabel(agentType),
+        })}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <p className="min-w-0 truncate text-sm font-medium">
+            {t("mentionConfigTitle", { agent: getAgentLabel(agentType) })}
+          </p>
+          <Button
+            size="xs"
+            variant="ghost"
+            className="shrink-0 gap-1 text-xs text-muted-foreground"
+            disabled={value == null}
+            onClick={() => onChange(null)}
+            title={t("mentionConfigUseGlobal")}
+          >
+            <RotateCcw className="size-3" aria-hidden="true" />
+            {t("mentionConfigUseGlobal")}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("mentionConfigHint")}
+        </p>
+        {globalDefaultLoading ? (
+          // Baseline still loading: hold the rows back entirely. Letting the
+          // user edit against an empty baseline would emit a partial override
+          // that the backend applies INSTEAD of the global default, dropping
+          // pins the user never touched. The load is a cheap local IPC.
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+            {t("loadingSettings")}
+          </div>
+        ) : globalDefaultError ? (
+          <div className="space-y-2 text-xs text-destructive">
+            <p>{tDelegation("loadFailed", { detail: globalDefaultError })}</p>
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => onRetryGlobalDefault?.()}
+            >
+              {tDelegation("retry")}
+            </Button>
+          </div>
+        ) : (
+          <>
+            <AgentConfigSection
+              snapshot={snapshot}
+              loading={loading}
+              error={error}
+              onReload={reload}
+              modeId={effectiveModeId}
+              configValues={effectiveConfigValues}
+              onModeChange={(modeId) => emit(modeId, effectiveConfigValues)}
+              onConfigChange={(optionId, valueId) => {
+                const nextConfig = { ...effectiveConfigValues }
+                if (valueId === null) delete nextConfig[optionId]
+                else nextConfig[optionId] = valueId
+                emit(effectiveModeId, nextConfig)
+              }}
+            />
+            {booleanOptions.length > 0 ? (
+              <div className="flex flex-wrap items-center gap-1.5">
+                {booleanOptions.map((option) => (
+                  <InlineSessionConfigToggle
+                    key={option.id}
+                    option={option}
+                    overrideValue={effectiveConfigValues[option.id] ?? null}
+                    onSelect={(configId, next) =>
+                      emit(effectiveModeId, {
+                        ...effectiveConfigValues,
+                        [configId]: next,
+                      })
+                    }
+                    onLabel={t("toggleOn")}
+                    offLabel={t("toggleOff")}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </>
+        )}
+        {!loading &&
+        !error &&
+        snapshot === null &&
+        !globalDefaultLoading &&
+        !globalDefaultError ? (
+          <p className="text-xs text-muted-foreground">
+            {tAutomations("configNone")}
+          </p>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/chat/composer/nodes/reference-node.ts
+++ b/src/components/chat/composer/nodes/reference-node.ts
@@ -33,12 +33,34 @@ function parseUri(raw: string | null): string | null {
     : null
 }
 
+/** Payload the badge view reports when an agent badge is clicked. */
+export interface ReferenceBadgeClickInfo {
+  attrs: ReferenceAttrs
+  /** The badge's live DOM element (popover anchoring). */
+  element: HTMLElement
+}
+
+export interface ReferenceNodeStorage {
+  /**
+   * Set by the host (message input) to receive clicks on AGENT badges — the
+   * entry point for re-opening the per-mention delegation config of a mention
+   * already in the composer. Other reference kinds don't report clicks.
+   */
+  onBadgeClick?: (info: ReferenceBadgeClickInfo) => void
+  /** Localized hover hint shown on agent badges. */
+  badgeTitle?: string
+}
+
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     reference: {
       /** Insert an inline reference badge (file/agent/session/commit/skill). */
       insertReference: (attrs: ReferenceAttrs) => ReturnType
     }
+  }
+
+  interface Storage {
+    reference: ReferenceNodeStorage
   }
 }
 
@@ -67,6 +89,10 @@ export const Reference = Node.create({
   atom: true,
   selectable: true,
   draggable: false,
+
+  addStorage() {
+    return { onBadgeClick: undefined } as ReferenceNodeStorage
+  },
 
   addAttributes() {
     return {

--- a/src/components/chat/composer/nodes/reference-view.tsx
+++ b/src/components/chat/composer/nodes/reference-view.tsx
@@ -1,19 +1,43 @@
 import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react"
+import type { MouseEvent } from "react"
 
 import { ReferenceBadge } from "../badges/reference-badge"
 import type { ReferenceAttrs } from "../types"
+import type { ReferenceNodeStorage } from "./reference-node"
 
 /**
  * React node view for the `reference` atom. Renders the inline badge and marks
  * the surface non-editable so the caret treats the whole reference as one unit.
+ *
+ * Clicking an AGENT badge additionally reports through the node's storage
+ * callback (`onBadgeClick`, registered by the host) — the re-entry point for
+ * the per-mention delegation config. The click still selects the node
+ * (ProseMirror's own handling is untouched); the callback is a side channel.
  */
-export function ReferenceView({ node }: ReactNodeViewProps) {
+export function ReferenceView({ node, editor }: ReactNodeViewProps) {
   const attrs = node.attrs as ReferenceAttrs
+
+  const handleClick = (event: MouseEvent<HTMLSpanElement>) => {
+    if (attrs.refType !== "agent") return
+    const storage = editor?.storage.reference as
+      | ReferenceNodeStorage
+      | undefined
+    storage?.onBadgeClick?.({ attrs, element: event.currentTarget })
+  }
+
   return (
     <NodeViewWrapper
       as="span"
       className="codeg-reference"
       contentEditable={false}
+      onClick={attrs.refType === "agent" ? handleClick : undefined}
+      // Cursor affordance: an agent badge opens its delegation config.
+      title={
+        attrs.refType === "agent"
+          ? (editor?.storage.reference as ReferenceNodeStorage | undefined)
+              ?.badgeTitle
+          : undefined
+      }
     >
       <ReferenceBadge data={attrs} />
     </NodeViewWrapper>

--- a/src/components/chat/composer/rich-composer-mention.test.tsx
+++ b/src/components/chat/composer/rich-composer-mention.test.tsx
@@ -6,6 +6,28 @@ import { describe, expect, it, vi } from "vitest"
 import { RichComposer, type RichComposerHandle } from "./rich-composer"
 import type { ReferenceSearch } from "./suggestion/types"
 
+// Agent-only stub for the onAgentMention tests: the panel auto-targets the
+// first non-empty tab and agent rows always list, so a mixed stub would
+// strand file queries on the agent tab.
+const agentSearch: ReferenceSearch = () => [
+  {
+    kind: "agent",
+    label: "Agents",
+    items: [
+      {
+        reference: {
+          refType: "agent",
+          id: "claude_code",
+          label: "Claude Code",
+          uri: null,
+          meta: { agentType: "claude_code", available: true },
+        },
+        detail: "Claude Code",
+      },
+    ],
+  },
+]
+
 const search: ReferenceSearch = () => [
   {
     kind: "file",
@@ -106,6 +128,115 @@ describe("RichComposer @ mention integration", () => {
       expect(dom.hasAttribute("aria-autocomplete")).toBe(false)
       expect(dom.hasAttribute("aria-activedescendant")).toBe(false)
     })
+  })
+
+  it("does NOT fire onAgentMention on a plain selection — insert only", async () => {
+    const onAgentMention = vi.fn()
+    const ref = createRef<RichComposerHandle>()
+    render(
+      <RichComposer
+        ref={ref}
+        referenceSearch={agentSearch}
+        onAgentMention={onAgentMention}
+      />
+    )
+    await waitFor(() => expect(ref.current?.getEditor()).not.toBeNull(), {
+      timeout: 5000,
+    })
+    const editor = ref.current!.getEditor()!
+    act(() => {
+      editor.commands.insertContent("@cla")
+    })
+    const row = await screen.findByRole(
+      "option",
+      { name: /Claude Code/ },
+      { timeout: 5000 }
+    )
+    act(() => {
+      row.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true })
+      )
+    })
+    await waitFor(() => {
+      const node = findReference(editor.getJSON())
+      expect(node?.attrs).toMatchObject({ refType: "agent", id: "claude_code" })
+    })
+    // Plain selection inserts the badge and nothing else — no popup.
+    expect(onAgentMention).not.toHaveBeenCalled()
+  })
+
+  it("fires onAgentMention only via the row's delegation-config entry", async () => {
+    const onAgentMention = vi.fn()
+    const ref = createRef<RichComposerHandle>()
+    render(
+      <RichComposer
+        ref={ref}
+        referenceSearch={agentSearch}
+        onAgentMention={onAgentMention}
+        mentionConfigActionLabel="Configure for this delegation"
+      />
+    )
+    await waitFor(() => expect(ref.current?.getEditor()).not.toBeNull(), {
+      timeout: 5000,
+    })
+    const editor = ref.current!.getEditor()!
+    act(() => {
+      editor.commands.insertContent("@cla")
+    })
+    const configEntry = await screen.findByRole(
+      "button",
+      { name: /^Configure for this delegation/ },
+      { timeout: 5000 }
+    )
+    act(() => {
+      // click (not the row's mousedown): the entry inserts AND asks for config
+      configEntry.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      )
+    })
+    await waitFor(() => {
+      const node = findReference(editor.getJSON())
+      expect(node?.attrs).toMatchObject({ refType: "agent", id: "claude_code" })
+    })
+    expect(onAgentMention).toHaveBeenCalledTimes(1)
+    const info = onAgentMention.mock.calls[0][0]
+    expect(info.agentType).toBe("claude_code")
+    expect(info.referenceAttrs).toMatchObject({
+      refType: "agent",
+      id: "claude_code",
+    })
+    expect(info.range.from).toBeGreaterThan(0)
+  })
+
+  it("does not fire onAgentMention for non-agent mentions", async () => {
+    const onAgentMention = vi.fn()
+    const ref = createRef<RichComposerHandle>()
+    render(
+      <RichComposer
+        ref={ref}
+        referenceSearch={search}
+        onAgentMention={onAgentMention}
+      />
+    )
+    await waitFor(() => expect(ref.current?.getEditor()).not.toBeNull(), {
+      timeout: 5000,
+    })
+    const editor = ref.current!.getEditor()!
+    act(() => {
+      editor.commands.insertContent("@app")
+    })
+    const row = await screen.findByText("app.ts", {}, { timeout: 5000 })
+    act(() => {
+      row.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, cancelable: true })
+      )
+    })
+    await waitFor(() => {
+      expect(findReference(editor.getJSON())?.attrs).toMatchObject({
+        refType: "file",
+      })
+    })
+    expect(onAgentMention).not.toHaveBeenCalled()
   })
 
   it("does not submit on Enter while the panel is open", async () => {

--- a/src/components/chat/composer/rich-composer.tsx
+++ b/src/components/chat/composer/rich-composer.tsx
@@ -42,6 +42,16 @@ import type {
 } from "./suggestion/types"
 import type { ReferenceAttrs, ReferenceKind } from "./types"
 
+/** Info about an agent mention the `@` panel just inserted. */
+export interface AgentMentionInfo {
+  /** The mentioned agent type (the reference's stable id). */
+  agentType: string
+  /** The query range the mention badge replaced (the badge sits at `from`). */
+  range: { from: number; to: number }
+  /** The exact attributes the inserted badge carries. */
+  referenceAttrs: ReferenceAttrs
+}
+
 /**
  * Imperative handle exposed to the parent (e.g. the message input that owns
  * attachments, queue and send orchestration). The parent reads/writes plain text
@@ -146,6 +156,15 @@ export interface RichComposerProps {
    * Commits/Skills). English fallbacks apply when omitted. Render-only.
    */
   tabLabels?: Record<ReferenceKind, string>
+  /** Localized label for the delegation-config entry shown on agent rows of
+   *  the `@` panel. Render-only; English fallback applies when omitted. */
+  mentionConfigActionLabel?: string
+  /** Localized "Agent default" text for agent rows without a delegation
+   *  default. Render-only. */
+  mentionDelegationDefaultLabel?: string
+  /** Per-agent READ-ONLY delegation-config summaries (persisted global
+   *  default's mode/model ids) shown on agent rows. Render-only. */
+  mentionDelegationSummaries?: Partial<Record<string, string>>
   /**
    * Box the `@` panel lines up with: it adopts this element's width and left
    * edge and opens above it. Point it at the composer's outer chrome so the
@@ -189,6 +208,14 @@ export interface RichComposerProps {
    */
   onDropFiles?: (event: DragEvent) => boolean
   /**
+   * Called when the `@` panel's delegation-config entry inserts an AGENT
+   * mention (the row's chevron). A plain selection (click / Enter) inserts
+   * exactly as before and does NOT fire this — configuring a mention is
+   * opt-in. The host opens the per-mention delegation config popover anchored
+   * to the new badge.
+   */
+  onAgentMention?: (info: AgentMentionInfo) => void
+  /**
    * Paste-without-formatting intent: fired when `Ctrl/⌘+Shift+V` is pressed. The
    * host owns the clipboard read (and its non-secure fallback). Return true when
    * the host took over so the editor consumes the key and the browser's native
@@ -223,7 +250,11 @@ export const RichComposer = forwardRef<RichComposerHandle, RichComposerProps>(
       referenceSearch,
       mentionUiLabels,
       tabLabels,
+      mentionConfigActionLabel,
+      mentionDelegationDefaultLabel,
+      mentionDelegationSummaries,
       mentionAnchorRef,
+      onAgentMention,
       submitShortcut,
       newlineShortcut,
       isExternalMenuOpen,
@@ -241,6 +272,7 @@ export const RichComposer = forwardRef<RichComposerHandle, RichComposerProps>(
     const onFocusRef = useRef(onFocus)
     const onBlurRef = useRef(onBlur)
     const onReadyRef = useRef(onReady)
+    const onAgentMentionRef = useRef(onAgentMention)
     // Latest referenceSearch, read at event time so the mention plugin (always
     // installed) is gated on whether mentions are currently enabled — robust to
     // the prop being added/removed after the editor is created once.
@@ -263,6 +295,7 @@ export const RichComposer = forwardRef<RichComposerHandle, RichComposerProps>(
       onFocusRef.current = onFocus
       onBlurRef.current = onBlur
       onReadyRef.current = onReady
+      onAgentMentionRef.current = onAgentMention
       referenceSearchRef.current = referenceSearch
       submitShortcutRef.current = submitShortcut
       newlineShortcutRef.current = newlineShortcut
@@ -539,7 +572,11 @@ export const RichComposer = forwardRef<RichComposerHandle, RichComposerProps>(
     }, [referenceSearch, closeMention])
 
     const handleReferenceSelect = useCallback(
-      (reference: ReferenceAttrs, range: { from: number; to: number }) => {
+      (
+        reference: ReferenceAttrs,
+        range: { from: number; to: number },
+        opts?: { openConfig?: boolean }
+      ) => {
         editor
           ?.chain()
           .focus()
@@ -548,6 +585,18 @@ export const RichComposer = forwardRef<RichComposerHandle, RichComposerProps>(
           .insertContent(" ")
           .run()
         closeMention()
+        // Only the row's delegation-config entry asks for the popover — a
+        // plain selection keeps the native no-popup behavior. The badge landed
+        // at the start of the replaced query range; fire after the insert so
+        // the host can read a settled document (e.g. to find the badge's DOM
+        // node for popover anchoring).
+        if (reference.refType === "agent" && opts?.openConfig === true) {
+          onAgentMentionRef.current?.({
+            agentType: reference.id,
+            range,
+            referenceAttrs: reference,
+          })
+        }
       },
       [editor, closeMention]
     )
@@ -614,6 +663,9 @@ export const RichComposer = forwardRef<RichComposerHandle, RichComposerProps>(
             moreLabel={mentionUiLabels?.more}
             countLabel={mentionUiLabels?.count}
             tabLabels={tabLabels}
+            configActionLabel={mentionConfigActionLabel}
+            delegationDefaultLabel={mentionDelegationDefaultLabel}
+            delegationSummaries={mentionDelegationSummaries}
           />
         )}
       </div>

--- a/src/components/chat/composer/suggestion/suggestion-popup.test.tsx
+++ b/src/components/chat/composer/suggestion/suggestion-popup.test.tsx
@@ -290,6 +290,90 @@ describe("SuggestionPopup", () => {
     expect(screen.getAllByRole("tab")).toHaveLength(4)
   })
 
+  it("renders a delegation-config entry on agent rows only, and it opts into config", async () => {
+    const { onSelect } = mountPopup({
+      configActionLabel: "Configure for this delegation",
+    })
+    const panel = screen.getByTestId("mention-popup")
+    const codexRow = (await within(panel).findByText("Codex Helper")).closest(
+      "[role='option']"
+    ) as HTMLElement
+    // Agent row carries the entry (name = label + summary tail; no summary
+    // passed here → the "Agent default" fallback completes the name)…
+    const entry = within(codexRow).getByRole("button", {
+      name: /Configure for this delegation/,
+    })
+    // …and clicking it inserts WITH the config opt-in (not a plain selection).
+    act(() => {
+      entry.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      )
+    })
+    expect(onSelect).toHaveBeenCalledWith(agentRef, state.range, {
+      openConfig: true,
+    })
+  })
+
+  it("renders a READ-ONLY delegation summary + config entry on agent rows", async () => {
+    const onSelect = vi.fn()
+    render(
+      <SuggestionPopup
+        ref={createRef<SuggestionPopupHandle>()}
+        state={state}
+        search={search}
+        onSelect={onSelect}
+        onClose={vi.fn()}
+        configActionLabel="Configure for this delegation"
+        delegationDefaultLabel="Agent default"
+        delegationSummaries={{
+          codex: "gpt-5.2-codex",
+          claude_code: "claude-opus-4-1 · plan",
+        }}
+      />
+    )
+    const panel = screen.getByTestId("mention-popup")
+    // Codex row: persisted global default summary (stable ids are fine).
+    const codexEntry = await within(panel).findByRole("button", {
+      name: "Configure for this delegation: gpt-5.2-codex",
+    })
+    expect(within(codexEntry).getByText("gpt-5.2-codex")).toBeInTheDocument()
+    // Claude row: mode + model joined.
+    expect(
+      await within(panel).findByText("claude-opus-4-1 · plan")
+    ).toBeInTheDocument()
+    // The entry is a span with the button role (no nested <button> inside the
+    // option's <button>): clicking it opts into config.
+    act(() => {
+      codexEntry.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      )
+    })
+    expect(onSelect).toHaveBeenCalledWith(agentRef, state.range, {
+      openConfig: true,
+    })
+  })
+
+  it("shows the Agent-default label when no summary exists, and never probes", async () => {
+    // The popup itself has NO probe surface: no onProbeAgent-style prop
+    // exists, and rendering + opening the panel is synchronous display of
+    // host-supplied data. No global default for either agent → the
+    // "Agent default" label shows on both rows.
+    const onSelect = vi.fn()
+    render(
+      <SuggestionPopup
+        ref={createRef<SuggestionPopupHandle>()}
+        state={state}
+        search={search}
+        onSelect={onSelect}
+        onClose={vi.fn()}
+        delegationDefaultLabel="Agent default"
+      />
+    )
+    const panel = screen.getByTestId("mention-popup")
+    expect(await within(panel).findAllByText("Agent default")).toHaveLength(2)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
   it("selects the active tab's highlighted row on Enter (default = first agent)", async () => {
     const { ref, onSelect } = mountPopup()
     await screen.findByText("Codex Helper")
@@ -582,10 +666,14 @@ describe("SuggestionPopup", () => {
     mountPopup()
     await screen.findByText("Codex Helper")
     // The agent row's AgentIcon is a titled <svg>; if it weren't decorative the
-    // option would be named "Codex Codex Helper". The name must be just label.
+    // option would be named "Codex Codex Helper …". The name must START with
+    // just the label (the delegation-config entry text trails it).
     expect(
-      screen.getByRole("option", { name: "Codex Helper" })
+      screen.getByRole("option", { name: /^Codex Helper/ })
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("option", { name: "Codex Codex Helper" })
+    ).toBeNull()
   })
 
   it("moves aria-selected with the keyboard", async () => {

--- a/src/components/chat/composer/suggestion/suggestion-popup.tsx
+++ b/src/components/chat/composer/suggestion/suggestion-popup.tsx
@@ -11,6 +11,7 @@ import {
   type RefObject,
 } from "react"
 import { createPortal } from "react-dom"
+import { Settings2 } from "lucide-react"
 
 import { isImeCompositionKey } from "@/lib/ime-composition"
 import { cn } from "@/lib/utils"
@@ -100,10 +101,14 @@ export interface SuggestionPopupProps {
   state: MentionRenderState
   /** Resolves the query into grouped suggestions. Must be referentially stable. */
   search: ReferenceSearch
-  /** Insert the chosen reference, replacing the trigger range. */
+  /** Insert the chosen reference, replacing the trigger range. `opts.openConfig`
+   *  is set only when the row's delegation-config entry was used — the host
+   *  opens the per-mention config popover for it; a plain selection never
+   *  carries it. */
   onSelect: (
     reference: ReferenceAttrs,
-    range: { from: number; to: number }
+    range: { from: number; to: number },
+    opts?: { openConfig?: boolean }
   ) => void
   /** Dismiss the panel without inserting. */
   onClose: () => void
@@ -117,6 +122,19 @@ export interface SuggestionPopupProps {
   moreLabel?: string
   /** Localized per-kind tab labels (English fallbacks apply when omitted). */
   tabLabels?: Record<ReferenceKind, string>
+  /** Localized aria/title label for the per-row delegation-config entry shown
+   *  on agent rows. The entry is rendered only for agents. */
+  configActionLabel?: string
+  /** Localized label shown on an agent row when no delegation default is
+   *  pinned for it ("Agent default"). */
+  delegationDefaultLabel?: string
+  /**
+   * Per-agent READ-ONLY delegation-config summary (the persisted global
+   * default's mode/model ids, precomputed by the host — no probing happens
+   * here). Rendered on the agent row next to the config entry so the user
+   * sees what the delegation would use before opening it.
+   */
+  delegationSummaries?: Partial<Record<string, string>>
   /**
    * The composer box the panel lines up with. When given, the panel adopts that
    * box's width and left edge and opens above it — the same geometry as the
@@ -156,6 +174,9 @@ export const SuggestionPopup = forwardRef<
     countLabel = (count) => `${count} results`,
     moreLabel = "More results — keep typing to filter",
     tabLabels = DEFAULT_TAB_LABELS,
+    configActionLabel,
+    delegationDefaultLabel,
+    delegationSummaries,
     anchorRef,
     onActiveOptionChange,
   },
@@ -622,6 +643,54 @@ export const SuggestionPopup = forwardRef<
                         title={item.detail}
                       >
                         {item.detail}
+                      </span>
+                    )}
+                    {item.reference.refType === "agent" && (
+                      // Delegation-config entry (agents only): opens the
+                      // per-mention config view for THIS mention. A nested
+                      // <button> is invalid inside the option's <button>, so
+                      // this is a span with the button role (Space/Enter
+                      // handled for keyboard access). Selecting the row
+                      // (click elsewhere / Enter) stays a plain insert —
+                      // configuring is strictly opt-in via this affordance.
+                      // The entry carries the agent's READ-ONLY config
+                      // summary (the persisted global default's mode/model
+                      // ids) so the user sees what a delegation would use
+                      // before opening; the summary is display-only — options
+                      // load lazily inside the popover, never in this list.
+                      <span
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`${configActionLabel ?? "Configure delegation"}: ${delegationSummaries?.[item.reference.id] ?? delegationDefaultLabel ?? "Agent default"}`}
+                        title={configActionLabel ?? "Configure delegation"}
+                        className="ml-auto inline-flex h-6 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs text-muted-foreground hover:bg-background/70 hover:text-foreground"
+                        onMouseDown={(event) => {
+                          // Don't let the row's insert handler fire…
+                          event.preventDefault()
+                          event.stopPropagation()
+                        }}
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          onSelect(item.reference, state.range, {
+                            openConfig: true,
+                          })
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key !== "Enter" && event.key !== " ") {
+                            return
+                          }
+                          event.stopPropagation()
+                          onSelect(item.reference, state.range, {
+                            openConfig: true,
+                          })
+                        }}
+                      >
+                        <Settings2 className="size-3.5" aria-hidden="true" />
+                        <span className="max-w-40 truncate">
+                          {delegationSummaries?.[item.reference.id] ??
+                            delegationDefaultLabel ??
+                            "Agent default"}
+                        </span>
                       </span>
                     )}
                   </button>

--- a/src/components/chat/composer/types.ts
+++ b/src/components/chat/composer/types.ts
@@ -1,4 +1,4 @@
-import type { AgentType } from "@/lib/types"
+import type { AgentDelegationDefaults, AgentType } from "@/lib/types"
 
 /** The five kinds of inline reference the composer can embed. */
 export type ReferenceKind = "file" | "agent" | "session" | "commit" | "skill"
@@ -56,6 +56,15 @@ export interface ReferenceMeta {
    * `/` when absent.
    */
   invocationPrefix?: "/" | "$"
+  /**
+   * agent: the draft-scoped delegation config override picked in the
+   * per-mention config popover (model/mode/permission for THIS delegation
+   * only). Lives on the mention node so it survives the composer doc's
+   * round-trips (localStorage v2 draft, JSON hydration); `buildDraft` collects
+   * it into `PromptDraft.delegation_overrides`. Absent = use the global
+   * delegation default. Never written to global settings.
+   */
+  delegationOverride?: AgentDelegationDefaults
 }
 
 /**

--- a/src/components/chat/conversation-shell.tsx
+++ b/src/components/chat/conversation-shell.tsx
@@ -2,6 +2,7 @@ import type { ConversationFolderPickerOverride } from "@/components/chat/convers
 import { useMemo, type ReactNode } from "react"
 import { useTranslations } from "next-intl"
 import type {
+  AgentDelegationDefaults,
   AgentType,
   ConnectionStatus,
   PendingPlanApprovalState,
@@ -113,6 +114,9 @@ interface ConversationShellProps {
   editingItemId?: string | null
   editingDraftText?: string | null
   editingDraftBlocks?: PromptInputBlock[] | null
+  editingDelegationOverrides?: Partial<
+    Record<AgentType, AgentDelegationDefaults>
+  > | null
   isEditingQueueItem?: boolean
   onSaveQueueEdit?: (draft: PromptDraft) => void
   onCancelQueueEdit?: () => void
@@ -182,6 +186,7 @@ export function ConversationShell({
   editingItemId,
   editingDraftText,
   editingDraftBlocks,
+  editingDelegationOverrides,
   isEditingQueueItem,
   onSaveQueueEdit,
   onCancelQueueEdit,
@@ -343,6 +348,7 @@ export function ConversationShell({
               editingItemId={editingItemId}
               editingDraftText={editingDraftText}
               editingDraftBlocks={editingDraftBlocks}
+              editingDelegationOverrides={editingDelegationOverrides}
               isEditingQueueItem={isEditingQueueItem}
               onSaveQueueEdit={onSaveQueueEdit}
               onCancelQueueEdit={onCancelQueueEdit}

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -50,6 +50,7 @@ import { isNoActiveTurnRejection } from "@/lib/turn-busy"
 import { ServerFileBrowserDialog } from "@/components/shared/server-file-browser-dialog"
 import { toast } from "sonner"
 import type {
+  AgentDelegationDefaults,
   AgentSkillItem,
   AgentType,
   AvailableCommandInfo,
@@ -101,6 +102,14 @@ import {
   loadMessageInputDraftV2,
   saveMessageInputDraftV2,
 } from "@/lib/message-input-draft"
+import {
+  collectDelegationOverrides,
+  readReferenceDelegationOverride,
+  withDelegationOverrides,
+  writeReferenceDelegationOverride,
+} from "@/lib/delegation-overrides"
+import { delegationDefaultsSummaryParts } from "@/lib/delegation-overrides"
+import { useDelegationGlobalBaseline } from "@/hooks/use-delegation-baseline"
 import { rankByTextMatch } from "@/lib/fuzzy-text-match"
 import {
   RichComposer,
@@ -113,6 +122,7 @@ import {
   serializeDocToText,
 } from "@/components/chat/composer/to-prompt-blocks"
 import { isEmbeddedReferenceUri } from "@/components/chat/composer/reference-uri"
+import type { ReferenceNodeStorage } from "@/components/chat/composer/nodes/reference-node"
 import {
   applyExpertReference,
   isComposerChromeClick,
@@ -125,6 +135,7 @@ import {
   skillToReference,
 } from "@/components/chat/composer/invocation-reference"
 import { cutSelectionToClipboard } from "@/components/chat/composer/clipboard-actions"
+import { AgentDelegationConfigPopover } from "@/components/chat/composer/agent-delegation-config-popover"
 import { sessionToSuggestion } from "@/components/chat/composer/suggestion/adapters"
 import { editorHasReference } from "@/components/chat/composer/attachment-files"
 import type { ReferenceAttrs } from "@/components/chat/composer/types"
@@ -207,6 +218,15 @@ interface MessageInputProps {
    * falls back to {@link editingDraftText} when absent.
    */
   editingDraftBlocks?: PromptInputBlock[] | null
+  /**
+   * The queued item's draft-scoped delegation overrides, when editing a queue
+   * item. Agent mentions hydrate from blocks as plain text (no badge meta to
+   * read back), so the queued overrides ride as a seed: a save re-emits them
+   * unless the user re-mentions the agent and overrides it again in the doc.
+   */
+  editingDelegationOverrides?: Partial<
+    Record<AgentType, AgentDelegationDefaults>
+  > | null
   isEditingQueueItem?: boolean
   onSaveQueueEdit?: (draft: PromptDraft) => void
   onCancelQueueEdit?: () => void
@@ -322,6 +342,7 @@ export function MessageInput({
   editingItemId,
   editingDraftText,
   editingDraftBlocks,
+  editingDelegationOverrides,
   isEditingQueueItem = false,
   onSaveQueueEdit,
   onCancelQueueEdit,
@@ -450,6 +471,139 @@ export function MessageInput({
     labels: referenceGroupLabels,
   })
 
+  // ── Per-mention delegation config (@Agent → popover) ──
+  // The doc is the source of truth while composing: an override lives on the
+  // mention badge's meta (survives v2 draft persistence) and `buildDraft`
+  // collects it into `PromptDraft.delegation_overrides`. Queue edits are the
+  // one gap — their agent mentions hydrate from blocks as plain text — so the
+  // queued item's overrides seed `editingOverridesRef` and the save merges
+  // them under whatever the doc carries now.
+  const editingOverridesRef = useRef<Partial<
+    Record<AgentType, AgentDelegationDefaults>
+  > | null>(null)
+  const [delegationConfig, setDelegationConfig] = useState<{
+    agentType: AgentType
+    anchorEl: HTMLElement | null
+  } | null>(null)
+  const [delegationOverride, setDelegationOverride] =
+    useState<AgentDelegationDefaults | null>(null)
+  // The global baseline the popover displays for a mention with no override.
+  // Re-fetched (and cleared) on EVERY open — the previous values must never
+  // survive a close, or an edit right after a settings change would emit a
+  // stale per-call replacement. While loading, the popover holds its rows
+  // back (see globalDefaultLoading).
+  const delegationBaseline = useDelegationGlobalBaseline(
+    delegationConfig != null
+  )
+  // The @ panel's agent rows show a READ-ONLY summary of each agent's
+  // persisted global delegation default (mode/model ids — stable identifiers;
+  // human-readable names would require a probe we refuse to run during
+  // listing). This baseline may lag the newest settings by one fetch; the
+  // popover refetches on every open, so what the user EDITS against is
+  // always fresh.
+  const panelBaseline = useDelegationGlobalBaseline(isActive)
+  const mentionDelegationSummaries = useMemo(() => {
+    const out: Record<string, string> = {}
+    for (const [agent, defaults] of Object.entries(
+      panelBaseline.baseline ?? {}
+    )) {
+      const parts = delegationDefaultsSummaryParts(defaults)
+      if (parts.length > 0) out[agent] = parts.join(" · ")
+    }
+    return out
+  }, [panelBaseline.baseline])
+
+  // Seed / clear the queue-edit override base when an edit session starts or
+  // ends (and when a DIFFERENT item is opened — mirrors prevEditingItemIdRef).
+  // The seed is consumed ONCE, right after block hydration, by being written
+  // onto the restored badges (see applySeedOverridesToEditor) — after that the
+  // document is the single source of truth, and nothing seeds the save path.
+  useEffect(() => {
+    if (isEditingQueueItem && editingItemId != null) {
+      if (editingItemId !== prevEditingItemIdRef.current) {
+        editingOverridesRef.current = editingDelegationOverrides ?? null
+      }
+    } else {
+      editingOverridesRef.current = null
+    }
+  }, [isEditingQueueItem, editingItemId, editingDelegationOverrides])
+
+  // Find the DOM badge for the reference node that starts at `pos`, falling
+  // back to the composer container so the popover still opens predictably.
+  const anchorElForMention = useCallback((pos: number): HTMLElement | null => {
+    const editor = editorRef.current?.getEditor()
+    const dom = editor ? (editor.view.nodeDOM(pos) as Node | null) : null
+    const el = dom instanceof HTMLElement && dom.isConnected ? dom : null
+    return el ?? containerRef.current
+  }, [])
+
+  const handleAgentMention = useCallback(
+    (info: {
+      agentType: string
+      range: { from: number; to: number }
+      referenceAttrs: ReferenceAttrs
+    }) => {
+      setDelegationOverride(
+        readReferenceDelegationOverride(info.referenceAttrs.meta)
+      )
+      setDelegationConfig({
+        agentType: info.agentType,
+        anchorEl: anchorElForMention(info.range.from),
+      })
+    },
+    [anchorElForMention]
+  )
+
+  // Apply a popover edit to EVERY badge of this agent in the doc (one
+  // draft-level value per agent; the most recent edit wins) + mirror it into
+  // React state so the open popover re-renders its selects.
+  const handleDelegationChange = useCallback(
+    (next: AgentDelegationDefaults | null) => {
+      const agent = delegationConfig?.agentType
+      if (!agent) return
+      setDelegationOverride(next)
+      const editor = editorRef.current?.getEditor()
+      if (!editor) return
+      const tr = editor.state.tr
+      let touched = false
+      editor.state.doc.descendants((node, pos) => {
+        if (
+          node.type.name === "reference" &&
+          node.attrs.refType === "agent" &&
+          node.attrs.id === agent
+        ) {
+          tr.setNodeMarkup(pos, undefined, {
+            ...node.attrs,
+            meta: writeReferenceDelegationOverride(node.attrs.meta, next),
+          })
+          touched = true
+        }
+        return true
+      })
+      if (touched) editor.view.dispatch(tr)
+    },
+    [delegationConfig]
+  )
+
+  const closeDelegationConfig = useCallback(() => {
+    setDelegationConfig(null)
+    setDelegationOverride(null)
+  }, [])
+
+  // Re-apply the queued item's delegation overrides onto the freshly restored
+  // agent badges. Block hydration rebuilds `[@Agent](codeg://…)` tokens as
+  // badges WITHOUT their meta (the queue stores prompt prose, not badges), so
+  // without this an untouched queue edit would silently drop its per-mention
+  // config. Runs right after hydration, inside the same rAF; from here on the
+  // document is the single source of truth — no seed touches the save path.
+  const applySeedOverridesToEditor = useCallback(() => {
+    const editor = editorRef.current?.getEditor()
+    const seed = editingOverridesRef.current
+    if (!editor || !seed) return
+    const next = withDelegationOverrides(editor.getJSON(), seed)
+    if (next) editor.commands.setContent(next)
+  }, [])
+
   // Debounced v2 draft persistence. We snapshot the Tiptap *document* (JSON, not
   // Markdown) ~300ms after the last change so inline reference badges survive a
   // reload — a Markdown round-trip would downgrade them to plain links.
@@ -516,6 +670,9 @@ export function MessageInput({
         } else if (editingDraftText != null) {
           ed.setText(editingDraftText)
         }
+        // The restored badges carry no delegation meta (the queue stores
+        // prose) — write the queued overrides onto them now.
+        applySeedOverridesToEditor()
       } else if (effectiveDraftStorageKey) {
         const loaded = loadMessageInputDraftV2(effectiveDraftStorageKey)
         if (loaded?.kind === "doc") {
@@ -536,6 +693,7 @@ export function MessageInput({
     editingDraftBlocks,
     effectiveDraftStorageKey,
     hydrateFromBlocks,
+    applySeedOverridesToEditor,
   ])
 
   // Focus the composer the moment the editor exists and this tab is active, so
@@ -577,6 +735,8 @@ export function MessageInput({
         } else if (editingDraftText != null) {
           editorRef.current?.setText(editingDraftText)
         }
+        // Same re-attachment as the mount hydration above.
+        applySeedOverridesToEditor()
         setComposerEmpty(editor ? isComposerEmpty(editor) : true)
         editorRef.current?.focus()
       })
@@ -590,6 +750,7 @@ export function MessageInput({
     editingDraftText,
     editingDraftBlocks,
     hydrateFromBlocks,
+    applySeedOverridesToEditor,
   ])
 
   useEffect(() => {
@@ -674,8 +835,25 @@ export function MessageInput({
   }, [syncComposerEmpty, scheduleDraftSave])
 
   const handleComposerReady = useCallback(() => {
+    // Agent badges report clicks through the editor's node storage (the
+    // React NodeView lives outside this tree) — that's the re-entry point
+    // for the per-mention delegation config of a mention already in the doc.
+    const editor = editorRef.current?.getEditor()
+    const storage = editor?.storage.reference as
+      | ReferenceNodeStorage
+      | undefined
+    if (storage) {
+      storage.onBadgeClick = ({ attrs, element }) => {
+        setDelegationOverride(readReferenceDelegationOverride(attrs.meta))
+        setDelegationConfig({
+          agentType: attrs.id,
+          anchorEl: element.isConnected ? element : containerRef.current,
+        })
+      }
+      storage.badgeTitle = t("mentionConfigBadgeTitle")
+    }
     setComposerReady(true)
-  }, [])
+  }, [t])
 
   const availableModes = useMemo(() => modes ?? [], [modes])
   const availableConfigOptions = useMemo(
@@ -1196,16 +1374,32 @@ export function MessageInput({
     const displayText =
       displayProse ||
       `Attached ${attachments.length} attachment${attachments.length > 1 ? "s" : ""}`
-    return { blocks, displayText }
+    // Draft-scoped delegation overrides: read from the doc's agent mention
+    // badges — the single source of truth. Queue-edit hydration re-attaches
+    // the queued values onto the restored badges (see
+    // `applySeedOverridesToEditor`), so nothing is layered on here: a reset or
+    // a deleted mention is expressed in the doc itself. Omitted entirely for
+    // an untouched draft so the sent payload stays byte-identical.
+    const docOverrides = collectDelegationOverrides(editor?.getJSON() ?? null)
+    const delegation_overrides = docOverrides
+    return {
+      blocks,
+      displayText,
+      ...(delegation_overrides && Object.keys(delegation_overrides).length > 0
+        ? { delegation_overrides }
+        : {}),
+    }
   }, [attachments, skillPrefix, imagePromptBlocks, embeddedPayloadsRef])
 
-  // Clear the editor + attachments after a send / enqueue / save.
+  // Clear the editor + attachments after a send / enqueue / save. The popover
+  // targets a mention badge that no longer exists, so close it with the rest.
   const resetComposer = useCallback(() => {
     editorRef.current?.clear()
     setComposerEmpty(true)
     clearAttachments()
     closeSlashMenu()
-  }, [clearAttachments, closeSlashMenu])
+    closeDelegationConfig()
+  }, [clearAttachments, closeSlashMenu, closeDelegationConfig])
 
   const handleSend = useCallback(() => {
     // The editor stays editable while `disabled` (the agent is busy) so the user
@@ -1926,6 +2120,11 @@ export function MessageInput({
                 referenceSearch={referenceSearch}
                 mentionUiLabels={mentionUiLabels}
                 tabLabels={referenceGroupLabels}
+                mentionConfigActionLabel={t("mentionConfigAction")}
+                mentionDelegationDefaultLabel={t(
+                  "mentionDelegationDefaultLabel"
+                )}
+                mentionDelegationSummaries={mentionDelegationSummaries}
                 // The `@` panel spans the whole composer and opens above it —
                 // the same box the `/` menu hangs off (this container), so the
                 // two read as one affordance.
@@ -1937,12 +2136,30 @@ export function MessageInput({
                 onPasteFiles={attach.handlePasteFiles}
                 onDropFiles={attach.handleEditorDrop}
                 onPlainPaste={handlePlainPasteShortcut}
+                onAgentMention={handleAgentMention}
                 submitShortcut={shortcuts.send_message}
                 newlineShortcut={shortcuts.newline_in_message}
                 isExternalMenuOpen={slashMenuVisible}
                 onExternalMenuKeyDown={handleExternalMenuKeyDown}
                 className="min-h-0 flex-1"
               />
+              {delegationConfig && (
+                <AgentDelegationConfigPopover
+                  agentType={delegationConfig.agentType}
+                  workingDir={defaultPath ?? null}
+                  anchorEl={delegationConfig.anchorEl}
+                  globalDefault={
+                    delegationBaseline.baseline?.[delegationConfig.agentType] ??
+                    null
+                  }
+                  globalDefaultLoading={delegationBaseline.loading}
+                  globalDefaultError={delegationBaseline.error}
+                  onRetryGlobalDefault={delegationBaseline.retry}
+                  value={delegationOverride}
+                  onChange={handleDelegationChange}
+                  onClose={closeDelegationConfig}
+                />
+              )}
               <div className="flex shrink-0 items-end justify-between gap-1 px-2 pb-2">
                 <div className="flex min-w-0 items-end gap-1">
                   <ComposerAddMenu

--- a/src/components/chat/session-config-selector.tsx
+++ b/src/components/chat/session-config-selector.tsx
@@ -139,6 +139,15 @@ interface SessionConfigToggleProps {
   onSelect: (configId: string, value: string) => void
   onLabel: string
   offLabel: string
+  /**
+   * The value to DISPLAY instead of the option's live `current_value` — the
+   * effective selection when a caller edits a stored override rather than the
+   * running session (per-mention delegation popover reads the mention's
+   * override, falling back to its global default). `"true"` / `"false"`;
+   * omitted (or null) keeps the original live-value behavior, so existing
+   * callers are untouched.
+   */
+  overrideValue?: string | null
 }
 
 /**
@@ -153,10 +162,16 @@ export function InlineSessionConfigToggle({
   onSelect,
   onLabel,
   offLabel,
+  overrideValue,
 }: SessionConfigToggleProps) {
   if (option.kind.type !== "boolean") return null
 
-  const checked = option.kind.current_value
+  const checked =
+    overrideValue === "true"
+      ? true
+      : overrideValue === "false"
+        ? false
+        : option.kind.current_value
   const Icon = checked ? ToggleRight : ToggleLeft
 
   return (

--- a/src/components/conversations/conversation-detail-panel.tsx
+++ b/src/components/conversations/conversation-detail-panel.tsx
@@ -1067,6 +1067,7 @@ const ConversationTabView = memo(function ConversationTabView({
           clientMessageId: optimisticTurn.id,
           onTurnInProgress,
           onSendFailed,
+          delegationOverrides: draft.delegation_overrides,
         })
         return
       }
@@ -1171,6 +1172,7 @@ const ConversationTabView = memo(function ConversationTabView({
             clientMessageId: optimisticTurn.id,
             onTurnInProgress,
             onSendFailed,
+            delegationOverrides: draft.delegation_overrides,
           })
         } catch (e) {
           console.error("[ConversationTabView] create conversation:", e)
@@ -1533,6 +1535,15 @@ const ConversationTabView = memo(function ConversationTabView({
     if (!mqEditingItemId) return null
     const item = msgQueue.find((m) => m.id === mqEditingItemId)
     return item?.draft.blocks ?? null
+  }, [mqEditingItemId, msgQueue])
+
+  // The editing item's draft-scoped delegation overrides. Agent mentions don't
+  // survive the queue-edit block hydration as badges (they become plain text),
+  // so the queued overrides ride as a seed the composer re-emits on save.
+  const editingQueueDelegationOverrides = useMemo(() => {
+    if (!mqEditingItemId) return null
+    const item = msgQueue.find((m) => m.id === mqEditingItemId)
+    return item?.draft.delegation_overrides ?? null
   }, [mqEditingItemId, msgQueue])
 
   const handleQueueEdit = useCallback(
@@ -2028,6 +2039,7 @@ const ConversationTabView = memo(function ConversationTabView({
       editingItemId={mqEditingItemId}
       editingDraftText={editingQueueDraftText}
       editingDraftBlocks={editingQueueDraftBlocks}
+      editingDelegationOverrides={editingQueueDelegationOverrides}
       isEditingQueueItem={mqEditingItemId != null}
       onSaveQueueEdit={handleSaveQueueEdit}
       onCancelQueueEdit={handleQueueCancelEdit}

--- a/src/contexts/acp-connections-context.tsx
+++ b/src/contexts/acp-connections-context.tsx
@@ -65,6 +65,7 @@ import type {
   SessionModeStateInfo,
   SessionUsageUpdateInfo,
   PromptCapabilitiesInfo,
+  PromptDraft,
   PromptInputBlock,
   ToolCallImageWire,
   UserMessageBlock,
@@ -5761,6 +5762,12 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
         folderId?: number | null
         conversationId?: number | null
         clientMessageId?: string | null
+        /**
+         * Draft-scoped delegation overrides (`@Agent` mention config) applied
+         * by the backend for this turn only. Undefined/empty = none; the
+         * transport payload omits the field entirely in that case.
+         */
+        delegationOverrides?: PromptDraft["delegation_overrides"]
       }
     ) => {
       const conn = storeRef.current.connections.get(contextKey)
@@ -5772,7 +5779,8 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
           blocks,
           opts?.folderId ?? null,
           opts?.conversationId ?? null,
-          opts?.clientMessageId ?? null
+          opts?.clientMessageId ?? null,
+          opts?.delegationOverrides
         )
       } catch (e) {
         // Same reasoning as `cancel`: the backend disowning this id proves the

--- a/src/hooks/use-connection-lifecycle.ts
+++ b/src/hooks/use-connection-lifecycle.ts
@@ -64,6 +64,12 @@ export interface UseConnectionLifecycleReturn {
        * deterministic failure would otherwise retry forever.
        */
       onSendFailed?: (error: unknown) => void
+      /**
+       * Draft-scoped delegation overrides (`@Agent` mention config), applied
+       * by the backend for THIS turn only. Empty/undefined = none — the wire
+       * payload stays identical to a plain prompt.
+       */
+      delegationOverrides?: PromptDraft["delegation_overrides"]
     }
   ) => void
   handleSetConfigOption: (configId: string, valueId: string) => void
@@ -421,6 +427,7 @@ export function useConnectionLifecycle({
         clientMessageId?: string | null
         onTurnInProgress?: () => void
         onSendFailed?: (error: unknown) => void
+        delegationOverrides?: PromptDraft["delegation_overrides"]
       }
     ) => {
       touchActivity(contextKey)
@@ -434,7 +441,10 @@ export function useConnectionLifecycle({
           // calls before CurrentModeUpdate arrives from the agent.
           modeIdRef.current = modeId
         }
-        await sendPrompt(draft.blocks, opts)
+        await sendPrompt(draft.blocks, {
+          ...opts,
+          delegationOverrides: opts?.delegationOverrides,
+        })
       })().catch((e: unknown) => {
         if (e instanceof TurnBusyError) {
           // A turn was already in flight on the connection (another

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -19,6 +19,7 @@ import type {
   PendingPlanApprovalState,
   PendingQuestionState,
   PromptCapabilitiesInfo,
+  PromptDraft,
   QuestionAnswer,
   SessionConfigOptionInfo,
   SessionFailureRecord,
@@ -113,6 +114,8 @@ export interface UseConnectionReturn {
       folderId?: number | null
       conversationId?: number | null
       clientMessageId?: string | null
+      /** Draft-scoped delegation overrides (`@Agent` mention config). */
+      delegationOverrides?: PromptDraft["delegation_overrides"]
     }
   ) => Promise<void>
   setMode: (modeId: string) => Promise<void>
@@ -270,6 +273,8 @@ export function useConnection(contextKey: string): UseConnectionReturn {
         folderId?: number | null
         conversationId?: number | null
         clientMessageId?: string | null
+        /** Draft-scoped delegation overrides (`@Agent` mention config). */
+        delegationOverrides?: PromptDraft["delegation_overrides"]
       }
     ) => actions.sendPrompt(contextKey, blocks, opts),
     [actions, contextKey]

--- a/src/hooks/use-delegation-baseline.test.ts
+++ b/src/hooks/use-delegation-baseline.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { AgentDelegationDefaults } from "@/lib/types"
+
+const getDelegationSettings = vi.fn<
+  () => Promise<{
+    agent_defaults?: Partial<Record<string, AgentDelegationDefaults>>
+  }>
+>()
+
+vi.mock("@/lib/api", () => ({
+  getDelegationSettings: () => getDelegationSettings(),
+}))
+
+import { useDelegationGlobalBaseline } from "./use-delegation-baseline"
+
+afterEach(() => {
+  getDelegationSettings.mockReset()
+})
+
+describe("useDelegationGlobalBaseline", () => {
+  it("does not fetch while the popover is closed", () => {
+    renderHook(() => useDelegationGlobalBaseline(false))
+    expect(getDelegationSettings).not.toHaveBeenCalled()
+  })
+
+  it("clears the baseline and loads it on open", async () => {
+    getDelegationSettings.mockResolvedValue({
+      agent_defaults: { codex: { config_values: { model: "gpt-5.2" } } },
+    })
+    const { result, rerender } = renderHook(
+      ({ active }) => useDelegationGlobalBaseline(active),
+      { initialProps: { active: false } }
+    )
+
+    rerender({ active: true })
+    // Loading state is visible IMMEDIATELY (before any promise settles):
+    // baseline is cleared so a stale value can never seed an edit.
+    expect(result.current).toMatchObject({
+      baseline: null,
+      loading: true,
+      error: null,
+    })
+
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        baseline: { codex: { config_values: { model: "gpt-5.2" } } },
+        loading: false,
+        error: null,
+      })
+    )
+  })
+
+  it("re-clears and re-fetches on reopen, picking up settings changed in between", async () => {
+    // Reviewer regression: the first open cached the baseline; on reopen the
+    // old values must NOT serve an edit while the fresh fetch is in flight.
+    getDelegationSettings.mockResolvedValueOnce({
+      agent_defaults: { codex: { config_values: { model: "old-model" } } },
+    })
+    const { result, rerender } = renderHook(
+      ({ active }) => useDelegationGlobalBaseline(active),
+      { initialProps: { active: false } }
+    )
+    rerender({ active: true })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.baseline?.codex?.config_values?.model).toBe(
+      "old-model"
+    )
+
+    // The user edits global defaults while the popover is closed.
+    getDelegationSettings.mockResolvedValueOnce({
+      agent_defaults: { codex: { config_values: { model: "new-model" } } },
+    })
+    rerender({ active: false })
+    expect(result.current).toMatchObject({
+      baseline: null,
+      loading: false,
+      error: null,
+    })
+
+    rerender({ active: true })
+    // The stale "old-model" baseline is GONE the moment the popover reopens.
+    expect(result.current).toMatchObject({
+      baseline: null,
+      loading: true,
+      error: null,
+    })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.baseline?.codex?.config_values?.model).toBe(
+      "new-model"
+    )
+  })
+
+  it("cancels a superseded fetch when the popover closes mid-load", async () => {
+    let resolve!: (v: { agent_defaults?: Record<string, never> }) => void
+    getDelegationSettings.mockReturnValue(
+      new Promise((r) => {
+        resolve = r
+      })
+    )
+    const { result, rerender } = renderHook(
+      ({ active }) => useDelegationGlobalBaseline(active),
+      { initialProps: { active: false } }
+    )
+    rerender({ active: true })
+    expect(result.current.loading).toBe(true)
+
+    rerender({ active: false })
+    await act(async () => {
+      resolve({})
+    })
+    // The late response must not land after close.
+    expect(result.current).toMatchObject({
+      baseline: null,
+      loading: false,
+      error: null,
+    })
+  })
+
+  it("surfaces a failed fetch and retries without inventing an empty baseline", async () => {
+    getDelegationSettings.mockRejectedValueOnce(new Error("database offline"))
+    getDelegationSettings.mockResolvedValueOnce({
+      agent_defaults: { codex: { config_values: { model: "gpt-5.2" } } },
+    })
+    const { result, rerender } = renderHook(
+      ({ active }) => useDelegationGlobalBaseline(active),
+      { initialProps: { active: false } }
+    )
+
+    rerender({ active: true })
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        baseline: null,
+        loading: false,
+        error: "database offline",
+      })
+    )
+
+    act(() => result.current.retry())
+    await waitFor(() =>
+      expect(result.current).toMatchObject({
+        baseline: { codex: { config_values: { model: "gpt-5.2" } } },
+        loading: false,
+        error: null,
+      })
+    )
+  })
+})

--- a/src/hooks/use-delegation-baseline.ts
+++ b/src/hooks/use-delegation-baseline.ts
@@ -1,0 +1,107 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { toErrorMessage } from "@/lib/app-error"
+import { getDelegationSettings } from "@/lib/api"
+import type { AgentDelegationDefaults, AgentType } from "@/lib/types"
+
+export interface DelegationBaselineState {
+  /** Per-agent global delegation defaults; `null` while loading. */
+  baseline: Partial<Record<AgentType, AgentDelegationDefaults>> | null
+  loading: boolean
+  /** Human-readable fetch failure; never treated as an empty baseline. */
+  error: string | null
+  /** Retry the current open's baseline fetch. */
+  retry: () => void
+}
+
+const CLOSED: DelegationBaselineState = {
+  baseline: null,
+  loading: false,
+  error: null,
+  retry: () => {},
+}
+
+interface Settled {
+  /** Which open this result belongs to; only the CURRENT open's fetch may
+   *  land — anything older is stale by definition. */
+  epoch: number
+  baseline: Partial<Record<AgentType, AgentDelegationDefaults>> | null
+  error: string | null
+}
+
+/**
+ * The global delegation defaults the per-mention popover displays as its
+ * baseline. `active` tracks whether the popover is open.
+ *
+ * Every activation re-fetches AND clears the baseline first: the previous
+ * values must never survive a close, or an edit made right after the user
+ * changed global settings would be seeded against stale values — and since a
+ * per-call value REPLACES the global default wholesale (no merge), a stale
+ * baseline silently drops the settings the user just saved. The clear is
+ * DERIVED during render from the open epoch (React's "adjust state when a
+ * prop changes" pattern), so the moment the popover reopens `loading` is true
+ * and `baseline` is null — no effect round-trip, no stale window. The fetch
+ * is a cheap local IPC; a superseded response never lands (cancelled flag +
+ * epoch check).
+ */
+export function useDelegationGlobalBaseline(
+  active: boolean
+): DelegationBaselineState {
+  const [settled, setSettled] = useState<Settled | null>(null)
+  const [retryToken, setRetryToken] = useState(0)
+  // Bumps each time the popover transitions closed → open.
+  const [openEpoch, setOpenEpoch] = useState(0)
+  const [wasActive, setWasActive] = useState(false)
+  if (active && !wasActive) {
+    setWasActive(true)
+    setOpenEpoch((epoch) => epoch + 1)
+  } else if (!active && wasActive) {
+    setWasActive(false)
+  }
+
+  const retry = useCallback(() => {
+    setSettled(null)
+    setRetryToken((token) => token + 1)
+  }, [])
+
+  useEffect(() => {
+    if (!active || openEpoch === 0) return
+    let cancelled = false
+    getDelegationSettings()
+      .then((settings) => {
+        if (!cancelled)
+          setSettled({
+            epoch: openEpoch,
+            baseline: settings.agent_defaults ?? {},
+            error: null,
+          })
+      })
+      .catch((err: unknown) => {
+        // Never turn an unreadable baseline into an empty successful one. The
+        // popover emits a whole per-call replacement, so editing against an
+        // unknown baseline can silently drop unrelated global pins.
+        if (!cancelled) {
+          const detail = toErrorMessage(err)
+          setSettled({
+            epoch: openEpoch,
+            baseline: null,
+            error: detail.trim() || "Unknown error",
+          })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [active, openEpoch, retryToken])
+
+  if (!active) return { ...CLOSED, retry }
+  const current = settled?.epoch === openEpoch ? settled : null
+  return {
+    baseline: current?.baseline ?? null,
+    loading: current === null,
+    error: current?.error ?? null,
+    retry,
+  }
+}

--- a/src/hooks/use-message-queue.test.ts
+++ b/src/hooks/use-message-queue.test.ts
@@ -115,3 +115,59 @@ describe("useMessageQueue bounce FIFO ordering", () => {
     expect(texts(result.current.queue)).toEqual(["B", "A-edited"])
   })
 })
+
+describe("useMessageQueue delegation override preservation", () => {
+  it("keeps a queued draft's delegation_overrides through dequeue and requeueFront", () => {
+    const { result } = renderHook(() => useMessageQueue())
+    const withOverride: PromptDraft = {
+      blocks: [{ type: "text", text: "@claude_code do it" }],
+      displayText: "@Claude Code do it",
+      delegation_overrides: {
+        claude_code: { config_values: { model: "claude-opus-4-1" } },
+      },
+    }
+    act(() => result.current.enqueue(withOverride, null))
+    expect(result.current.queue[0].draft.delegation_overrides).toEqual(
+      withOverride.delegation_overrides
+    )
+
+    // The auto-flush dequeues the head and sends it — the sent draft is the
+    // same object the queue stored, overrides included.
+    let dequeued: ReturnType<typeof result.current.dequeue>
+    act(() => {
+      dequeued = result.current.dequeue()
+    })
+    expect(dequeued?.draft.delegation_overrides).toEqual(
+      withOverride.delegation_overrides
+    )
+
+    // A bounce re-queues the SAME draft at the front — overrides survive the
+    // round-trip so the retry delegates with the user's per-mention config.
+    act(() => result.current.requeueFront(withOverride, null))
+    expect(result.current.queue[0].draft.delegation_overrides).toEqual(
+      withOverride.delegation_overrides
+    )
+  })
+
+  it("keeps overrides through updateItem (queue edit save)", () => {
+    const { result } = renderHook(() => useMessageQueue())
+    const withOverride: PromptDraft = {
+      blocks: [{ type: "text", text: "@codex refactor" }],
+      displayText: "@Codex refactor",
+      delegation_overrides: {
+        codex: { config_values: { model: "gpt-5.2-codex" } },
+      },
+    }
+    act(() => result.current.enqueue(withOverride, null))
+    const [item] = result.current.queue
+    // The edited draft (rebuilt by the composer) carries the seeded overrides.
+    const edited: PromptDraft = {
+      ...withOverride,
+      displayText: "@Codex refactor (edited)",
+    }
+    act(() => result.current.updateItem(item.id, edited))
+    expect(result.current.queue[0].draft.delegation_overrides).toEqual(
+      withOverride.delegation_overrides
+    )
+  })
+})

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "الوكلاء",
         "mentionGroupSession": "الجلسات",
         "mentionGroupCommit": "عمليات الإيداع",
-        "mentionGroupSkill": "المهارات"
+        "mentionGroupSkill": "المهارات",
+        "mentionConfigTitle": "إعدادات التفويض — {agent}",
+        "mentionConfigUseGlobal": "استخدام الافتراضي العام",
+        "mentionConfigHint": "ينطبق على هذا التفويض فقط. الإعدادات المحفوظة لا تتغير.",
+        "mentionConfigAction": "تهيئة هذا التفويض",
+        "mentionDelegationDefaultLabel": "افتراضي الوكيل",
+        "mentionConfigBadgeTitle": "انقر لتهيئة هذا التفويض"
       },
       "messageQueue": {
         "addToQueue": "إضافة للقائمة",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "Agenten",
         "mentionGroupSession": "Sitzungen",
         "mentionGroupCommit": "Commits",
-        "mentionGroupSkill": "Fähigkeiten"
+        "mentionGroupSkill": "Fähigkeiten",
+        "mentionConfigTitle": "Delegierungs-Konfiguration — {agent}",
+        "mentionConfigUseGlobal": "Globalen Standard verwenden",
+        "mentionConfigHint": "Gilt nur für diese Delegierung. Gespeicherte Standards bleiben unverändert.",
+        "mentionConfigAction": "Für diese Delegierung konfigurieren",
+        "mentionDelegationDefaultLabel": "Agent-Standard",
+        "mentionConfigBadgeTitle": "Klicken, um diese Delegierung zu konfigurieren"
       },
       "messageQueue": {
         "addToQueue": "Zur Warteschlange",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "Agents",
         "mentionGroupSession": "Sessions",
         "mentionGroupCommit": "Commits",
-        "mentionGroupSkill": "Skills"
+        "mentionGroupSkill": "Skills",
+        "mentionConfigTitle": "Delegation config — {agent}",
+        "mentionConfigUseGlobal": "Use global default",
+        "mentionConfigHint": "Applies to this delegation only. Saved defaults are unchanged.",
+        "mentionConfigAction": "Configure for this delegation",
+        "mentionDelegationDefaultLabel": "Agent default",
+        "mentionConfigBadgeTitle": "Click to configure this delegation"
       },
       "messageQueue": {
         "addToQueue": "Queue message",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "Agentes",
         "mentionGroupSession": "Sesiones",
         "mentionGroupCommit": "Commits",
-        "mentionGroupSkill": "Habilidades"
+        "mentionGroupSkill": "Habilidades",
+        "mentionConfigTitle": "Configuración de delegación — {agent}",
+        "mentionConfigUseGlobal": "Usar valor global",
+        "mentionConfigHint": "Se aplica solo a esta delegación. Los valores guardados no cambian.",
+        "mentionConfigAction": "Configurar para esta delegación",
+        "mentionDelegationDefaultLabel": "Predeterminado del agente",
+        "mentionConfigBadgeTitle": "Clic para configurar esta delegación"
       },
       "messageQueue": {
         "addToQueue": "Agregar a la cola",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "Agents",
         "mentionGroupSession": "Sessions",
         "mentionGroupCommit": "Commits",
-        "mentionGroupSkill": "Compétences"
+        "mentionGroupSkill": "Compétences",
+        "mentionConfigTitle": "Configuration de délégation — {agent}",
+        "mentionConfigUseGlobal": "Utiliser la valeur globale",
+        "mentionConfigHint": "S'applique uniquement à cette délégation. Les valeurs enregistrées ne changent pas.",
+        "mentionConfigAction": "Configurer pour cette délégation",
+        "mentionDelegationDefaultLabel": "Valeur par défaut de l'agent",
+        "mentionConfigBadgeTitle": "Cliquez pour configurer cette délégation"
       },
       "messageQueue": {
         "addToQueue": "Mettre en file",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "エージェント",
         "mentionGroupSession": "セッション",
         "mentionGroupCommit": "コミット",
-        "mentionGroupSkill": "スキル"
+        "mentionGroupSkill": "スキル",
+        "mentionConfigTitle": "デリゲーション設定 — {agent}",
+        "mentionConfigUseGlobal": "グローバルデフォルトを使用",
+        "mentionConfigHint": "この委託にのみ適用されます。保存済みのデフォルトは変更されません。",
+        "mentionConfigAction": "この委託を設定",
+        "mentionDelegationDefaultLabel": "Agent のデフォルト",
+        "mentionConfigBadgeTitle": "クリックでこの委託を設定"
       },
       "messageQueue": {
         "addToQueue": "キューに追加",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "에이전트",
         "mentionGroupSession": "세션",
         "mentionGroupCommit": "커밋",
-        "mentionGroupSkill": "스킬"
+        "mentionGroupSkill": "스킬",
+        "mentionConfigTitle": "위임 설정 — {agent}",
+        "mentionConfigUseGlobal": "전역 기본값 사용",
+        "mentionConfigHint": "이 위임에만 적용됩니다. 저장된 기본값은 변경되지 않습니다.",
+        "mentionConfigAction": "이 위임 구성",
+        "mentionDelegationDefaultLabel": "Agent 기본값",
+        "mentionConfigBadgeTitle": "클릭하여 이 위임 구성"
       },
       "messageQueue": {
         "addToQueue": "대기열에 추가",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "Agentes",
         "mentionGroupSession": "Sessões",
         "mentionGroupCommit": "Commits",
-        "mentionGroupSkill": "Habilidades"
+        "mentionGroupSkill": "Habilidades",
+        "mentionConfigTitle": "Configuração de delegação — {agent}",
+        "mentionConfigUseGlobal": "Usar padrão global",
+        "mentionConfigHint": "Aplica-se apenas a esta delegação. Os padrões salvos não mudam.",
+        "mentionConfigAction": "Configurar para esta delegação",
+        "mentionDelegationDefaultLabel": "Padrão do agente",
+        "mentionConfigBadgeTitle": "Clique para configurar esta delegação"
       },
       "messageQueue": {
         "addToQueue": "Adicionar à fila",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "智能体",
         "mentionGroupSession": "会话",
         "mentionGroupCommit": "提交",
-        "mentionGroupSkill": "技能"
+        "mentionGroupSkill": "技能",
+        "mentionConfigTitle": "委托配置 — {agent}",
+        "mentionConfigUseGlobal": "使用全局默认",
+        "mentionConfigHint": "仅对本次委托生效，不会修改已保存的默认设置。",
+        "mentionConfigAction": "配置本次委托",
+        "mentionDelegationDefaultLabel": "Agent 默认",
+        "mentionConfigBadgeTitle": "点击配置本次委托"
       },
       "messageQueue": {
         "addToQueue": "加入队列",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -2884,7 +2884,13 @@
         "mentionGroupAgent": "智能體",
         "mentionGroupSession": "工作階段",
         "mentionGroupCommit": "提交",
-        "mentionGroupSkill": "技能"
+        "mentionGroupSkill": "技能",
+        "mentionConfigTitle": "委派設定 — {agent}",
+        "mentionConfigUseGlobal": "使用全域預設",
+        "mentionConfigHint": "僅對本次委派生效，不會修改已儲存的預設設定。",
+        "mentionConfigAction": "設定本次委派",
+        "mentionDelegationDefaultLabel": "Agent 預設",
+        "mentionConfigBadgeTitle": "點擊設定本次委派"
       },
       "messageQueue": {
         "addToQueue": "加入佇列",

--- a/src/lib/api-delegation-overrides.test.ts
+++ b/src/lib/api-delegation-overrides.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { PromptInputBlock } from "@/lib/types"
+
+// acpPrompt reads the environment to decide payload stripping; pin it to the
+// plain-web shape (no remote workspace attached) so blocks pass through.
+vi.mock("@/lib/platform", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isDesktop: () => false,
+}))
+
+const callMock = vi.fn()
+
+vi.mock("./transport", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getTransport: () => ({ call: callMock }),
+  getActiveRemoteConnectionId: () => null,
+}))
+
+import { acpPrompt } from "./api"
+
+const blocks: PromptInputBlock[] = [{ type: "text", text: "@claude_code hi" }]
+
+beforeEach(() => {
+  callMock.mockReset()
+  callMock.mockResolvedValue(undefined)
+})
+
+describe("acpPrompt delegationOverrides serialization", () => {
+  it("ships a populated override map as the camelCase payload field", async () => {
+    await acpPrompt("conn-1", blocks, 3, 7, "msg-1", {
+      claude_code: {
+        mode_id: "plan",
+        config_values: { model: "claude-opus-4-1" },
+      },
+    })
+    expect(callMock).toHaveBeenCalledTimes(1)
+    const [command, payload] = callMock.mock.calls[0]
+    expect(command).toBe("acp_prompt")
+    expect(payload.delegationOverrides).toEqual({
+      claude_code: {
+        mode_id: "plan",
+        config_values: { model: "claude-opus-4-1" },
+      },
+    })
+    // The rest of the payload keeps its existing shape.
+    expect(payload.connectionId).toBe("conn-1")
+    expect(payload.blocks).toEqual(blocks)
+    expect(payload.folderId).toBe(3)
+    expect(payload.conversationId).toBe(7)
+    expect(payload.clientMessageId).toBe("msg-1")
+  })
+
+  it("omits the field from the wire payload when no overrides are passed (compat)", async () => {
+    await acpPrompt("conn-1", blocks)
+    const [, payload] = callMock.mock.calls[0]
+    // The in-memory payload object carries the key as `undefined`; JSON — the
+    // actual wire form for both HTTP bodies and Tauri invoke args — drops it.
+    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty(
+      "delegationOverrides"
+    )
+  })
+
+  it("omits the field from the wire payload for an undefined override map", async () => {
+    await acpPrompt("conn-1", blocks, null, null, null, undefined)
+    const [, payload] = callMock.mock.calls[0]
+    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty(
+      "delegationOverrides"
+    )
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -281,7 +281,12 @@ export async function acpPrompt(
   blocks: PromptInputBlock[],
   folderId: number | null = null,
   conversationId: number | null = null,
-  clientMessageId: string | null = null
+  clientMessageId: string | null = null,
+  // Draft-scoped delegation overrides for `@Agent` mentions (per-turn only).
+  // Optional trailing argument: existing callers stay untouched, and an
+  // undefined map is omitted from the payload so the wire request is
+  // byte-identical to a prompt without overrides.
+  delegationOverrides?: Partial<Record<AgentType, AgentDelegationDefaults>>
 ): Promise<void> {
   try {
     await getTransport().call("acp_prompt", {
@@ -295,6 +300,7 @@ export async function acpPrompt(
       folderId,
       conversationId,
       clientMessageId,
+      delegationOverrides,
     })
   } catch (e) {
     if (isTurnInProgressRejection(e)) throw new TurnBusyError()

--- a/src/lib/delegation-overrides.test.ts
+++ b/src/lib/delegation-overrides.test.ts
@@ -1,0 +1,387 @@
+import type { JSONContent } from "@tiptap/core"
+import { describe, expect, it } from "vitest"
+
+import type { ReferenceMeta } from "@/components/chat/composer/types"
+import type {
+  AgentDelegationDefaults,
+  PromptDraft,
+  PromptInputBlock,
+} from "@/lib/types"
+
+import {
+  clearDelegationOverride,
+  collectDelegationOverrides,
+  delegationDefaultsSummaryParts,
+  isEmptyDelegationOverride,
+  mergeDelegationOverride,
+  readReferenceDelegationOverride,
+  withDelegationOverrides,
+  writeReferenceDelegationOverride,
+} from "./delegation-overrides"
+import { blocksToRestoredDraft } from "@/components/chat/composer/from-prompt-blocks"
+import { textToSeededInlineContent } from "@/components/chat/composer/plain-text-content"
+
+function agentMention(
+  id: string,
+  override: AgentDelegationDefaults | null
+): JSONContent {
+  const meta: ReferenceMeta | null = override
+    ? ({ agentType: id, delegationOverride: override } as ReferenceMeta)
+    : ({ agentType: id } as ReferenceMeta)
+  return {
+    type: "reference",
+    attrs: { refType: "agent", id, label: id, uri: null, meta },
+  }
+}
+
+function doc(...content: JSONContent[]): JSONContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [...content, { type: "text", text: "hi" }],
+      },
+    ],
+  }
+}
+
+function draft(overrides?: PromptDraft["delegation_overrides"]): PromptDraft {
+  return {
+    blocks: [{ type: "text", text: "@claude_code do it" }],
+    displayText: "@Claude Code do it",
+    ...(overrides ? { delegation_overrides: overrides } : {}),
+  }
+}
+
+const modeOverride: AgentDelegationDefaults = {
+  mode_id: "plan",
+  config_values: {},
+}
+const modelOverride: AgentDelegationDefaults = {
+  config_values: { model: "claude-opus-4-1" },
+}
+
+describe("isEmptyDelegationOverride", () => {
+  it("treats null, empty mode and empty config as absence", () => {
+    expect(isEmptyDelegationOverride(null)).toBe(true)
+    expect(isEmptyDelegationOverride(undefined)).toBe(true)
+    expect(isEmptyDelegationOverride({ config_values: {} })).toBe(true)
+    expect(isEmptyDelegationOverride({ mode_id: "", config_values: {} })).toBe(
+      true
+    )
+  })
+
+  it("treats any populated field as present", () => {
+    expect(isEmptyDelegationOverride(modeOverride)).toBe(false)
+    expect(isEmptyDelegationOverride(modelOverride)).toBe(false)
+  })
+})
+
+describe("readReferenceDelegationOverride", () => {
+  it("round-trips a stored override", () => {
+    const meta = writeReferenceDelegationOverride(null, modelOverride)
+    expect(readReferenceDelegationOverride(meta)).toEqual(modelOverride)
+  })
+
+  it("returns null for absent, malformed, or empty values", () => {
+    expect(readReferenceDelegationOverride(null)).toBeNull()
+    expect(readReferenceDelegationOverride({})).toBeNull()
+    expect(
+      readReferenceDelegationOverride({
+        delegationOverride: { config_values: {} },
+      })
+    ).toBeNull()
+    // Non-string config values (untrusted pasted payload) are dropped.
+    expect(
+      readReferenceDelegationOverride({
+        delegationOverride: {
+          config_values: { model: 42 } as unknown as Record<string, string>,
+        },
+      })
+    ).toEqual({ config_values: {} })
+  })
+})
+
+describe("writeReferenceDelegationOverride", () => {
+  it("preserves unrelated meta fields when writing", () => {
+    const meta: ReferenceMeta = { agentType: "claude_code", available: true }
+    const next = writeReferenceDelegationOverride(meta, modeOverride)
+    expect(next).toEqual({
+      agentType: "claude_code",
+      available: true,
+      delegationOverride: modeOverride,
+    })
+    expect(meta).not.toHaveProperty("delegationOverride")
+  })
+
+  it("removes the field on reset instead of storing an empty object", () => {
+    const meta = writeReferenceDelegationOverride(
+      { agentType: "claude_code" },
+      modeOverride
+    )
+    const reset = writeReferenceDelegationOverride(meta, null)
+    expect(reset).toEqual({ agentType: "claude_code" })
+    expect(
+      writeReferenceDelegationOverride(meta, { config_values: {} })
+    ).toEqual({ agentType: "claude_code" })
+  })
+})
+
+describe("collectDelegationOverrides", () => {
+  it("returns undefined for an untouched doc (no meta overrides)", () => {
+    expect(
+      collectDelegationOverrides(doc(agentMention("claude_code", null)))
+    ).toBeUndefined()
+    expect(collectDelegationOverrides(doc())).toBeUndefined()
+    expect(collectDelegationOverrides(null)).toBeUndefined()
+  })
+
+  it("ignores non-agent references", () => {
+    const fileRef: JSONContent = {
+      type: "reference",
+      attrs: {
+        refType: "file",
+        id: "src/app.ts",
+        label: "app.ts",
+        uri: "file:///repo/src/app.ts",
+        meta: { fileKind: "file" },
+      },
+    }
+    expect(collectDelegationOverrides(doc(fileRef))).toBeUndefined()
+  })
+
+  it("collects one entry per mentioned agent", () => {
+    const collected = collectDelegationOverrides(
+      doc(
+        agentMention("claude_code", modeOverride),
+        agentMention("codex", modelOverride)
+      )
+    )
+    expect(collected).toEqual({
+      claude_code: modeOverride,
+      codex: modelOverride,
+    })
+  })
+
+  it("picks the last occurrence in doc order for duplicate mentions", () => {
+    const collected = collectDelegationOverrides(
+      doc(
+        agentMention("claude_code", modeOverride),
+        agentMention("claude_code", modelOverride)
+      )
+    )
+    expect(collected).toEqual({ claude_code: modelOverride })
+  })
+
+  it("drops the entry when the last duplicate was reset to global", () => {
+    const collected = collectDelegationOverrides(
+      doc(
+        agentMention("claude_code", modeOverride),
+        agentMention("claude_code", null)
+      )
+    )
+    expect(collected).toBeUndefined()
+  })
+})
+
+describe("mergeDelegationOverride", () => {
+  it("adds an override without mutating the input draft", () => {
+    const base = draft()
+    const next = mergeDelegationOverride(base, "claude_code", modeOverride)
+    expect(next.delegation_overrides).toEqual({ claude_code: modeOverride })
+    expect(base).not.toHaveProperty("delegation_overrides")
+  })
+
+  it("preserves unrelated agents", () => {
+    const base = mergeDelegationOverride(draft(), "codex", modelOverride)
+    const next = mergeDelegationOverride(base, "claude_code", modeOverride)
+    expect(next.delegation_overrides).toEqual({
+      codex: modelOverride,
+      claude_code: modeOverride,
+    })
+  })
+
+  it("lets the most recent explicit edit win for the same agent", () => {
+    const base = mergeDelegationOverride(draft(), "claude_code", modeOverride)
+    const next = mergeDelegationOverride(base, "claude_code", modelOverride)
+    expect(next.delegation_overrides).toEqual({ claude_code: modelOverride })
+  })
+
+  it("clears back to global on an empty value", () => {
+    const base = mergeDelegationOverride(draft(), "claude_code", modeOverride)
+    const reset = mergeDelegationOverride(base, "claude_code", null)
+    expect(reset).not.toHaveProperty("delegation_overrides")
+    expect(reset.blocks).toEqual(base.blocks)
+  })
+
+  it("clearing an absent agent returns the same draft", () => {
+    const base = draft()
+    expect(clearDelegationOverride(base, "claude_code")).toBe(base)
+  })
+
+  it("removes the whole field when the last entry is cleared", () => {
+    const base = mergeDelegationOverride(
+      mergeDelegationOverride(draft(), "codex", modelOverride),
+      "claude_code",
+      modeOverride
+    )
+    const one = clearDelegationOverride(base, "codex")
+    expect(one.delegation_overrides).toEqual({ claude_code: modeOverride })
+    const none = clearDelegationOverride(one, "claude_code")
+    expect(none).not.toHaveProperty("delegation_overrides")
+    expect(none).not.toBe(base)
+  })
+})
+
+/**
+ * Reviewer regression: a queue edit must PRESERVE its delegation overrides.
+ * Real path, no stubs: the queued blocks are exactly what a send serialized
+ * (agent mention reduced to prose) → blocksToRestoredDraft (the queue-edit
+ * restore) → textToSeededInlineContent (badge hydration) → the hydration-time
+ * override injection (`withDelegationOverrides`) → what buildDraft collects.
+ */
+function restoredDocFromBlocks(blocks: PromptInputBlock[]): JSONContent {
+  const { segments } = blocksToRestoredDraft(blocks)
+  const content = segments.flatMap((segment) =>
+    segment.kind === "text"
+      ? textToSeededInlineContent(segment.text)
+      : [{ type: "reference", attrs: segment.attrs } as JSONContent]
+  )
+  return { type: "doc", content: [{ type: "paragraph", content }] }
+}
+
+describe("queue-edit override round-trip (real hydration path)", () => {
+  const queuedBlocks: PromptInputBlock[] = [
+    {
+      type: "text",
+      text: "[@Codex](codeg://agent/codex) refactor the parser",
+    },
+  ]
+  const queuedOverrides = {
+    codex: { config_values: { model: "gpt-5.2-codex" } },
+  }
+
+  it("block hydration rebuilds the agent badge WITHOUT its meta", () => {
+    // The precondition the injection exists for: the restored badge has no
+    // delegationOverride, because the queue only stored prompt prose.
+    const restored = restoredDocFromBlocks(queuedBlocks)
+    expect(collectDelegationOverrides(restored)).toBeUndefined()
+    const badge = findBadge(restored)
+    expect(badge?.attrs).toMatchObject({ refType: "agent", id: "codex" })
+  })
+
+  it("injecting the queued overrides makes an untouched edit preserve them", () => {
+    const restored = restoredDocFromBlocks(queuedBlocks)
+    const injected = withDelegationOverrides(restored, queuedOverrides)
+    expect(injected).not.toBeNull()
+    expect(collectDelegationOverrides(injected!)).toEqual(queuedOverrides)
+  })
+
+  it("injection is idempotent and skips badges the doc already agrees with", () => {
+    const restored = restoredDocFromBlocks(queuedBlocks)
+    const once = withDelegationOverrides(restored, queuedOverrides)!
+    // A second pass (e.g. a re-hydrate) changes nothing.
+    expect(withDelegationOverrides(once, queuedOverrides)).toBeNull()
+    expect(collectDelegationOverrides(once)).toEqual(queuedOverrides)
+  })
+
+  it("a reset expressed in the doc (cleared meta) is NOT resurrected", () => {
+    // User re-mentioned @Codex and clicked "use global default": the badge's
+    // meta was cleared in the doc. Injection happens only at hydration time,
+    // so a later save reads the doc and sends nothing.
+    const d = doc(agentMention("codex", null))
+    expect(withDelegationOverrides(d, queuedOverrides)).not.toBeNull()
+    // …but only hydration applies the seed; collectDelegationOverrides — what
+    // buildDraft reads — still sees no override on the badge.
+    expect(collectDelegationOverrides(d)).toBeUndefined()
+  })
+
+  it("a deleted mention simply has nothing to collect", () => {
+    const restored = restoredDocFromBlocks([
+      { type: "text", text: "refactor the parser" },
+    ])
+    expect(collectDelegationOverrides(restored)).toBeUndefined()
+    expect(withDelegationOverrides(restored, queuedOverrides)).toBeNull()
+  })
+})
+
+function findBadge(node: JSONContent): JSONContent | undefined {
+  if (node.type === "reference") return node
+  for (const child of node.content ?? []) {
+    const found = findBadge(child)
+    if (found) return found
+  }
+  return undefined
+}
+
+describe("delegationDefaultsSummaryParts (readonly @ panel summary)", () => {
+  it("returns empty for nothing pinned (row shows the Agent default label)", () => {
+    expect(delegationDefaultsSummaryParts(null)).toEqual([])
+    expect(delegationDefaultsSummaryParts({ config_values: {} })).toEqual([])
+  })
+
+  it("puts the model first, then the mode", () => {
+    expect(
+      delegationDefaultsSummaryParts({
+        mode_id: "plan",
+        config_values: { model: "claude-opus-4-1", permission_mode: "plan" },
+      })
+    ).toEqual(["claude-opus-4-1", "plan"])
+  })
+
+  it("caps at two parts to fit the row", () => {
+    expect(
+      delegationDefaultsSummaryParts({
+        mode_id: "plan",
+        config_values: {
+          model: "claude-opus-4-1",
+          permission_mode: "plan",
+          extra: "x",
+        },
+      })
+    ).toHaveLength(2)
+  })
+})
+
+describe("one agent, one config (explicit non-goal: per-mention overrides)", () => {
+  it("applies the same override to EVERY badge of the agent in one doc", () => {
+    // Documented limitation: two mentions of the same agent share ONE
+    // override. The popover writes all same-agent badges in a single
+    // transaction (message-input handleDelegationChange); the hydration-time
+    // injector has the same shape. There is no per-mention wire schema, and
+    // no last-write-wins ambiguity — every badge of the agent carries the
+    // identical value by construction.
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            agentMention("claude_code", null),
+            { type: "text", text: " then " },
+            agentMention("claude_code", null),
+          ],
+        },
+      ],
+    }
+    const next = withDelegationOverrides(doc, {
+      claude_code: modelOverride,
+    })
+    expect(next).not.toBeNull()
+    const badges: JSONContent[] = []
+    const walk = (node: JSONContent): void => {
+      if (node.type === "reference") badges.push(node)
+      for (const child of node.content ?? []) walk(child)
+    }
+    walk(next!)
+    expect(badges).toHaveLength(2)
+    for (const badge of badges) {
+      expect(
+        readReferenceDelegationOverride(
+          (badge.attrs as { meta: ReferenceMeta }).meta
+        )
+      ).toEqual(modelOverride)
+    }
+  })
+})

--- a/src/lib/delegation-overrides.ts
+++ b/src/lib/delegation-overrides.ts
@@ -1,0 +1,254 @@
+import type { JSONContent } from "@tiptap/core"
+
+import type { ReferenceMeta } from "@/components/chat/composer/types"
+import type {
+  AgentDelegationDefaults,
+  AgentType,
+  PromptDraft,
+} from "@/lib/types"
+
+/**
+ * Draft-scoped delegation config overrides for `@Agent` mentions.
+ *
+ * The composer's per-mention config popover stores the user's pick on the
+ * mention node's `ReferenceMeta.delegationOverride` (so it survives the doc's
+ * JSON round-trips); these pure helpers collect those picks into the
+ * `PromptDraft.delegation_overrides` map the send path ships to the backend,
+ * and maintain such maps imperatively for callers that hold a draft-level
+ * value (queue-edit seeding, the popover itself).
+ *
+ * An override object with nothing set counts as ABSENCE everywhere here — a
+ * "reset to global/default" edit removes the entry instead of storing an empty
+ * `{}`, so an untouched mention produces a draft with no `delegation_overrides`
+ * field at all and the wire payload stays byte-identical to today's.
+ */
+
+/** A shallow copy with `mode_id`/`config_values` normalized to present shapes. */
+function normalizeOverride(
+  value: AgentDelegationDefaults
+): AgentDelegationDefaults {
+  return {
+    ...(value.mode_id ? { mode_id: value.mode_id } : {}),
+    config_values: { ...(value.config_values ?? {}) },
+  }
+}
+
+/** True when the override carries nothing — the "use global/default" shape. */
+export function isEmptyDelegationOverride(
+  value: AgentDelegationDefaults | null | undefined
+): boolean {
+  if (!value) return true
+  const modeEmpty = value.mode_id == null || value.mode_id.length === 0
+  const configEmpty =
+    value.config_values == null || Object.keys(value.config_values).length === 0
+  return modeEmpty && configEmpty
+}
+
+/**
+ * Read the override stored on one reference node's `meta`, or `null` when the
+ * meta carries none (or a non-object / empty one — pasted HTML is an untrusted
+ * input, so anything malformed degrades to "no override").
+ */
+export function readReferenceDelegationOverride(
+  meta: ReferenceMeta | null | undefined
+): AgentDelegationDefaults | null {
+  const raw = meta?.delegationOverride
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+  if (isEmptyDelegationOverride(raw)) return null
+  const config_values: Record<string, string> = {}
+  if (raw.config_values && typeof raw.config_values === "object") {
+    for (const [key, value] of Object.entries(raw.config_values)) {
+      if (typeof value === "string" && value.length > 0) {
+        config_values[key] = value
+      }
+    }
+  }
+  return normalizeOverride({ mode_id: raw.mode_id ?? undefined, config_values })
+}
+
+/**
+ * Immutably set or clear the override on a `ReferenceMeta`. `null` (or an
+ * empty value) removes the field; other fields on the meta are preserved.
+ */
+export function writeReferenceDelegationOverride(
+  meta: ReferenceMeta | null | undefined,
+  value: AgentDelegationDefaults | null
+): ReferenceMeta {
+  const base: ReferenceMeta = { ...(meta ?? {}) }
+  if (isEmptyDelegationOverride(value)) {
+    delete base.delegationOverride
+  } else {
+    base.delegationOverride = normalizeOverride(
+      value as AgentDelegationDefaults
+    )
+  }
+  return base
+}
+
+/**
+ * Collect the per-agent overrides stored on a composer document's agent
+ * mention nodes. One draft-level value per agent: when the same agent is
+ * mentioned more than once, the LAST occurrence in document order wins
+ * (deterministic; the popover also writes every duplicate in one edit, so the
+ * doc-order tiebreak only matters for docs edited out-of-band). Returns
+ * `undefined` when the doc carries no overrides — callers omit the
+ * `delegation_overrides` field entirely rather than shipping an empty map.
+ */
+export function collectDelegationOverrides(
+  doc: JSONContent | null | undefined
+): Partial<Record<AgentType, AgentDelegationDefaults>> | undefined {
+  const collected: Partial<Record<AgentType, AgentDelegationDefaults>> = {}
+  if (!doc) return undefined
+
+  const walk = (node: JSONContent | undefined): void => {
+    if (!node) return
+    if (node.type === "reference") {
+      const attrs = node.attrs as
+        | { refType?: string; id?: string; meta?: ReferenceMeta | null }
+        | undefined
+      if (attrs?.refType === "agent" && attrs.id) {
+        const override = readReferenceDelegationOverride(attrs.meta)
+        if (override) collected[attrs.id as AgentType] = override
+        else delete collected[attrs.id as AgentType]
+      }
+    }
+    for (const child of node.content ?? []) walk(child)
+  }
+  walk(doc)
+
+  if (Object.keys(collected).length === 0) return undefined
+  return collected
+}
+
+/**
+ * Merge one agent's draft-scoped override into a `PromptDraft`, immutably.
+ * An empty `value` clears the entry (back to the global default). Later calls
+ * for the same agent overwrite earlier ones — the most recent explicit edit is
+ * authoritative.
+ */
+export function mergeDelegationOverride(
+  draft: PromptDraft,
+  agentType: AgentType,
+  value: AgentDelegationDefaults | null
+): PromptDraft {
+  if (isEmptyDelegationOverride(value)) {
+    return clearDelegationOverride(draft, agentType)
+  }
+  const overrides = { ...(draft.delegation_overrides ?? {}) }
+  overrides[agentType] = normalizeOverride(value as AgentDelegationDefaults)
+  return { ...draft, delegation_overrides: overrides }
+}
+
+/**
+ * Remove one agent's draft-scoped override from a `PromptDraft`, immutably.
+ * Dropping the last entry removes the `delegation_overrides` field itself.
+ */
+export function clearDelegationOverride(
+  draft: PromptDraft,
+  agentType: AgentType
+): PromptDraft {
+  if (
+    !draft.delegation_overrides ||
+    !(agentType in draft.delegation_overrides)
+  ) {
+    return draft
+  }
+  const overrides = { ...draft.delegation_overrides }
+  delete overrides[agentType]
+  const next: PromptDraft = { ...draft }
+  if (Object.keys(overrides).length === 0) {
+    delete next.delegation_overrides
+  } else {
+    next.delegation_overrides = overrides
+  }
+  return next
+}
+
+/**
+ * Human-readable summary of what a delegation to one agent would use, from its
+ * (global-default or override) config: the mode id and the model-ish config
+ * value, most informative first, capped at two parts — this renders inline in
+ * the `@` panel's agent row, where only a few characters fit. Empty array =
+ * nothing pinned, the agent's native default applies.
+ */
+export function delegationDefaultsSummaryParts(
+  defaults: AgentDelegationDefaults | null | undefined,
+  maxParts = 2
+): string[] {
+  if (isEmptyDelegationOverride(defaults)) return []
+  const parts: string[] = []
+  if (defaults?.mode_id) parts.push(defaults.mode_id)
+  let modelPinned = false
+  for (const [key, value] of Object.entries(defaults?.config_values ?? {})) {
+    if (value.length === 0) continue
+    const isModel = key.toLowerCase().includes("model")
+    if (isModel) {
+      // Model reads first (it's what people check first); mode shifts over.
+      parts.splice(0, 0, value)
+      modelPinned = true
+      if (parts.length >= maxParts) break
+      continue
+    }
+    if (modelPinned || parts.length >= maxParts) continue
+    parts.push(value)
+  }
+  return parts.slice(0, maxParts)
+}
+
+/**
+ * Write the given per-agent overrides onto a composer document's agent mention
+ * badges IN PLACE (pure: returns a new tree, or `null` when nothing changed).
+ *
+ * This is how a queued item's delegation overrides survive a queue edit: the
+ * queue stores only prompt prose, and the edit's block → badge hydration
+ * (`restoreBlocksIntoEditor` → `textToSeededInlineContent`) rebuilds agent
+ * badges WITHOUT their meta — so the host re-applies the queued overrides
+ * right after hydration. Once the badges carry the values, the document is the
+ * single source of truth: `collectDelegationOverrides` reads them back on
+ * send, and a user reset / mention deletion is expressed in the doc itself
+ * (cleared meta / no badge), with no seed layered on top at save time.
+ */
+export function withDelegationOverrides(
+  doc: JSONContent,
+  overrides: Partial<Record<AgentType, AgentDelegationDefaults>>
+): JSONContent | null {
+  let changed = false
+
+  const walk = (node: JSONContent): JSONContent => {
+    if (node.type === "reference") {
+      const attrs = node.attrs as
+        | { refType?: string; id?: string; meta?: ReferenceMeta | null }
+        | undefined
+      const agent = attrs?.refType === "agent" ? (attrs.id as AgentType) : null
+      const incoming = agent ? overrides[agent] : undefined
+      if (agent && !isEmptyDelegationOverride(incoming)) {
+        const current = readReferenceDelegationOverride(attrs?.meta)
+        if (
+          !current ||
+          JSON.stringify(current) !==
+            JSON.stringify(
+              normalizeOverride(incoming as AgentDelegationDefaults)
+            )
+        ) {
+          changed = true
+          return {
+            ...node,
+            attrs: {
+              ...attrs,
+              meta: writeReferenceDelegationOverride(attrs?.meta, incoming!),
+            },
+          }
+        }
+      }
+      return node
+    }
+    if (!node.content?.length) return node
+    const children = node.content.map(walk)
+    return children.some((child, i) => child !== node.content![i])
+      ? { ...node, content: children }
+      : node
+  }
+
+  const next = walk(doc)
+  return changed ? next : null
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core"
 import { getCurrentEffectiveAppLocale } from "./i18n"
 import type {
+  AgentDelegationDefaults,
   AgentType,
   ConversationSummary,
   ConversationDetail,
@@ -120,9 +121,16 @@ export async function acpConnect(
 
 export async function acpPrompt(
   connectionId: string,
-  blocks: PromptInputBlock[]
+  blocks: PromptInputBlock[],
+  // Draft-scoped delegation overrides for `@Agent` mentions (per-turn only).
+  // Undefined/empty is omitted from the invoke args (serde default = none).
+  delegationOverrides?: Partial<Record<AgentType, AgentDelegationDefaults>>
 ): Promise<void> {
-  return invoke("acp_prompt", { connectionId, blocks })
+  return invoke("acp_prompt", {
+    connectionId,
+    blocks,
+    ...(delegationOverrides ? { delegationOverrides } : {}),
+  })
 }
 
 export async function acpSetMode(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1274,6 +1274,16 @@ export type PromptInputBlock =
 export interface PromptDraft {
   blocks: PromptInputBlock[]
   displayText: string
+  /**
+   * Draft-scoped delegation config overrides, keyed by the mentioned agent.
+   * Populated when the user tweaks an `@Agent` mention's model/mode/permission
+   * in the composer's per-mention config popover; overrides ride the draft
+   * through send / queue / requeue / edit and reach the delegation broker as
+   * per-call values (precedence: per-call > global default > agent native).
+   * Absent/empty = untouched — the request is byte-identical to a draft
+   * without this field. Never persisted to global delegation settings.
+   */
+  delegation_overrides?: Partial<Record<AgentType, AgentDelegationDefaults>>
 }
 
 // Permission option info from agent


### PR DESCRIPTION
## 变更说明

现在通过 `@Agent` 提及时，单次委托只能使用全局默认配置，无法针对某一次委托选择不同的模型、思考等级或权限配置。

本 PR 支持在智能体选择面板中查看当前摘要，并通过按需打开的配置面板修改本次委托配置。未修改时继续使用全局默认配置。

## 主要改动

### 前端

- `@Agent` mention 支持保存单次委托的配置覆盖；配置随编辑器文档、发送、排队、重排队和队列编辑流程保留。
- 智能体选择面板展示当前配置摘要，详细配置面板按需加载，不阻塞普通 mention 搜索。
- 配置面板复用现有 ACP agent options，只展示智能体实际广告的模型、思考模式、权限及其他配置项。
- 行级修改发送完整的有效配置，避免覆盖全局默认时静默丢失未修改的配置。
- 配置加载失败时禁止基于不完整基线编辑，并提供重试入口。

### 后端

- ACP prompt transport 增加可选的单次 delegation overrides，未设置时保持旧 payload 不变。
- 当前 turn 使用的单次配置写入 `SessionState`，turn 完成、取消或断开后清理，避免配置污染后续对话。
- delegation broker 使用以下优先级：

  `per-call > 持久化全局默认 > agent 原生默认`

- 后端统一清理空白的 mode/config 值；空覆盖会回退到全局默认。
- 保持现有 one-shot delegation 的 task、status、cancel 和结果缓存语义不变，不修改 agent 原生配置文件或环境变量。

## 兼容性

- 新字段均为可选字段，旧客户端和未配置的 mention 保持原有行为。
- 同时覆盖桌面 Tauri transport 和服务器 Web transport。
- 不引入持续会话，也不改变 delegation task 的生命周期。

## 测试与检查

- 前端全量测试：375 个测试文件，5289 个测试通过。
- Rust delegation broker 测试：124 个通过。
- Rust delegation settings 测试：10 个通过。
- server-mode clippy：通过。
- ESLint：通过。
- `git diff --check`：通过。
