### PR TITLE
fix(chat): 对话区域长按菜单冲突解决

### DIFF
--- a/src/components/conversations/conversation-detail-panel.tsx
+++ b/src/components/conversations/conversation-detail-panel.tsx
@@ -49,6 +49,7 @@ import { useAdvertisedGoalActions } from "@/hooks/use-goal-actions"
 import { ConversationShell } from "@/components/chat/conversation-shell"
 import { SessionConfigStaleBanner } from "@/components/chat/session-config-stale-banner"
 import { PiProjectTrustBanner } from "@/components/chat/pi-project-trust-banner"
+import { useContextMenuPointerGuard } from "@/hooks/use-context-menu-pointer-guard"
 import { FeedbackNotesDisplay } from "@/components/chat/feedback-notes-display"
 import { FeedbackDialog } from "@/components/chat/feedback-dialog"
 import { AgentDiagnosticsDialog } from "@/components/settings/agent-diagnostics-dialog"
@@ -2368,6 +2369,7 @@ export function ConversationDetailPanel() {
   const [detailsOpen, setDetailsOpen] = useState(false)
 
   const exportLabels = useExportLabels()
+  const contextMenuPointerGuard = useContextMenuPointerGuard()
 
   // Release the old connection as soon as a preview tab is replaced (the next
   // single-click in the sidebar takes its slot) instead of waiting for a sweep.
@@ -2855,6 +2857,7 @@ export function ConversationDetailPanel() {
             <div
               ref={groupContainerRef}
               className="relative min-h-0 flex-1 overflow-hidden"
+              {...contextMenuPointerGuard.triggerProps}
             >
               {/* Flat sibling shells keyed by stable group id + divider
                   overlays — stable across every split/tile flip, otherwise

--- a/src/hooks/use-context-menu-pointer-guard.test.tsx
+++ b/src/hooks/use-context-menu-pointer-guard.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, renderHook, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
+import { useContextMenuPointerGuard } from "./use-context-menu-pointer-guard"
+
+/**
+ * jsdom's `fireEvent.pointerDown` drops `pointerType` (it builds a plain
+ * MouseEvent), so the property is pinned by hand — the guard reads exactly
+ * that field to distinguish a native text-selection long-press from a mouse
+ * right-click.
+ */
+function pointerDown(element: Element, pointerType: string) {
+  const event = new MouseEvent("pointerdown", {
+    bubbles: true,
+    cancelable: true,
+  })
+  Object.defineProperty(event, "pointerType", { value: pointerType })
+  fireEvent(element, event)
+}
+
+function renderGuarded(onContextMenu: (event: Event) => void) {
+  const { result } = renderHook(() => useContextMenuPointerGuard())
+
+  return render(
+    <div onContextMenu={onContextMenu}>
+      <div data-testid="trigger" {...result.current.triggerProps}>
+        <span data-testid="text">message text</span>
+      </div>
+    </div>
+  )
+}
+
+describe("useContextMenuPointerGuard", () => {
+  it("lets a touch long-press reach the native menu but not the app menu", () => {
+    const onContextMenu = vi.fn()
+    renderGuarded(onContextMenu)
+    const text = screen.getByTestId("text")
+
+    pointerDown(text, "touch")
+    const event = fireEvent.contextMenu(text)
+
+    expect(onContextMenu).not.toHaveBeenCalled()
+    // Stopping Radix's propagation must not cancel the browser's native
+    // selection/image menu, which is the whole point on touch.
+    expect(event).toBe(true)
+  })
+
+  it("lets a pen long-press reach the native menu but not the app menu", () => {
+    const onContextMenu = vi.fn()
+    renderGuarded(onContextMenu)
+    const text = screen.getByTestId("text")
+
+    pointerDown(text, "pen")
+    fireEvent.contextMenu(text)
+
+    expect(onContextMenu).not.toHaveBeenCalled()
+  })
+
+  it("keeps a mouse right-click on the app menu", () => {
+    const onContextMenu = vi.fn()
+    renderGuarded(onContextMenu)
+    const text = screen.getByTestId("text")
+
+    pointerDown(text, "mouse")
+    fireEvent.contextMenu(text)
+
+    expect(onContextMenu).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps an app-menu shortcut usable when no pointer press preceded it", () => {
+    const onContextMenu = vi.fn()
+    renderGuarded(onContextMenu)
+
+    fireEvent.contextMenu(screen.getByTestId("text"))
+
+    expect(onContextMenu).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("context menu integration", () => {
+  function renderRadixGuarded() {
+    const { result } = renderHook(() => useContextMenuPointerGuard())
+
+    return render(
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div data-testid="trigger" {...result.current.triggerProps}>
+            <span data-testid="text">message text</span>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem>App action</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    )
+  }
+
+  it("keeps a touch long-press from opening the Radix menu", () => {
+    renderRadixGuarded()
+    const trigger = screen.getByTestId("trigger")
+
+    pointerDown(trigger, "touch")
+    const event = fireEvent.contextMenu(trigger)
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+    expect(event).toBe(true)
+  })
+
+  it("opens the Radix menu for a mouse right-click", () => {
+    renderRadixGuarded()
+    const trigger = screen.getByTestId("trigger")
+
+    pointerDown(trigger, "mouse")
+    fireEvent.contextMenu(trigger)
+
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+  })
+})

--- a/src/hooks/use-context-menu-pointer-guard.ts
+++ b/src/hooks/use-context-menu-pointer-guard.ts
@@ -1,0 +1,41 @@
+"use client"
+
+import {
+  useCallback,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react"
+
+interface ContextMenuTriggerGuardProps {
+  /** Record the gesture before the browser translates a long-press into `contextmenu`. */
+  onPointerDownCapture: (event: ReactPointerEvent) => void
+  /** Suppress the app menu for touch/pen while leaving the native menu intact. */
+  onContextMenuCapture: (event: ReactMouseEvent) => void
+}
+
+/**
+ * Text long-presses should belong to the platform's selection UI, not Radix's
+ * app menu. The pointer type is captured on the way in because `contextmenu`
+ * itself no longer says whether the gesture came from touch or mouse.
+ */
+export function useContextMenuPointerGuard() {
+  const pointerTypeRef = useRef<string | null>(null)
+
+  const trackPointerType = useCallback((event: ReactPointerEvent) => {
+    pointerTypeRef.current = event.pointerType
+  }, [])
+
+  const suppressAppMenu = useCallback((event: ReactMouseEvent) => {
+    if (pointerTypeRef.current && pointerTypeRef.current !== "mouse") {
+      event.stopPropagation()
+    }
+  }, [])
+
+  const triggerProps: ContextMenuTriggerGuardProps = {
+    onPointerDownCapture: trackPointerType,
+    onContextMenuCapture: suppressAppMenu,
+  }
+
+  return { triggerProps }
+}


### PR DESCRIPTION
## 问题

在手机上长按消息文本时，浏览器的原生文本选择 UI 和会话级 Radix 右键菜单会同时弹出，两个菜单互相遮挡，导致选择和复制文本变得困难。

## 解决方案

在进入会话内容区域时记录 pointer 类型。触摸或触控笔长按文本时，只阻止事件传播到会话级应用菜单，不调用 `preventDefault()`，因此系统文本选择菜单仍然可以正常出现。

鼠标右键行为保持不变，仍会打开会话菜单。原有的选区快捷操作（复制、引用、提问）也保持可用。

## 测试

- 已运行 `pnpm run lint`
- 已运行相关 Vitest 测试，覆盖新的 pointer guard、选区气泡、聊天输入、图片操作、文件引用操作和 group shell reconciliation，共 70 个测试通过
- 已验证：
  - 触摸/触控笔长按不再弹出应用会话菜单
  - 原生文本选择菜单未被阻止
  - 鼠标右键仍正常打开会话菜单


<img width="954" height="2100" alt="image" src="https://github.com/user-attachments/assets/43a14f13-70b8-4698-9a3c-d019e7e45a24" />
