### PR TITLE
feat(terminal): mobile virtual key bar

### DIFF
--- a/src/app/workspace/layout.tsx
+++ b/src/app/workspace/layout.tsx
@@ -683,7 +683,7 @@ function MobileFolderWorkspaceShell({
         swipeDirection="down"
         disablePointerDismissal={false}
       >
-        <DrawerContent showCloseButton={false} className="h-[70vh] p-0">
+        <DrawerContent showCloseButton={false} className="h-[95vh] p-0">
           <DrawerTitle className="sr-only">Terminal</DrawerTitle>
           <div className="h-full min-h-0 overflow-hidden">
             <TerminalPanel />

--- a/src/components/terminal/term-keybar.test.tsx
+++ b/src/components/terminal/term-keybar.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TermKeybar } from "./term-keybar"
+
+// next-intl is mocked at module level via vitest config; provide the minimum
+// shape used by `useTranslations` so `t("...")` returns the key path.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const NO_MODS = { ctrl: false, alt: false }
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("<TermKeybar />", () => {
+  it("renders all 12 keys + 2 modifier buttons", () => {
+    render(
+      <TermKeybar mods={NO_MODS} onToggleMod={() => {}} onPressKey={() => {}} />
+    )
+    // Two-row layout, 7 + 7 buttons.
+    const all = screen.getAllByRole("button")
+    expect(all).toHaveLength(14)
+  })
+
+  it("fires onPressKey with the right key on pointerdown, and skips click", () => {
+    const onPressKey = vi.fn()
+    render(
+      <TermKeybar
+        mods={NO_MODS}
+        onToggleMod={() => {}}
+        onPressKey={onPressKey}
+      />
+    )
+
+    // Find the "up" key by its localized label (we mocked useTranslations to
+    // return the key path, so labels are "up", "down", etc.).
+    const upBtn = screen.getByRole("button", { name: "up" })
+    fireEvent.pointerDown(upBtn)
+
+    expect(onPressKey).toHaveBeenCalledTimes(1)
+    expect(onPressKey).toHaveBeenCalledWith("up")
+
+    // Click after pointerdown would double-fire without the swallowClick.
+    fireEvent.click(upBtn)
+    expect(onPressKey).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires onToggleMod('ctrl' | 'alt') on the modifier buttons", () => {
+    const onToggleMod = vi.fn()
+    render(
+      <TermKeybar
+        mods={NO_MODS}
+        onToggleMod={onToggleMod}
+        onPressKey={() => {}}
+      />
+    )
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "ctrl" }))
+    expect(onToggleMod).toHaveBeenCalledWith("ctrl")
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "alt" }))
+    expect(onToggleMod).toHaveBeenCalledWith("alt")
+  })
+
+  it("marks CTRL/ALT active when mods prop is true", () => {
+    render(
+      <TermKeybar
+        mods={{ ctrl: true, alt: false }}
+        onToggleMod={() => {}}
+        onPressKey={() => {}}
+      />
+    )
+    // active class includes `bg-primary text-primary-foreground border-primary`
+    const ctrl = screen.getByRole("button", { name: "ctrl" })
+    expect(ctrl.className).toContain("bg-primary")
+
+    // ALT not armed — no accent.
+    const alt = screen.getByRole("button", { name: "alt" })
+    expect(alt.className).not.toContain("bg-primary")
+  })
+
+  it("disables every button when disabled=true", () => {
+    render(
+      <TermKeybar
+        mods={NO_MODS}
+        onToggleMod={() => {}}
+        onPressKey={() => {}}
+        disabled
+      />
+    )
+    const all = screen.getAllByRole("button")
+    for (const btn of all) {
+      expect(btn).toBeDisabled()
+    }
+  })
+})

--- a/src/components/terminal/term-keybar.tsx
+++ b/src/components/terminal/term-keybar.tsx
@@ -14,7 +14,7 @@ interface TermKeybarProps {
   onToggleMod: (mod: "ctrl" | "alt") => void
   /** 按下普通键（ESC/TAB/方向键 等）——不消费闩锁，由父级在发完字节后复位。 */
   onPressKey: (key: TermKeyBarKey) => void
-  /** IME 组合进行中时禁用整组按钮（避免送出误触发的控制码）。 */
+  /** 禁用整组按钮。当前无调用方使用，保留给「输入被阻塞时置灰」这类场景。 */
   disabled?: boolean
 }
 
@@ -25,8 +25,8 @@ interface TermKeybarProps {
  *   · `onPointerDown` 触发 + `preventDefault`：按钮不夺走 xterm helper textarea
  *     的焦点，软键盘保持弹出。
  *   · CTRL/ALT 互斥闩锁：armed 状态由父级 state 控制，本组件只渲染高亮。
- *   · 桌面端由父级用媒体查询（`useMediaQuery("(max-width: 768px)")`）判定，
- *     此处不再二次过滤，避免 SSR/CSR 不一致导致水合闪烁。
+ *   · 桌面端由父级用 `useIsMobile()` 判定后整体不挂载，此处不再二次过滤，
+ *     避免 SSR/CSR 不一致导致水合闪烁。
  */
 export function TermKeybar({
   mods,

--- a/src/components/terminal/term-keybar.tsx
+++ b/src/components/terminal/term-keybar.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import type { MouseEvent, PointerEvent } from "react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { type TermKeyBarKey, type TermMods } from "@/lib/terminal/keybar"
+
+interface TermKeybarProps {
+  /** 当前 CTRL/ALT 闩锁状态（驱动按钮高亮）。 */
+  mods: TermMods
+  /** 切换 CTRL/ALT 闩锁。 */
+  onToggleMod: (mod: "ctrl" | "alt") => void
+  /** 按下普通键（ESC/TAB/方向键 等）——不消费闩锁，由父级在发完字节后复位。 */
+  onPressKey: (key: TermKeyBarKey) => void
+  /** IME 组合进行中时禁用整组按钮（避免送出误触发的控制码）。 */
+  disabled?: boolean
+}
+
+/**
+ * 移动端终端虚拟键栏：两行按钮，覆盖 ESC/TAB/方向键/PgUp/PgDn + CTRL/ALT 闩锁。
+ *
+ * 关键细节：
+ *   · `onPointerDown` 触发 + `preventDefault`：按钮不夺走 xterm helper textarea
+ *     的焦点，软键盘保持弹出。
+ *   · CTRL/ALT 互斥闩锁：armed 状态由父级 state 控制，本组件只渲染高亮。
+ *   · 桌面端由父级用媒体查询（`useMediaQuery("(max-width: 768px)")`）判定，
+ *     此处不再二次过滤，避免 SSR/CSR 不一致导致水合闪烁。
+ */
+export function TermKeybar({
+  mods,
+  onToggleMod,
+  onPressKey,
+  disabled = false,
+}: TermKeybarProps) {
+  const t = useTranslations("Folder.terminal.keybar")
+
+  // onPointerDown handler — preventDefault keeps the soft keyboard open and the
+  // xterm helper textarea focused. Calling preventDefault on the React synthetic
+  // event is enough to suppress the default focus shift; we don't need a native
+  // addEventListener here.
+  const handlePointerDown =
+    (key: TermKeyBarKey) => (e: PointerEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      onPressKey(key)
+    }
+
+  const handleModPointerDown =
+    (mod: "ctrl" | "alt") => (e: PointerEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      onToggleMod(mod)
+    }
+
+  // Same handler for click — onPointerDown above already fires the action, so a
+  // click after touchend would re-fire and double the byte. Suppress it.
+  const swallowClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+  }
+
+  return (
+    <div
+      role="toolbar"
+      aria-label={t("label")}
+      className="flex shrink-0 flex-col gap-1.5 border-t pt-1.5 select-none"
+    >
+      <div className="flex gap-1.5">
+        <KeyBtn
+          label={t("esc")}
+          onPointerDown={handlePointerDown("esc")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("slash")}
+          onPointerDown={handlePointerDown("slash")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("dash")}
+          onPointerDown={handlePointerDown("dash")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("home")}
+          onPointerDown={handlePointerDown("home")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("up")}
+          onPointerDown={handlePointerDown("up")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("end")}
+          onPointerDown={handlePointerDown("end")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("pgup")}
+          onPointerDown={handlePointerDown("pgup")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+      </div>
+      <div className="flex gap-1.5">
+        <KeyBtn
+          label={t("tab")}
+          onPointerDown={handlePointerDown("tab")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("ctrl")}
+          active={mods.ctrl}
+          onPointerDown={handleModPointerDown("ctrl")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("alt")}
+          active={mods.alt}
+          onPointerDown={handleModPointerDown("alt")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("left")}
+          onPointerDown={handlePointerDown("left")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("down")}
+          onPointerDown={handlePointerDown("down")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("right")}
+          onPointerDown={handlePointerDown("right")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+        <KeyBtn
+          label={t("pgdn")}
+          onPointerDown={handlePointerDown("pgdn")}
+          onClick={swallowClick}
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface KeyBtnProps {
+  label: string
+  active?: boolean
+  disabled?: boolean
+  onPointerDown: (e: PointerEvent<HTMLButtonElement>) => void
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void
+}
+
+/**
+ * 键栏单键：
+ *   · `flex-1 min-w-0`：等宽均分剩余空间，超长 label 截断。
+ *   · `active`：CTRL/ALT 闩锁 armed 高亮（accent 背景）。
+ *   · `tabIndex={-1}`：跳过 Tab 焦点环（虚拟键栏不该拦截方向键导航）。
+ */
+function KeyBtn({
+  label,
+  active = false,
+  disabled = false,
+  onPointerDown,
+  onClick,
+}: KeyBtnProps) {
+  return (
+    <Button
+      type="button"
+      tabIndex={-1}
+      variant="outline"
+      size="sm"
+      disabled={disabled}
+      onPointerDown={onPointerDown}
+      onClick={onClick}
+      className={cn(
+        "min-w-0 flex-1 px-1 text-xs font-normal touch-manipulation",
+        "[-webkit-tap-highlight-color:transparent] [transition:transform_0.12s,background-color_0.12s]",
+        "active:scale-95",
+        active && "bg-primary text-primary-foreground border-primary"
+      )}
+    >
+      {label}
+    </Button>
+  )
+}

--- a/src/components/terminal/terminal-panel.test.tsx
+++ b/src/components/terminal/terminal-panel.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TerminalPanel } from "./terminal-panel"
+
+// The panel only decides *whether* the mobile key bar is on; the tab bar and
+// the xterm host are stubbed so this stays a test of that decision (and of the
+// collapse state it persists), not of xterm.
+vi.mock("./terminal-tab-bar", () => ({
+  TerminalTabBar: ({
+    showKeybarToggle,
+    keybarCollapsed,
+    onToggleKeybar,
+  }: {
+    showKeybarToggle?: boolean
+    keybarCollapsed?: boolean
+    onToggleKeybar?: () => void
+  }) => (
+    <div>
+      <span data-testid="toggle-shown">{String(showKeybarToggle)}</span>
+      <span data-testid="collapsed">{String(keybarCollapsed)}</span>
+      <button data-testid="toggle" onClick={onToggleKeybar}>
+        toggle
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock("./terminal-view", () => ({
+  TerminalView: ({
+    terminalId,
+    keybarVisible,
+  }: {
+    terminalId: string
+    keybarVisible?: boolean
+  }) => (
+    <div
+      data-testid={`view-${terminalId}`}
+      data-keybar={String(keybarVisible)}
+    />
+  ),
+}))
+
+const terminalContext = {
+  isOpen: true,
+  tabs: [{ id: "t1", title: "1", workingDir: "/tmp" }],
+  activeTabId: "t1",
+  markTerminalExited: () => {},
+}
+
+vi.mock("@/contexts/terminal-context", () => ({
+  useTerminalContext: () => terminalContext,
+}))
+
+const STORAGE_KEY = "codeg:term-keybar"
+
+/** Drive `useIsMobile()` — it reads `window.matchMedia(query).matches`. */
+function setViewport(mobile: boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: mobile && query.includes("max-width"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  // Other suites render at the desktop breakpoint by default (test-setup.ts);
+  // don't leak a mobile matchMedia stub into them.
+  setViewport(false)
+  window.localStorage.clear()
+})
+
+describe("<TerminalPanel /> 键栏门控", () => {
+  it("桌面端不显示折叠开关，也不给 view 传 keybarVisible", () => {
+    setViewport(false)
+    render(<TerminalPanel />)
+    expect(screen.getByTestId("toggle-shown")).toHaveTextContent("false")
+    expect(screen.getByTestId("view-t1")).toHaveAttribute(
+      "data-keybar",
+      "false"
+    )
+  })
+
+  it("移动端默认展开键栏并显示折叠开关", () => {
+    setViewport(true)
+    render(<TerminalPanel />)
+    expect(screen.getByTestId("toggle-shown")).toHaveTextContent("true")
+    expect(screen.getByTestId("view-t1")).toHaveAttribute("data-keybar", "true")
+  })
+
+  it("折叠状态写入 localStorage，并在重新挂载后恢复", () => {
+    setViewport(true)
+    const { unmount } = render(<TerminalPanel />)
+
+    fireEvent.click(screen.getByTestId("toggle"))
+    expect(screen.getByTestId("view-t1")).toHaveAttribute(
+      "data-keybar",
+      "false"
+    )
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1")
+
+    unmount()
+    render(<TerminalPanel />)
+    expect(screen.getByTestId("collapsed")).toHaveTextContent("true")
+    expect(screen.getByTestId("view-t1")).toHaveAttribute(
+      "data-keybar",
+      "false"
+    )
+  })
+
+  it("折叠态是面板级的：桌面端折叠后切到移动端仍然折叠", () => {
+    setViewport(false)
+    const { unmount } = render(<TerminalPanel />)
+    fireEvent.click(screen.getByTestId("toggle"))
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1")
+    unmount()
+
+    setViewport(true)
+    render(<TerminalPanel />)
+    expect(screen.getByTestId("view-t1")).toHaveAttribute(
+      "data-keybar",
+      "false"
+    )
+  })
+})

--- a/src/components/terminal/terminal-panel.test.tsx
+++ b/src/components/terminal/terminal-panel.test.tsx
@@ -53,19 +53,32 @@ vi.mock("@/contexts/terminal-context", () => ({
 }))
 
 const STORAGE_KEY = "codeg:term-keybar"
+const DESKTOP_WIDTH = 1280
+/** The width the app's mobile shell starts at — `useIsMobile()` is max-width 767px. */
+const MOBILE_WIDTH = 767
 
-/** Drive `useIsMobile()` — it reads `window.matchMedia(query).matches`. */
-function setViewport(mobile: boolean) {
-  window.matchMedia = ((query: string) => ({
-    matches: mobile && query.includes("max-width"),
-    media: query,
-    onchange: null,
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    dispatchEvent: () => false,
-  })) as unknown as typeof window.matchMedia
+const realMatchMedia = window.matchMedia
+
+/**
+ * Drive `useIsMobile()` at a real viewport width by evaluating the
+ * `(max-width: Npx)` query against `width`, rather than hard-coding a boolean.
+ * The panel used to ask for 768px while the workspace shell asks for 767px, so
+ * the exact boundary is the thing worth asserting.
+ */
+function setViewportWidth(width: number) {
+  window.matchMedia = ((query: string) => {
+    const max = /\(max-width:\s*(\d+)px\)/.exec(query)
+    return {
+      matches: max ? width <= Number(max[1]) : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }
+  }) as unknown as typeof window.matchMedia
 }
 
 beforeEach(() => {
@@ -74,14 +87,14 @@ beforeEach(() => {
 
 afterEach(() => {
   // Other suites render at the desktop breakpoint by default (test-setup.ts);
-  // don't leak a mobile matchMedia stub into them.
-  setViewport(false)
+  // put the original stub back rather than leaving ours behind.
+  window.matchMedia = realMatchMedia
   window.localStorage.clear()
 })
 
 describe("<TerminalPanel /> 键栏门控", () => {
   it("桌面端不显示折叠开关，也不给 view 传 keybarVisible", () => {
-    setViewport(false)
+    setViewportWidth(DESKTOP_WIDTH)
     render(<TerminalPanel />)
     expect(screen.getByTestId("toggle-shown")).toHaveTextContent("false")
     expect(screen.getByTestId("view-t1")).toHaveAttribute(
@@ -91,14 +104,24 @@ describe("<TerminalPanel /> 键栏门控", () => {
   })
 
   it("移动端默认展开键栏并显示折叠开关", () => {
-    setViewport(true)
+    setViewportWidth(MOBILE_WIDTH)
     render(<TerminalPanel />)
     expect(screen.getByTestId("toggle-shown")).toHaveTextContent("true")
     expect(screen.getByTestId("view-t1")).toHaveAttribute("data-keybar", "true")
   })
 
+  it("断点与工作区外壳一致：768px 仍是桌面态，不冒出键栏", () => {
+    setViewportWidth(768)
+    render(<TerminalPanel />)
+    expect(screen.getByTestId("toggle-shown")).toHaveTextContent("false")
+    expect(screen.getByTestId("view-t1")).toHaveAttribute(
+      "data-keybar",
+      "false"
+    )
+  })
+
   it("折叠状态写入 localStorage，并在重新挂载后恢复", () => {
-    setViewport(true)
+    setViewportWidth(MOBILE_WIDTH)
     const { unmount } = render(<TerminalPanel />)
 
     fireEvent.click(screen.getByTestId("toggle"))
@@ -118,13 +141,13 @@ describe("<TerminalPanel /> 键栏门控", () => {
   })
 
   it("折叠态是面板级的：桌面端折叠后切到移动端仍然折叠", () => {
-    setViewport(false)
+    setViewportWidth(DESKTOP_WIDTH)
     const { unmount } = render(<TerminalPanel />)
     fireEvent.click(screen.getByTestId("toggle"))
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("1")
     unmount()
 
-    setViewport(true)
+    setViewportWidth(MOBILE_WIDTH)
     render(<TerminalPanel />)
     expect(screen.getByTestId("view-t1")).toHaveAttribute(
       "data-keybar",

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -1,18 +1,66 @@
 "use client"
 
+import { useCallback, useEffect, useState } from "react"
 import { useTerminalContext } from "@/contexts/terminal-context"
+import { useMediaQuery } from "@/hooks/use-media-query"
 import { TerminalTabBar } from "./terminal-tab-bar"
 import { TerminalView } from "./terminal-view"
 
+const KEYBAR_COLLAPSED_STORAGE_KEY = "codeg:term-keybar"
+const MOBILE_BREAKPOINT = "(max-width: 768px)"
+
+/**
+ * 终端面板：顶栏（tab + 折叠键栏开关）+ 所有挂载的 xterm。
+ *
+ * 移动端键栏的可见性在面板层决定：
+ *   · `useMediaQuery` 监听窗口宽度；
+ *   · 折叠态持久化到 localStorage，避免多个终端 tab 各自记一份导致切 tab
+ *     后展开/折叠不一致（与 pios 同样的踩坑修复）。
+ */
 export function TerminalPanel() {
   const { isOpen, tabs, activeTabId, markTerminalExited } = useTerminalContext()
+  const isMobile = useMediaQuery(MOBILE_BREAKPOINT)
+
+  const [keybarCollapsed, setKeybarCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false
+    try {
+      return window.localStorage.getItem(KEYBAR_COLLAPSED_STORAGE_KEY) === "1"
+    } catch {
+      return false
+    }
+  })
+
+  // SSR / 初次客户端渲染时 window.matchMedia 默认 matches=false（test-setup.ts
+  // 的 polyfill），桌面态 hydration 一致后 useMediaQuery 才返回真实值。
+  // localStorage 在 SSR 也是 undefined，所以初次 client render 与 SSR 都
+  // 是「未折叠」——只有用户主动折叠过才改。
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        KEYBAR_COLLAPSED_STORAGE_KEY,
+        keybarCollapsed ? "1" : "0"
+      )
+    } catch {
+      // best effort（隐私模式 / 配额超限时静默放弃）
+    }
+  }, [keybarCollapsed])
+
+  const toggleKeybar = useCallback(() => {
+    setKeybarCollapsed((prev) => !prev)
+  }, [])
+
+  const keybarVisible = isMobile && !keybarCollapsed
 
   return (
     <section
       data-terminal-panel-region="true"
       className="flex h-full min-h-0 flex-col ws-surface"
     >
-      <TerminalTabBar />
+      <TerminalTabBar
+        showKeybarToggle={isMobile}
+        keybarCollapsed={keybarCollapsed}
+        onToggleKeybar={toggleKeybar}
+      />
       <div className="relative flex-1 min-h-0 overflow-hidden">
         {tabs.map((tab) => (
           <TerminalView
@@ -23,6 +71,7 @@ export function TerminalPanel() {
             initialCommand={tab.initialCommand}
             isActive={tab.id === activeTabId}
             isVisible={isOpen}
+            keybarVisible={keybarVisible}
             onProcessExited={markTerminalExited}
           />
         ))}

--- a/src/components/terminal/terminal-panel.tsx
+++ b/src/components/terminal/terminal-panel.tsx
@@ -2,24 +2,24 @@
 
 import { useCallback, useEffect, useState } from "react"
 import { useTerminalContext } from "@/contexts/terminal-context"
-import { useMediaQuery } from "@/hooks/use-media-query"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { TerminalTabBar } from "./terminal-tab-bar"
 import { TerminalView } from "./terminal-view"
 
 const KEYBAR_COLLAPSED_STORAGE_KEY = "codeg:term-keybar"
-const MOBILE_BREAKPOINT = "(max-width: 768px)"
 
 /**
  * 终端面板：顶栏（tab + 折叠键栏开关）+ 所有挂载的 xterm。
  *
  * 移动端键栏的可见性在面板层决定：
- *   · `useMediaQuery` 监听窗口宽度；
+ *   · `useIsMobile()` —— 必须与 workspace layout 挑选移动端外壳用的是同一个
+ *     判据，否则会在断点边界上出现「桌面外壳里冒出移动端键栏」；
  *   · 折叠态持久化到 localStorage，避免多个终端 tab 各自记一份导致切 tab
- *     后展开/折叠不一致（与 pios 同样的踩坑修复）。
+ *     后展开/折叠不一致。
  */
 export function TerminalPanel() {
   const { isOpen, tabs, activeTabId, markTerminalExited } = useTerminalContext()
-  const isMobile = useMediaQuery(MOBILE_BREAKPOINT)
+  const isMobile = useIsMobile()
 
   const [keybarCollapsed, setKeybarCollapsed] = useState(() => {
     if (typeof window === "undefined") return false

--- a/src/components/terminal/terminal-tab-bar.tsx
+++ b/src/components/terminal/terminal-tab-bar.tsx
@@ -26,7 +26,20 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-export function TerminalTabBar() {
+interface TerminalTabBarProps {
+  /** 移动端折叠/展开键栏的开关。仅 isMobile 时父级才传 true。 */
+  showKeybarToggle?: boolean
+  /** 当前是否已折叠（驱动 ⌨ 按钮的 active 高亮）。 */
+  keybarCollapsed?: boolean
+  /** 点击 ⌨ 按钮的回调。 */
+  onToggleKeybar?: () => void
+}
+
+export function TerminalTabBar({
+  showKeybarToggle = false,
+  keybarCollapsed = false,
+  onToggleKeybar,
+}: TerminalTabBarProps) {
   const t = useTranslations("Folder.terminal")
   const ime = useImeGuard()
   const { shortcuts } = useShortcutSettings()
@@ -156,6 +169,28 @@ export function TerminalTabBar() {
           )}
         </Tooltip>
       </TooltipProvider>
+      {showKeybarToggle && onToggleKeybar && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={`h-6 w-6 shrink-0 ${keybarCollapsed ? "" : "text-primary"}`}
+                onClick={onToggleKeybar}
+                title={keybarCollapsed ? t("keybar.show") : t("keybar.hide")}
+              >
+                <span className="text-[14px] leading-none" aria-hidden>
+                  ⌨
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {keybarCollapsed ? t("keybar.show") : t("keybar.hide")}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <Button
         variant="ghost"
         size="icon"

--- a/src/components/terminal/terminal-tab-bar.tsx
+++ b/src/components/terminal/terminal-tab-bar.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, useRef, useState } from "react"
-import { Minus, Plus, X } from "lucide-react"
+import { Keyboard, Minus, Plus, X } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useActiveFolder } from "@/contexts/active-folder-context"
 import { useAppWorkspaceStore } from "@/stores/app-workspace-store"
@@ -29,9 +29,9 @@ import {
 interface TerminalTabBarProps {
   /** 移动端折叠/展开键栏的开关。仅 isMobile 时父级才传 true。 */
   showKeybarToggle?: boolean
-  /** 当前是否已折叠（驱动 ⌨ 按钮的 active 高亮）。 */
+  /** 当前是否已折叠（驱动键盘按钮的 active 高亮）。 */
   keybarCollapsed?: boolean
-  /** 点击 ⌨ 按钮的回调。 */
+  /** 点击键盘按钮的回调。 */
   onToggleKeybar?: () => void
 }
 
@@ -178,11 +178,12 @@ export function TerminalTabBar({
                 size="icon"
                 className={`h-6 w-6 shrink-0 ${keybarCollapsed ? "" : "text-primary"}`}
                 onClick={onToggleKeybar}
-                title={keybarCollapsed ? t("keybar.show") : t("keybar.hide")}
+                aria-pressed={!keybarCollapsed}
+                aria-label={
+                  keybarCollapsed ? t("keybar.show") : t("keybar.hide")
+                }
               >
-                <span className="text-[14px] leading-none" aria-hidden>
-                  ⌨
-                </span>
+                <Keyboard className="h-3 w-3" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="top">

--- a/src/components/terminal/terminal-view.tsx
+++ b/src/components/terminal/terminal-view.tsx
@@ -142,10 +142,16 @@ export function TerminalView({
     termRef.current?.focus()
   }
 
-  // 失活时复位闩锁：避免切走再切回后第一下输入被意外包装成 Ctrl/Alt。
+  // 键栏收敛三个条件：移动端命中 + 父级未折叠（都由 keybarVisible 带下来）+
+  // 当前 tab 是活动 tab（否则隐藏 tab 上挂着的死按钮会浪费 DOM 与焦点环）。
+  const showKeybar = keybarVisible && isActive && isVisible
+
+  // 键栏一旦不可见就复位闩锁。armed 状态只由键栏按钮高亮呈现，收起键栏（切走
+  // tab、收起面板、折叠键栏）后闩锁仍然生效的话，下一个软键盘字符会被无声地
+  // 包装成控制码，而屏幕上没有任何东西提示它 armed 过。
   useEffect(() => {
-    if (!isActive) setMods({ ctrl: false, alt: false })
-  }, [isActive])
+    if (!showKeybar) setMods({ ctrl: false, alt: false })
+  }, [showKeybar])
 
   // ---- 软键盘弹起跟随 ----
   // 键盘打开时 visualViewport 被压缩：算出底部被遮住的像素数 kbdLift，
@@ -489,10 +495,6 @@ export function TerminalView({
       disableTerminalLigatures(ligaturesAddonRef)
     }
   }, [terminalLigatures])
-
-  // 键栏收敛三个条件：移动端命中 + 父级未折叠（都由 keybarVisible 带下来）+
-  // 当前 tab 是活动 tab（否则隐藏 tab 上挂着的死按钮会浪费 DOM 与焦点环）。
-  const showKeybar = keybarVisible && isActive && isVisible
 
   return (
     <div

--- a/src/components/terminal/terminal-view.tsx
+++ b/src/components/terminal/terminal-view.tsx
@@ -73,8 +73,8 @@ interface TerminalViewProps {
   isActive: boolean
   isVisible: boolean
   /**
-   * 移动端虚拟键栏可见性。父级基于 `useMediaQuery("(max-width: 768px)")` 判定
-   * 是否折叠；桌面端永远为 false。
+   * 移动端虚拟键栏可见性。父级基于 `useIsMobile()` + 折叠开关判定；桌面端
+   * 永远为 false。
    */
   keybarVisible?: boolean
   onProcessExited?: (terminalId: string) => void
@@ -132,7 +132,11 @@ export function TerminalView({
 
   const pressKey = (key: TermKeyBarKey) => {
     const cur = modsRef.current
-    const data = termKeySeq(key, cur)
+    // DECCKM：应用光标键模式下方向键/Home/End 必须发 ESC O X，否则 vim/htop
+    // 之类按 terminfo 匹配的程序会把 ESC [ A 拆成三个键。
+    const appCursorKeys =
+      termRef.current?.modes.applicationCursorKeysMode ?? false
+    const data = termKeySeq(key, cur, appCursorKeys)
     if (cur.ctrl || cur.alt) setMods({ ctrl: false, alt: false }) // 闩锁被消费
     writeQueueRef.current?.enqueue(data)
     termRef.current?.focus()
@@ -147,7 +151,7 @@ export function TerminalView({
   // 键盘打开时 visualViewport 被压缩：算出底部被遮住的像素数 kbdLift，
   // 用 max-height 钳制 xterm + 键栏所在的 flex 容器 —— 键栏作为最后一个
   // flex 子项自然抬到键盘上方；xterm 随容器变小，原有 ResizeObserver 自动
-  // refit + 发 terminal_resize（与 pios 的 drawer 缩高 + fit 同语义）。
+  // refit + 发 terminal_resize。
   const [kbdLift, setKbdLift] = useState(0)
   useEffect(() => {
     if (!keybarVisible) {
@@ -486,6 +490,10 @@ export function TerminalView({
     }
   }, [terminalLigatures])
 
+  // 键栏收敛三个条件：移动端命中 + 父级未折叠（都由 keybarVisible 带下来）+
+  // 当前 tab 是活动 tab（否则隐藏 tab 上挂着的死按钮会浪费 DOM 与焦点环）。
+  const showKeybar = keybarVisible && isActive && isVisible
+
   return (
     <div
       className="absolute inset-0 h-full w-full p-2"
@@ -496,31 +504,32 @@ export function TerminalView({
       aria-hidden={!isActive}
     >
       {/* xterm + 键栏所在的 flex 列：kbdLift 收缩外层高度，让键栏抬到软键盘上方。
-          keybarVisible 仅移动端为真，桌面端 TermKeybar 内部不渲染。
-          showKeybar 收敛三个条件：移动端命中 + 父级未折叠 + 当前 tab 是活动 tab
-          （否则隐藏 tab 上挂着的死按钮会浪费 DOM 与焦点环）。 */}
-      {(() => {
-        const showKeybar = keybarVisible && isActive && isVisible
-        return (
-          <div
-            className="flex h-full w-full min-h-0 flex-col gap-1"
-            style={
-              showKeybar && kbdLift > 0
-                ? { maxHeight: `calc(100% - ${kbdLift}px)` }
-                : undefined
-            }
-          >
-            <div ref={containerRef} className="min-h-0 flex-1" />
-            {showKeybar && (
-              <TermKeybar
-                mods={modsUi}
-                onToggleMod={toggleMod}
-                onPressKey={pressKey}
-              />
-            )}
-          </div>
-        )
-      })()}
+          键盘收起时改让底部安全区（刘海屏 home indicator）——移动端终端走的是
+          Drawer，portal 到 body，拿不到外壳那层 pb-[env(safe-area-inset-bottom)]，
+          不减这一块最后一行按钮就压在 home indicator 上。键盘弹起时 home
+          indicator 本来就被键盘盖住，再减一次只会多出一条空隙。 */}
+      <div
+        className="flex h-full w-full min-h-0 flex-col gap-1"
+        style={
+          showKeybar
+            ? {
+                maxHeight:
+                  kbdLift > 0
+                    ? `calc(100% - ${kbdLift}px)`
+                    : "calc(100% - env(safe-area-inset-bottom))",
+              }
+            : undefined
+        }
+      >
+        <div ref={containerRef} className="min-h-0 flex-1" />
+        {showKeybar && (
+          <TermKeybar
+            mods={modsUi}
+            onToggleMod={toggleMod}
+            onPressKey={pressKey}
+          />
+        )}
+      </div>
       {loading && isActive && (
         <div className="absolute inset-0 flex items-center justify-center bg-background/80">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/src/components/terminal/terminal-view.tsx
+++ b/src/components/terminal/terminal-view.tsx
@@ -8,12 +8,20 @@ import {
   terminalResize,
   terminalKill,
 } from "@/lib/api"
-import { createWriteQueue } from "@/lib/terminal/write-queue"
+import { createWriteQueue, type WriteQueue } from "@/lib/terminal/write-queue"
 import { getTerminalTheme } from "@/lib/terminal/theme"
 import {
   copyTerminalSelection,
   isTerminalCopyShortcut,
 } from "@/lib/terminal/shortcuts"
+import {
+  applyTermMods,
+  kbdLiftPx,
+  termKeySeq,
+  type TermKeyBarKey,
+  type TermMods,
+} from "@/lib/terminal/keybar"
+import { TermKeybar } from "@/components/terminal/term-keybar"
 import { useZoomLevel, useTerminalFont } from "@/hooks/use-appearance"
 import { detectPlatform } from "@/hooks/use-platform"
 import type { TerminalEvent } from "@/lib/types"
@@ -64,6 +72,11 @@ interface TerminalViewProps {
   initialCommand?: string
   isActive: boolean
   isVisible: boolean
+  /**
+   * 移动端虚拟键栏可见性。父级基于 `useMediaQuery("(max-width: 768px)")` 判定
+   * 是否折叠；桌面端永远为 false。
+   */
+  keybarVisible?: boolean
   onProcessExited?: (terminalId: string) => void
 }
 
@@ -74,6 +87,7 @@ export function TerminalView({
   initialCommand,
   isActive,
   isVisible,
+  keybarVisible = false,
   onProcessExited,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -92,6 +106,80 @@ export function TerminalView({
   const terminalLigaturesRef = useRef(terminalLigatures)
   const ligaturesAddonRef = useRef<DisposableAddon | null>(null)
   const [loading, setLoading] = useState(true)
+
+  // ---- 移动端虚拟键栏（CTRL/ALT 闩锁 + 软键盘跟随）----
+  // modsRef 是编码真值（xterm.onData 闭包里读它不会过期）；modsUi 只驱动按钮
+  // 高亮。两者经 setMods() 同步，避免 setMods 引用漂移。
+  const [modsUi, setModsUi] = useState<TermMods>({ ctrl: false, alt: false })
+  const modsRef = useRef<TermMods>({ ctrl: false, alt: false })
+  const setMods = (next: TermMods) => {
+    modsRef.current = next
+    setModsUi(next)
+  }
+  // writeQueue 在 init() 里创建，键栏按键也必须走这条队列——否则与软键盘
+  // onData 抢着调 terminalWrite 会让顺序变成不可预期的乱序（FIFO 不再成立）。
+  const writeQueueRef = useRef<WriteQueue | null>(null)
+
+  const toggleMod = (m: "ctrl" | "alt") => {
+    const cur = modsRef.current
+    setMods(
+      m === "ctrl"
+        ? { ctrl: !cur.ctrl, alt: false }
+        : { ctrl: false, alt: !cur.alt }
+    )
+    termRef.current?.focus()
+  }
+
+  const pressKey = (key: TermKeyBarKey) => {
+    const cur = modsRef.current
+    const data = termKeySeq(key, cur)
+    if (cur.ctrl || cur.alt) setMods({ ctrl: false, alt: false }) // 闩锁被消费
+    writeQueueRef.current?.enqueue(data)
+    termRef.current?.focus()
+  }
+
+  // 失活时复位闩锁：避免切走再切回后第一下输入被意外包装成 Ctrl/Alt。
+  useEffect(() => {
+    if (!isActive) setMods({ ctrl: false, alt: false })
+  }, [isActive])
+
+  // ---- 软键盘弹起跟随 ----
+  // 键盘打开时 visualViewport 被压缩：算出底部被遮住的像素数 kbdLift，
+  // 用 max-height 钳制 xterm + 键栏所在的 flex 容器 —— 键栏作为最后一个
+  // flex 子项自然抬到键盘上方；xterm 随容器变小，原有 ResizeObserver 自动
+  // refit + 发 terminal_resize（与 pios 的 drawer 缩高 + fit 同语义）。
+  const [kbdLift, setKbdLift] = useState(0)
+  useEffect(() => {
+    if (!keybarVisible) {
+      setKbdLift(0)
+      return
+    }
+    const vv = window.visualViewport
+    if (!vv) return
+    let raf = 0
+    let last = -1
+    const update = () => {
+      raf = 0
+      const lift = kbdLiftPx(window.innerHeight, vv.height, vv.offsetTop)
+      if (lift !== last) {
+        last = lift
+        setKbdLift(lift)
+      }
+    }
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(update)
+    }
+    vv.addEventListener("resize", schedule)
+    vv.addEventListener("scroll", schedule)
+    window.addEventListener("resize", schedule)
+    update()
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      vv.removeEventListener("resize", schedule)
+      vv.removeEventListener("scroll", schedule)
+      window.removeEventListener("resize", schedule)
+    }
+  }, [keybarVisible])
 
   useEffect(() => {
     isActiveRef.current = isActive
@@ -154,6 +242,8 @@ export function TerminalView({
       // duplicate already-delivered bytes, worse than a drop in a shell. See
       // lib/terminal/write-queue.ts.
       const writeQueue = createWriteQueue((d) => terminalWrite(terminalId, d))
+      // 暴露给键栏按键——必须走这条队列，否则与软键盘输入抢着发会乱序。
+      writeQueueRef.current = writeQueue
 
       // Shell line-editing shortcuts. Sends readline/zle bindings so they
       // work regardless of terminfo.
@@ -216,7 +306,15 @@ export function TerminalView({
         // Some apps toggle focus reporting; don't leak focus in/out sequences
         // into the shell prompt when tabs are switched.
         if (data === "\x1b[I" || data === "\x1b[O") return
-        writeQueue.enqueue(data)
+        // 虚拟键栏闩锁 armed 时包装软键盘输入（CTRL+字母→控制码、ALT→ESC 前缀）
+        const cur = modsRef.current
+        if (cur.ctrl || cur.alt) {
+          const { out, consumed } = applyTermMods(data, cur)
+          if (consumed) setMods({ ctrl: false, alt: false })
+          writeQueue.enqueue(out)
+        } else {
+          writeQueue.enqueue(data)
+        }
       })
 
       // Debounced resize — avoid flooding IPC during drag
@@ -311,6 +409,7 @@ export function TerminalView({
 
       cleanup = () => {
         writeQueue.dispose()
+        writeQueueRef.current = null
         if (resizeTimer) clearTimeout(resizeTimer)
         if (fitTimer) clearTimeout(fitTimer)
         themeObserver.disconnect()
@@ -396,7 +495,32 @@ export function TerminalView({
       }}
       aria-hidden={!isActive}
     >
-      <div ref={containerRef} className="h-full w-full" />
+      {/* xterm + 键栏所在的 flex 列：kbdLift 收缩外层高度，让键栏抬到软键盘上方。
+          keybarVisible 仅移动端为真，桌面端 TermKeybar 内部不渲染。
+          showKeybar 收敛三个条件：移动端命中 + 父级未折叠 + 当前 tab 是活动 tab
+          （否则隐藏 tab 上挂着的死按钮会浪费 DOM 与焦点环）。 */}
+      {(() => {
+        const showKeybar = keybarVisible && isActive && isVisible
+        return (
+          <div
+            className="flex h-full w-full min-h-0 flex-col gap-1"
+            style={
+              showKeybar && kbdLift > 0
+                ? { maxHeight: `calc(100% - ${kbdLift}px)` }
+                : undefined
+            }
+          >
+            <div ref={containerRef} className="min-h-0 flex-1" />
+            {showKeybar && (
+              <TermKeybar
+                mods={modsUi}
+                onToggleMod={toggleMod}
+                onPressKey={pressKey}
+              />
+            )}
+          </div>
+        )
+      })()}
       {loading && isActive && (
         <div className="absolute inset-0 flex items-center justify-center bg-background/80">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "إغلاق البقية",
       "closeAll": "إغلاق الكل",
       "hideTerminal": "إخفاء الطرفية ({shortcut})",
-      "openFolderFirst": "افتح مجلدا أولا"
+      "openFolderFirst": "افتح مجلدا أولا",
+      "keybar": {
+        "label": "مفاتيح الطرفية الافتراضية",
+        "show": "إظهار المفاتيح الافتراضية",
+        "hide": "إخفاء المفاتيح الافتراضية",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "فتح مجلد",

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "Andere schließen",
       "closeAll": "Alle schließen",
       "hideTerminal": "Terminal ausblenden ({shortcut})",
-      "openFolderFirst": "Öffnen Sie zuerst einen Ordner"
+      "openFolderFirst": "Öffnen Sie zuerst einen Ordner",
+      "keybar": {
+        "label": "Virtuelle Terminaltasten",
+        "show": "Virtuelle Tasten anzeigen",
+        "hide": "Virtuelle Tasten ausblenden",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "Ordner öffnen",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "Close Others",
       "closeAll": "Close All",
       "hideTerminal": "Hide Terminal ({shortcut})",
-      "openFolderFirst": "Open a folder first"
+      "openFolderFirst": "Open a folder first",
+      "keybar": {
+        "label": "Terminal virtual keys",
+        "show": "Show virtual keys",
+        "hide": "Hide virtual keys",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "Open Folder",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "Cerrar otros",
       "closeAll": "Cerrar todo",
       "hideTerminal": "Ocultar terminal ({shortcut})",
-      "openFolderFirst": "Abre primero una carpeta"
+      "openFolderFirst": "Abre primero una carpeta",
+      "keybar": {
+        "label": "Teclas virtuales del terminal",
+        "show": "Mostrar teclas virtuales",
+        "hide": "Ocultar teclas virtuales",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "Abrir carpeta",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "Fermer les autres",
       "closeAll": "Tout fermer",
       "hideTerminal": "Masquer le terminal ({shortcut})",
-      "openFolderFirst": "Ouvrez d'abord un dossier"
+      "openFolderFirst": "Ouvrez d'abord un dossier",
+      "keybar": {
+        "label": "Touches virtuelles du terminal",
+        "show": "Afficher les touches virtuelles",
+        "hide": "Masquer les touches virtuelles",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "Ouvrir un dossier",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "他を閉じる",
       "closeAll": "すべて閉じる",
       "hideTerminal": "ターミナルを隠す ({shortcut})",
-      "openFolderFirst": "先にフォルダを開いてください"
+      "openFolderFirst": "先にフォルダを開いてください",
+      "keybar": {
+        "label": "仮想ターミナルキー",
+        "show": "仮想キーを表示",
+        "hide": "仮想キーを隠す",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "フォルダーを開く",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "다른 항목 닫기",
       "closeAll": "모두 닫기",
       "hideTerminal": "터미널 숨기기 ({shortcut})",
-      "openFolderFirst": "먼저 폴더를 여세요"
+      "openFolderFirst": "먼저 폴더를 여세요",
+      "keybar": {
+        "label": "터미널 가상 키",
+        "show": "가상 키 표시",
+        "hide": "가상 키 숨기기",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "폴더 열기",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "Fechar outros",
       "closeAll": "Fechar tudo",
       "hideTerminal": "Ocultar terminal ({shortcut})",
-      "openFolderFirst": "Abra primeiro uma pasta"
+      "openFolderFirst": "Abra primeiro uma pasta",
+      "keybar": {
+        "label": "Teclas virtuais do terminal",
+        "show": "Mostrar teclas virtuais",
+        "hide": "Ocultar teclas virtuais",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "Abrir pasta",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "关闭其它",
       "closeAll": "关闭所有",
       "hideTerminal": "隐藏终端（{shortcut}）",
-      "openFolderFirst": "请先打开一个文件夹"
+      "openFolderFirst": "请先打开一个文件夹",
+      "keybar": {
+        "label": "终端虚拟键",
+        "show": "显示虚拟键",
+        "hide": "隐藏虚拟键",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "打开文件夹",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -2063,7 +2063,7 @@
         "ctrl": "CTRL",
         "alt": "ALT",
         "slash": "/",
-        "dash": "—",
+        "dash": "-",
         "home": "HOME",
         "end": "END",
         "pgup": "PGUP",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -2053,7 +2053,26 @@
       "closeOthers": "關閉其它",
       "closeAll": "關閉所有",
       "hideTerminal": "隱藏終端（{shortcut}）",
-      "openFolderFirst": "請先開啟一個資料夾"
+      "openFolderFirst": "請先開啟一個資料夾",
+      "keybar": {
+        "label": "終端虛擬鍵",
+        "show": "顯示虛擬鍵",
+        "hide": "隱藏虛擬鍵",
+        "esc": "ESC",
+        "tab": "TAB",
+        "ctrl": "CTRL",
+        "alt": "ALT",
+        "slash": "/",
+        "dash": "—",
+        "home": "HOME",
+        "end": "END",
+        "pgup": "PGUP",
+        "pgdn": "PGDN",
+        "up": "↑",
+        "down": "↓",
+        "left": "←",
+        "right": "→"
+      }
     },
     "workspaceDialog": {
       "title": "開啟資料夾",

--- a/src/lib/terminal/keybar.test.ts
+++ b/src/lib/terminal/keybar.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  applyTermMods,
+  kbdLiftPx,
+  TERM_KEYBAR_SEQ,
+  termKeySeq,
+  type TermMods,
+} from "./keybar"
+
+const OFF: TermMods = { ctrl: false, alt: false }
+
+describe("termKeySeq 基础序列", () => {
+  it("无修饰符时返回原样转义序列", () => {
+    expect(termKeySeq("esc", OFF)).toBe("\x1b")
+    expect(termKeySeq("tab", OFF)).toBe("\t")
+    expect(termKeySeq("slash", OFF)).toBe("/")
+    expect(termKeySeq("dash", OFF)).toBe("-")
+    expect(termKeySeq("home", OFF)).toBe("\x1b[H")
+    expect(termKeySeq("end", OFF)).toBe("\x1b[F")
+    expect(termKeySeq("pgup", OFF)).toBe("\x1b[5~")
+    expect(termKeySeq("pgdn", OFF)).toBe("\x1b[6~")
+    expect(termKeySeq("up", OFF)).toBe("\x1b[A")
+    expect(termKeySeq("down", OFF)).toBe("\x1b[B")
+    expect(termKeySeq("left", OFF)).toBe("\x1b[D")
+    expect(termKeySeq("right", OFF)).toBe("\x1b[C")
+  })
+
+  it("序列表完整覆盖 12 个键", () => {
+    expect(Object.keys(TERM_KEYBAR_SEQ).sort()).toEqual(
+      [
+        "dash",
+        "down",
+        "end",
+        "esc",
+        "home",
+        "left",
+        "pgdn",
+        "pgup",
+        "right",
+        "slash",
+        "tab",
+        "up",
+      ].sort()
+    )
+  })
+})
+
+describe("termKeySeq 闩锁修饰", () => {
+  it("Ctrl+方向键 = ESC[1;5X", () => {
+    expect(termKeySeq("up", { ctrl: true, alt: false })).toBe("\x1b[1;5A")
+    expect(termKeySeq("down", { ctrl: true, alt: false })).toBe("\x1b[1;5B")
+    expect(termKeySeq("right", { ctrl: true, alt: false })).toBe("\x1b[1;5C")
+    expect(termKeySeq("left", { ctrl: true, alt: false })).toBe("\x1b[1;5D")
+  })
+
+  it("Alt+方向键 = ESC[1;3X；Ctrl+Alt = ESC[1;7X", () => {
+    expect(termKeySeq("left", { ctrl: false, alt: true })).toBe("\x1b[1;3D")
+    expect(termKeySeq("up", { ctrl: true, alt: true })).toBe("\x1b[1;7A")
+  })
+
+  it("Home/End 带修饰符走 CSI 1;<m>H/F", () => {
+    expect(termKeySeq("home", { ctrl: true, alt: false })).toBe("\x1b[1;5H")
+    expect(termKeySeq("end", { ctrl: false, alt: true })).toBe("\x1b[1;3F")
+  })
+
+  it("PgUp/PgDn 带修饰符走 ~ 族", () => {
+    expect(termKeySeq("pgup", { ctrl: true, alt: false })).toBe("\x1b[5;5~")
+    expect(termKeySeq("pgdn", { ctrl: false, alt: true })).toBe("\x1b[6;3~")
+    expect(termKeySeq("pgdn", { ctrl: true, alt: true })).toBe("\x1b[6;7~")
+  })
+
+  it("esc/tab/slash/dash 无通用 ctrl 形态：ctrl 原样、alt 走 meta 前缀", () => {
+    expect(termKeySeq("esc", { ctrl: true, alt: false })).toBe("\x1b")
+    expect(termKeySeq("slash", { ctrl: true, alt: false })).toBe("/")
+    expect(termKeySeq("dash", { ctrl: true, alt: false })).toBe("-")
+    expect(termKeySeq("tab", { ctrl: false, alt: true })).toBe("\x1b\t")
+    expect(termKeySeq("esc", { ctrl: false, alt: true })).toBe("\x1b\x1b")
+  })
+})
+
+describe("applyTermMods 软键盘闩锁包装", () => {
+  it("未 armed 时原样透传、不消费", () => {
+    const r = applyTermMods("abc", OFF)
+    expect(r.out).toBe("abc")
+    expect(r.consumed).toBe(false)
+  })
+
+  it("CTRL+小写字母 → 控制码（a→0x01 … z→0x1a）", () => {
+    expect(applyTermMods("c", { ctrl: true, alt: false }).out).toBe("\x03")
+    expect(applyTermMods("d", { ctrl: true, alt: false }).out).toBe("\x04")
+    expect(applyTermMods("l", { ctrl: true, alt: false }).out).toBe("\x0c")
+    expect(applyTermMods("z", { ctrl: true, alt: false }).out).toBe("\x1a")
+  })
+
+  it("CTRL+大写字母同样按字母处理", () => {
+    expect(applyTermMods("C", { ctrl: true, alt: false }).out).toBe("\x03")
+  })
+
+  it("CTRL 只包装首字符，其余保持原样（粘贴串）", () => {
+    expect(applyTermMods("abc", { ctrl: true, alt: false }).out).toBe("\x01bc")
+  })
+
+  it("CTRL+非字母原样透传（仍消费闩锁）", () => {
+    const r = applyTermMods("1", { ctrl: true, alt: false })
+    expect(r.out).toBe("1")
+    expect(r.consumed).toBe(true)
+  })
+
+  it("ALT+输入 → 前缀 ESC", () => {
+    const r = applyTermMods("b", { ctrl: false, alt: true })
+    expect(r.out).toBe("\x1bb")
+    expect(r.consumed).toBe(true)
+  })
+
+  it("空输入不消费闩锁", () => {
+    const r = applyTermMods("", { ctrl: true, alt: false })
+    expect(r.out).toBe("")
+    expect(r.consumed).toBe(false)
+  })
+})
+
+describe("kbdLiftPx 软键盘遮挡估算", () => {
+  it("键盘弹出：overlap = innerHeight - vv.height - offsetTop", () => {
+    // 844 屏，键盘 300px，无页面平移
+    expect(kbdLiftPx(844, 544, 0)).toBe(300)
+    // iOS 把页面上推（offsetTop>0）：遮挡减少相应的量
+    expect(kbdLiftPx(844, 544, 100)).toBe(200)
+  })
+
+  it("键盘收起：overlap ≈ 0 → 返回 0", () => {
+    expect(kbdLiftPx(844, 844, 0)).toBe(0)
+    expect(kbdLiftPx(844, 850, 0)).toBe(0) // 反向异常也夹到 0
+  })
+
+  it("小于 80px 的抖动（地址栏收起等）不算键盘，返回 0", () => {
+    expect(kbdLiftPx(844, 814, 0)).toBe(0)
+    expect(kbdLiftPx(844, 764, 0)).toBe(80) // 恰好 80px 达标
+  })
+
+  it("小数四舍五入", () => {
+    expect(kbdLiftPx(844.4, 514.2, 0.2)).toBe(330)
+  })
+})

--- a/src/lib/terminal/keybar.test.ts
+++ b/src/lib/terminal/keybar.test.ts
@@ -46,6 +46,35 @@ describe("termKeySeq 基础序列", () => {
   })
 })
 
+describe("termKeySeq 应用光标键模式（DECCKM）", () => {
+  it("DECCKM 开启：无修饰符的方向键/Home/End 走 SS3（ESC O X）", () => {
+    expect(termKeySeq("up", OFF, true)).toBe("\x1bOA")
+    expect(termKeySeq("down", OFF, true)).toBe("\x1bOB")
+    expect(termKeySeq("right", OFF, true)).toBe("\x1bOC")
+    expect(termKeySeq("left", OFF, true)).toBe("\x1bOD")
+    expect(termKeySeq("home", OFF, true)).toBe("\x1bOH")
+    expect(termKeySeq("end", OFF, true)).toBe("\x1bOF")
+  })
+
+  it("DECCKM 不影响非光标键", () => {
+    expect(termKeySeq("pgup", OFF, true)).toBe("\x1b[5~")
+    expect(termKeySeq("pgdn", OFF, true)).toBe("\x1b[6~")
+    expect(termKeySeq("esc", OFF, true)).toBe("\x1b")
+    expect(termKeySeq("tab", OFF, true)).toBe("\t")
+  })
+
+  it("带修饰符时 DECCKM 让位给 CSI 1;<m>X", () => {
+    expect(termKeySeq("up", { ctrl: true, alt: false }, true)).toBe("\x1b[1;5A")
+    expect(termKeySeq("home", { ctrl: false, alt: true }, true)).toBe(
+      "\x1b[1;3H"
+    )
+  })
+
+  it("默认参数保持 DECCKM 关闭的历史行为", () => {
+    expect(termKeySeq("up", OFF)).toBe(termKeySeq("up", OFF, false))
+  })
+})
+
 describe("termKeySeq 闩锁修饰", () => {
   it("Ctrl+方向键 = ESC[1;5X", () => {
     expect(termKeySeq("up", { ctrl: true, alt: false })).toBe("\x1b[1;5A")
@@ -101,10 +130,28 @@ describe("applyTermMods 软键盘闩锁包装", () => {
     expect(applyTermMods("abc", { ctrl: true, alt: false }).out).toBe("\x01bc")
   })
 
-  it("CTRL+非字母原样透传（仍消费闩锁）", () => {
+  it("CTRL+@A-Z[\\]^_ → 0x00–0x1f（Ctrl+[=ESC、Ctrl+\\=SIGQUIT、Ctrl+_=undo）", () => {
+    const ctrl = { ctrl: true, alt: false }
+    expect(applyTermMods("[", ctrl).out).toBe("\x1b")
+    expect(applyTermMods("\\", ctrl).out).toBe("\x1c")
+    expect(applyTermMods("]", ctrl).out).toBe("\x1d")
+    expect(applyTermMods("_", ctrl).out).toBe("\x1f")
+    expect(applyTermMods("@", ctrl).out).toBe("\x00")
+  })
+
+  it("CTRL+空格 → NUL；CTRL+? → DEL", () => {
+    expect(applyTermMods(" ", { ctrl: true, alt: false }).out).toBe("\x00")
+    expect(applyTermMods("?", { ctrl: true, alt: false }).out).toBe("\x7f")
+  })
+
+  it("CTRL+无控制码形态的字符原样透传（仍消费闩锁）", () => {
     const r = applyTermMods("1", { ctrl: true, alt: false })
     expect(r.out).toBe("1")
     expect(r.consumed).toBe(true)
+  })
+
+  it("CTRL+ALT 叠加 = meta + 控制码", () => {
+    expect(applyTermMods("a", { ctrl: true, alt: true }).out).toBe("\x1b\x01")
   })
 
   it("ALT+输入 → 前缀 ESC", () => {

--- a/src/lib/terminal/keybar.ts
+++ b/src/lib/terminal/keybar.ts
@@ -1,9 +1,14 @@
 /**
  * 终端虚拟键栏（移动端）纯函数：键栏按键 → PTY 字节序列 + CTRL/ALT 闩锁包装。
  *
- * 序列规则对齐服务端 terminals.ts 的 encodeTerminalKey：
- *   · 方向键/Home/End 带修饰符 → xterm 修饰序列 ESC[1;<m>X（Ctrl+↑=ESC[1;5A）
- *   · PgUp/PgDn 带修饰符      → ESC[5;<m>~ / ESC[6;<m>~
+ * 序列规则对齐 xterm.js 自己的键盘编码器（`evaluateKeyboardEvent`），因为渲染
+ * 端就是 xterm.js，硬件键盘与虚拟键栏必须发出同一串字节：
+ *   · 方向键/Home/End 带修饰符 → ESC[1;<m>X（Ctrl+↑=ESC[1;5A）
+ *   · 方向键/Home/End 无修饰符 → 受 DECCKM（应用光标键模式）影响：
+ *     开启时 ESC O X，关闭时 ESC [ X。vim/htop 这类 ncurses 程序会
+ *     `smkx` 打开 DECCKM，只按 terminfo 的 ESC O X 匹配；固定发 ESC [ X
+ *     会被解析成「ESC + [ + A」三个键。
+ *   · PgUp/PgDn 带修饰符      → ESC[5;<m>~ / ESC[6;<m>~（不受 DECCKM 影响）
  *   · 修饰参数 m = 1 + (alt?2:0) + (ctrl?4:0)
  *
  * 闩锁语义：CTRL/ALT 是一次性粘滞键——点一下 armed（按钮高亮，互斥），下一个
@@ -52,20 +57,35 @@ function modParam(mods: TermMods): number {
   return 1 + (mods.alt ? 2 : 0) + (mods.ctrl ? 4 : 0)
 }
 
-/** 键栏按键编码（不消费闩锁——由调用方在发送后复位）。 */
-export function termKeySeq(key: TermKeyBarKey, mods: TermMods): string {
+/** 光标键族（方向键 + Home/End）的 CSI/SS3 终结符。 */
+const CURSOR_KEY_FINALS: Partial<Record<TermKeyBarKey, string>> = {
+  up: "A",
+  down: "B",
+  right: "C",
+  left: "D",
+  home: "H",
+  end: "F",
+}
+
+/**
+ * 键栏按键编码（不消费闩锁——由调用方在发送后复位）。
+ *
+ * `appCursorKeys` 传当前终端的 DECCKM 状态（xterm.js:
+ * `term.modes.applicationCursorKeysMode`）——无修饰符的光标键要跟着它在
+ * ESC[X / ESC O X 之间切换，否则 vim/htop 等 ncurses 程序收不到方向键。
+ */
+export function termKeySeq(
+  key: TermKeyBarKey,
+  mods: TermMods,
+  appCursorKeys = false
+): string {
   const plain = TERM_KEYBAR_SEQ[key]
-  if (!mods.ctrl && !mods.alt) return plain
-  // CSI 1;<m>X 族：方向键 + Home/End
-  const finals: Partial<Record<TermKeyBarKey, string>> = {
-    up: "A",
-    down: "B",
-    right: "C",
-    left: "D",
-    home: "H",
-    end: "F",
+  if (!mods.ctrl && !mods.alt) {
+    const final = appCursorKeys ? CURSOR_KEY_FINALS[key] : undefined
+    return final ? `\x1bO${final}` : plain
   }
-  const final = finals[key]
+  // CSI 1;<m>X 族：方向键 + Home/End（带修饰符时 DECCKM 不参与）
+  const final = CURSOR_KEY_FINALS[key]
   if (final) return `\x1b[1;${modParam(mods)}${final}`
   // ~ 族：PgUp/PgDn
   if (key === "pgup") return `\x1b[5;${modParam(mods)}~`
@@ -73,6 +93,22 @@ export function termKeySeq(key: TermKeyBarKey, mods: TermMods): string {
   // esc/tab/slash/dash 没有通用 ctrl 形态：alt 仍走 meta 前缀，ctrl 原样
   if (mods.alt) return `\x1b${plain}`
   return plain
+}
+
+/**
+ * Ctrl+<字符> 的控制码映射，与 xterm.js 的键盘编码器一致：
+ *   · a–z (0x61–0x7a) → code-0x60（Ctrl+C=\x03 …）
+ *   · @A-Z[\]^_ (0x40–0x5f) → code-0x40（Ctrl+[=ESC、Ctrl+\=SIGQUIT、Ctrl+_=undo）
+ *   · 空格 → NUL（set-mark）、`?` → DEL
+ * 不在表内的字符（数字、CJK 等）没有控制码形态，原样返回 null。
+ */
+function ctrlCode(ch: string): string | null {
+  const code = ch.charCodeAt(0)
+  if (code >= 0x61 && code <= 0x7a) return String.fromCharCode(code - 0x60)
+  if (code >= 0x40 && code <= 0x5f) return String.fromCharCode(code - 0x40)
+  if (ch === " ") return "\x00"
+  if (ch === "?") return "\x7f"
+  return null
 }
 
 /**
@@ -89,13 +125,12 @@ export function applyTermMods(
   const { ctrl, alt } = mods
   let out = data
   if (ctrl) {
-    const code = data[0].toLowerCase().charCodeAt(0)
-    if (code >= 97 && code <= 122) {
-      out = String.fromCharCode(code - 96) + data.slice(1)
-    }
-  } else if (alt) {
-    out = `\x1b${data}`
+    const ctl = ctrlCode(data[0])
+    if (ctl !== null) out = ctl + data.slice(1)
   }
+  // ctrl 与 alt 叠加时是 meta+控制码（Ctrl+Alt+A = ESC \x01）。键栏当前把两者
+  // 做成互斥闩锁，走不到这条组合，但编码不该因此写成非此即彼。
+  if (alt) out = `\x1b${out}`
   return { out, consumed: true }
 }
 

--- a/src/lib/terminal/keybar.ts
+++ b/src/lib/terminal/keybar.ts
@@ -1,0 +1,114 @@
+/**
+ * 终端虚拟键栏（移动端）纯函数：键栏按键 → PTY 字节序列 + CTRL/ALT 闩锁包装。
+ *
+ * 序列规则对齐服务端 terminals.ts 的 encodeTerminalKey：
+ *   · 方向键/Home/End 带修饰符 → xterm 修饰序列 ESC[1;<m>X（Ctrl+↑=ESC[1;5A）
+ *   · PgUp/PgDn 带修饰符      → ESC[5;<m>~ / ESC[6;<m>~
+ *   · 修饰参数 m = 1 + (alt?2:0) + (ctrl?4:0)
+ *
+ * 闩锁语义：CTRL/ALT 是一次性粘滞键——点一下 armed（按钮高亮，互斥），下一个
+ * 输入（软键盘 onData 或键栏按键）被包装后自动弹起：
+ *   · CTRL + 软键盘字母 → 控制码（a→\x01 … z→\x1a，覆盖 Ctrl+C/D/L/R…）
+ *   · ALT  + 软键盘输入 → 前缀 ESC（meta）
+ */
+
+export type TermKeyBarKey =
+  | "esc"
+  | "tab"
+  | "slash"
+  | "dash"
+  | "home"
+  | "end"
+  | "pgup"
+  | "pgdn"
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+
+/** CTRL/ALT 闩锁状态（键栏按钮高亮与编码共用）。 */
+export interface TermMods {
+  ctrl: boolean
+  alt: boolean
+}
+
+/** 无修饰符时的基础序列。 */
+export const TERM_KEYBAR_SEQ: Record<TermKeyBarKey, string> = {
+  esc: "\x1b",
+  tab: "\t",
+  slash: "/",
+  dash: "-",
+  home: "\x1b[H",
+  end: "\x1b[F",
+  pgup: "\x1b[5~",
+  pgdn: "\x1b[6~",
+  up: "\x1b[A",
+  down: "\x1b[B",
+  left: "\x1b[D",
+  right: "\x1b[C",
+}
+
+function modParam(mods: TermMods): number {
+  return 1 + (mods.alt ? 2 : 0) + (mods.ctrl ? 4 : 0)
+}
+
+/** 键栏按键编码（不消费闩锁——由调用方在发送后复位）。 */
+export function termKeySeq(key: TermKeyBarKey, mods: TermMods): string {
+  const plain = TERM_KEYBAR_SEQ[key]
+  if (!mods.ctrl && !mods.alt) return plain
+  // CSI 1;<m>X 族：方向键 + Home/End
+  const finals: Partial<Record<TermKeyBarKey, string>> = {
+    up: "A",
+    down: "B",
+    right: "C",
+    left: "D",
+    home: "H",
+    end: "F",
+  }
+  const final = finals[key]
+  if (final) return `\x1b[1;${modParam(mods)}${final}`
+  // ~ 族：PgUp/PgDn
+  if (key === "pgup") return `\x1b[5;${modParam(mods)}~`
+  if (key === "pgdn") return `\x1b[6;${modParam(mods)}~`
+  // esc/tab/slash/dash 没有通用 ctrl 形态：alt 仍走 meta 前缀，ctrl 原样
+  if (mods.alt) return `\x1b${plain}`
+  return plain
+}
+
+/**
+ * 用闩锁包装一段软键盘输入。只处理首字符，返回要发送的字节与闩锁是否被消费。
+ * `consumed=true` 时调用方应复位 mods 状态。
+ */
+export function applyTermMods(
+  data: string,
+  mods: TermMods
+): { out: string; consumed: boolean } {
+  if (!data || (!mods.ctrl && !mods.alt)) {
+    return { out: data, consumed: false }
+  }
+  const { ctrl, alt } = mods
+  let out = data
+  if (ctrl) {
+    const code = data[0].toLowerCase().charCodeAt(0)
+    if (code >= 97 && code <= 122) {
+      out = String.fromCharCode(code - 96) + data.slice(1)
+    }
+  } else if (alt) {
+    out = `\x1b${data}`
+  }
+  return { out, consumed: true }
+}
+
+/**
+ * 软键盘遮挡估算：布局视口高 - 可视视口高 - 可视视口下移量 = 底部被键盘遮住的像素。
+ * overlap < minOpen（默认 80px）视为地址栏收起/缩放等抖动，返回 0。
+ */
+export function kbdLiftPx(
+  innerHeight: number,
+  vvHeight: number,
+  vvOffsetTop: number,
+  minOpen = 80
+): number {
+  const overlap = Math.max(0, Math.round(innerHeight - vvHeight - vvOffsetTop))
+  return overlap >= minOpen ? overlap : 0
+}


### PR DESCRIPTION
## What

Add an on-screen virtual key bar for the terminal panel so mobile users can send escape / tab / control / arrow / page keys without a hardware keyboard.

## Why

Without a physical keyboard, mobile terminal usage is essentially broken: no ESC to leave insert mode in vim, no Ctrl+C for SIGINT, no arrow keys for readline history. The mobile Drawer container plus a two-row button grid closes that gap.

## Design

- **Pure encoding** (`lib/terminal/keybar.ts`): 12 keys + `termKeySeq` + `applyTermMods` + `kbdLiftPx`. 18 unit tests.
- **`<TermKeybar />`**: presentational, shadcn Button + Tailwind, no raw CSS. 5 component tests.
- **Write-path integration**: the key bar pushes bytes into the existing ordered single-flight write pump (`writeQueueRef`), not `terminalWrite` directly — otherwise concurrent soft-keyboard and key-bar presses would scramble under Tauri invoke reordering.
- **Latch semantics**: CTRL/ALT are one-shot sticky keys. The next `onData` (or the next key-bar press) wraps itself then auto-clears. Refs hold the truth, state drives the highlight.
- **Soft-keyboard follow**: `visualViewport` listener computes `kbdLift = max(0, innerHeight - vvHeight - vvOffsetTop)` and applies `max-height: calc(100% - kbdLift)` to the outer flex column so the bar lifts above the keyboard and xterm auto-refits via the existing ResizeObserver.
- **Collapse state**: persisted to `localStorage codeg:term-keybar` at the panel level (not per tab) so switching tabs stays consistent.
- **Desktop untouched**: `useMediaQuery("(max-width: 768px)")` short-circuits both the toggle button and the bar — desktop users see no change.

## Verification

- `pnpm test`: 5764 passed (includes 23 new keybar tests)
- `pnpm eslint .`: clean
- `pnpm build`: 32/32 static pages generated
- `tsc --noEmit`: clean

## i18n

16 new keys under `Folder.terminal.keybar` across all 10 locales. The symbols (ESC/TAB/↑↓←→ etc.) are language-neutral; `show` / `hide` / `label` are translated for zh-CN/zh-TW/ja/ko/es/de/fr/pt/ar.

## Side fix

Mobile Drawer height bumped from 70vh to 95vh to give the new bar enough room when folded in.