### PR TITLE
fix(tabs): reopen a closed tab at its original position

### DIFF
--- a/src/components/layout/workspace-chrome-controller-source.test.ts
+++ b/src/components/layout/workspace-chrome-controller-source.test.ts
@@ -66,6 +66,12 @@ describe("tab close/navigation shortcuts live in the always-mounted controller",
     )
   })
 
+  // Each entry carries the slot it was closed from; every opener gets it, so
+  // the tab goes back where it was (clamped) instead of at the end of the strip.
+  it("hands the closed tab's slot to each opener when restoring", () => {
+    expect(controllerSource.match(/index: closed\.index/g)).toHaveLength(3)
+  })
+
   it("removes the keydown shortcut listeners from both tab strips", () => {
     // The strips are conditionally mounted (desktop only; the file strip only
     // when a file tab is open), so they must not own any global shortcut.

--- a/src/components/layout/workspace-chrome-controller.tsx
+++ b/src/components/layout/workspace-chrome-controller.tsx
@@ -205,12 +205,16 @@ export function WorkspaceChromeController() {
 
       if (matchShortcutEvent(e, shortcuts.reopen_last_closed_tab)) {
         e.preventDefault()
+        // Every entry carries the slot it was closed from, and each opener
+        // puts the tab back there (clamped to the strip) rather than at the
+        // end.
         while (true) {
           const closed = popClosedTab()
           if (!closed) return
           if (closed.kind === "file") {
             void openFilePreview(closed.path, {
               folderId: closed.folderId ?? undefined,
+              index: closed.index,
             })
             return
           }
@@ -226,7 +230,8 @@ export function WorkspaceChromeController() {
               closed.conversationId,
               closed.agentType,
               closed.isPinned,
-              closed.title
+              closed.title,
+              { index: closed.index }
             )
             return
           }
@@ -236,7 +241,9 @@ export function WorkspaceChromeController() {
           const workingDir = closed.workingDir ?? folder?.path
           if (!workingDir) continue
           openConversations()
-          openNewConversationTab(closed.folderId, workingDir)
+          openNewConversationTab(closed.folderId, workingDir, {
+            index: closed.index,
+          })
           return
         }
       }

--- a/src/contexts/workspace-context.test.tsx
+++ b/src/contexts/workspace-context.test.tsx
@@ -11,6 +11,7 @@ import {
 import * as api from "@/lib/api"
 import {
   peekClosedTab,
+  popClosedTab,
   resetClosedTabStackForTests,
 } from "@/lib/closed-tab-stack"
 import { resetHomeDirCacheForTests } from "@/lib/file-open-target"
@@ -3276,16 +3277,38 @@ describe("reopening a closed file tab", () => {
   })
 
   function Probe({ onCapture }: { onCapture: (ids: string[]) => void }) {
-    const { openFilePreview, fileTabs, closeFileTab } = useWorkspaceContext()
+    const {
+      openFilePreview,
+      fileTabs,
+      closeFileTab,
+      closeOtherFileTabs,
+      closeAllFileTabs,
+    } = useWorkspaceContext()
     onCapture(fileTabs.map((tab) => tab.id))
+    // What the reopen shortcut does with the entry it pops: hand the opener
+    // the path AND the slot the tab was closed from.
+    const restoreLast = () => {
+      const closed = popClosedTab()
+      if (closed?.kind !== "file") return
+      void openFilePreview(closed.path, {
+        folderId: closed.folderId ?? undefined,
+        index: closed.index,
+      })
+    }
     return (
       <div>
         <button onClick={() => void openFilePreview("a.ts")}>open-a</button>
         <button onClick={() => void openFilePreview("b.ts")}>open-b</button>
         <button onClick={() => void openFilePreview("c.ts")}>open-c</button>
+        <button onClick={() => void openFilePreview("d.ts")}>open-d</button>
         <button onClick={() => closeFileTab(fileTabId("/repo/b.ts"))}>
           close-b
         </button>
+        <button onClick={() => closeOtherFileTabs(fileTabId("/repo/c.ts"))}>
+          close-others-c
+        </button>
+        <button onClick={closeAllFileTabs}>close-all</button>
+        <button onClick={restoreLast}>restore</button>
         <button onClick={() => void openFilePreview("b.ts", { index: 1 })}>
           reopen-b
         </button>
@@ -3362,6 +3385,55 @@ describe("reopening a closed file tab", () => {
       fileTabId("/repo/a.ts"),
       fileTabId("/repo/c.ts"),
       fileTabId("/repo/b.ts"),
+    ])
+  })
+
+  // "Close others" records every tab against the same strip, but the stack is
+  // popped newest-first — so each entry carries the slot it would have had if
+  // the batch had closed one tab at a time.
+  it("walks a close-others batch back into its original order", async () => {
+    const ids = mount()
+    await click("open-a")
+    await click("open-b")
+    await click("open-c")
+    await click("open-d")
+
+    await click("close-others-c")
+    expect(ids()).toEqual([fileTabId("/repo/c.ts")])
+
+    await click("restore")
+    expect(ids()).toEqual([fileTabId("/repo/c.ts"), fileTabId("/repo/d.ts")])
+    await click("restore")
+    expect(ids()).toEqual([
+      fileTabId("/repo/b.ts"),
+      fileTabId("/repo/c.ts"),
+      fileTabId("/repo/d.ts"),
+    ])
+    await click("restore")
+    expect(ids()).toEqual([
+      fileTabId("/repo/a.ts"),
+      fileTabId("/repo/b.ts"),
+      fileTabId("/repo/c.ts"),
+      fileTabId("/repo/d.ts"),
+    ])
+  })
+
+  it("rebuilds a closed-all strip in its original order", async () => {
+    const ids = mount()
+    await click("open-a")
+    await click("open-b")
+    await click("open-c")
+
+    await click("close-all")
+    expect(ids()).toEqual([])
+
+    await click("restore")
+    await click("restore")
+    await click("restore")
+    expect(ids()).toEqual([
+      fileTabId("/repo/a.ts"),
+      fileTabId("/repo/b.ts"),
+      fileTabId("/repo/c.ts"),
     ])
   })
 })

--- a/src/contexts/workspace-context.test.tsx
+++ b/src/contexts/workspace-context.test.tsx
@@ -9,6 +9,10 @@ import {
   useWorkspaceView,
 } from "@/contexts/workspace-context"
 import * as api from "@/lib/api"
+import {
+  peekClosedTab,
+  resetClosedTabStackForTests,
+} from "@/lib/closed-tab-stack"
 import { resetHomeDirCacheForTests } from "@/lib/file-open-target"
 import {
   resetAppWorkspaceStore,
@@ -3250,5 +3254,114 @@ describe("unified absolute-path file tabs (outside-workspace opens)", () => {
     expect(mockedApi.readFileForEdit.mock.calls.length).toBe(
       readsAfterFreshness
     )
+  })
+})
+
+describe("reopening a closed file tab", () => {
+  beforeEach(() => {
+    resetClosedTabStackForTests()
+    mockedApi.readFileForEdit.mockReset()
+    mockedApi.gitIsTracked.mockReset()
+    mockedApi.gitIsTracked.mockResolvedValue(false)
+    mockedApi.readFileForEdit.mockImplementation(
+      async (_rootPath: string, ioPath: string) => ({
+        path: ioPath,
+        content: `${ioPath}-v1`,
+        etag: `e-${ioPath}`,
+        mtime_ms: 1,
+        readonly: false,
+        line_ending: "lf",
+      })
+    )
+  })
+
+  function Probe({ onCapture }: { onCapture: (ids: string[]) => void }) {
+    const { openFilePreview, fileTabs, closeFileTab } = useWorkspaceContext()
+    onCapture(fileTabs.map((tab) => tab.id))
+    return (
+      <div>
+        <button onClick={() => void openFilePreview("a.ts")}>open-a</button>
+        <button onClick={() => void openFilePreview("b.ts")}>open-b</button>
+        <button onClick={() => void openFilePreview("c.ts")}>open-c</button>
+        <button onClick={() => closeFileTab(fileTabId("/repo/b.ts"))}>
+          close-b
+        </button>
+        <button onClick={() => void openFilePreview("b.ts", { index: 1 })}>
+          reopen-b
+        </button>
+        <button onClick={() => void openFilePreview("b.ts", { index: 9 })}>
+          reopen-b-far
+        </button>
+        <button onClick={() => void openFilePreview("c.ts", { index: 0 })}>
+          front-c
+        </button>
+      </div>
+    )
+  }
+
+  async function click(label: string) {
+    await act(async () => {
+      screen.getByText(label).click()
+    })
+  }
+
+  function mount() {
+    let ids: string[] = []
+    render(
+      <WorkspaceProvider>
+        <Probe onCapture={(next) => (ids = next)} />
+      </WorkspaceProvider>
+    )
+    return () => ids
+  }
+
+  it("puts the tab back at the slot it was closed from", async () => {
+    const ids = mount()
+    await click("open-a")
+    await click("open-b")
+    await click("open-c")
+    expect(ids()).toEqual([
+      fileTabId("/repo/a.ts"),
+      fileTabId("/repo/b.ts"),
+      fileTabId("/repo/c.ts"),
+    ])
+
+    await click("close-b")
+    expect(ids()).toEqual([fileTabId("/repo/a.ts"), fileTabId("/repo/c.ts")])
+    expect(peekClosedTab()).toMatchObject({
+      kind: "file",
+      path: "/repo/b.ts",
+      index: 1,
+    })
+
+    await click("reopen-b")
+    expect(ids()).toEqual([
+      fileTabId("/repo/a.ts"),
+      fileTabId("/repo/b.ts"),
+      fileTabId("/repo/c.ts"),
+    ])
+
+    // A tab that is already open is activated where it is, never moved.
+    await click("front-c")
+    expect(ids()).toEqual([
+      fileTabId("/repo/a.ts"),
+      fileTabId("/repo/b.ts"),
+      fileTabId("/repo/c.ts"),
+    ])
+  })
+
+  it("clamps the slot to the strip", async () => {
+    const ids = mount()
+    await click("open-a")
+    await click("open-b")
+    await click("open-c")
+    await click("close-b")
+
+    await click("reopen-b-far")
+    expect(ids()).toEqual([
+      fileTabId("/repo/a.ts"),
+      fileTabId("/repo/c.ts"),
+      fileTabId("/repo/b.ts"),
+    ])
   })
 })

--- a/src/contexts/workspace-context.tsx
+++ b/src/contexts/workspace-context.tsx
@@ -36,7 +36,11 @@ import {
   splitAbsPath,
 } from "@/lib/file-open-target"
 import { isAbsoluteFilePath } from "@/lib/file-path-display"
-import { pushClosedTab, snapshotFileTab } from "@/lib/closed-tab-stack"
+import {
+  batchCloseSlots,
+  pushClosedTab,
+  snapshotFileTab,
+} from "@/lib/closed-tab-stack"
 import {
   isBinaryImageFile,
   isHiddenPath,
@@ -135,9 +139,18 @@ interface WorkspaceActionsValue {
   // no folder to resolve against). Callers that only want the side effect
   // ignore it; a caller that must then FIND the tab (the file viewer drawer)
   // has no other way to reproduce this resolution.
+  //
+  // `index` is the strip slot for a tab that is not open yet, clamped to the
+  // strip; omitted = append. Reopening a closed tab passes the slot it was
+  // closed from. A tab that is already open is activated where it is.
   openFilePreview: (
     path: string,
-    options?: { line?: number; reload?: boolean; folderId?: number }
+    options?: {
+      line?: number
+      reload?: boolean
+      folderId?: number
+      index?: number
+    }
   ) => Promise<string | null>
   // Refetch the open tab matching the absolute `path` without changing
   // activeFileTabId. No-op when no tab matches or when the tab has unsaved
@@ -591,13 +604,18 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
     [activateFilePane]
   )
 
-  // Insert a freshly created (loading, empty) tab. Caller has verified no tab
-  // with this id exists. If a race introduced one, leave it alone.
+  // Insert a freshly created (loading, empty) tab at `index` (clamped), or at
+  // the end. Caller has verified no tab with this id exists. If a race
+  // introduced one, leave it alone.
   const seedLoadingTab = useCallback(
-    (nextTab: FileWorkspaceTab) => {
+    (nextTab: FileWorkspaceTab, index?: number) => {
       setFileTabs((prev) => {
         if (prev.some((tab) => tab.id === nextTab.id)) return prev
-        return [...prev, nextTab]
+        const at =
+          index == null
+            ? prev.length
+            : Math.max(0, Math.min(index, prev.length))
+        return [...prev.slice(0, at), nextTab, ...prev.slice(at)]
       })
       setActiveFileTabId(nextTab.id)
       activateFilePane()
@@ -696,7 +714,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   }, [])
 
   const decideLoad = useCallback(
-    (seed: FileWorkspaceTab, reload: boolean): LoadDecision => {
+    (seed: FileWorkspaceTab, reload: boolean, index?: number): LoadDecision => {
       // Dedup synchronously. inFlightLoadsRef is updated immediately on
       // generation start, so rapid re-clicks within a single event loop
       // turn collapse here — unlike fileTabsRef.current, which only
@@ -712,7 +730,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
         // e.g. the user closed it while a watcher-driven reload was in
         // flight — do not resurrect it as a phantom tab.
         if (reload) return { kind: "skip" }
-        seedLoadingTab(seed)
+        seedLoadingTab(seed, index)
         return { kind: "fetch", gen: beginFetchGeneration(seed.id) }
       }
 
@@ -1149,7 +1167,12 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
   const openFilePreview = useCallback(
     async (
       rawPath: string,
-      options?: { line?: number; reload?: boolean; folderId?: number }
+      options?: {
+        line?: number
+        reload?: boolean
+        folderId?: number
+        index?: number
+      }
     ) => {
       const absPath = await resolveOpenAbsolutePath(rawPath, options?.folderId)
       if (!absPath) return null
@@ -1188,7 +1211,11 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
           image ? "image" : office ? "office" : languageFromPath(absPath)
         )
 
-        const decision = decideLoad(seed, options?.reload ?? false)
+        const decision = decideLoad(
+          seed,
+          options?.reload ?? false,
+          options?.index
+        )
         if (decision.kind === "skip") return
         const { gen } = decision
 
@@ -2291,7 +2318,7 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
         // `pushClosedTab` keys on the tab id and moves an existing entry to the
         // top, so recording from inside this updater survives React invoking it
         // more than once (StrictMode, or a discarded render replayed).
-        const closed = snapshotFileTab(tab)
+        const closed = snapshotFileTab(tab, idx)
         if (closed) pushClosedTab(closed)
 
         const next = prev.filter((candidate) => candidate.id !== tabId)
@@ -2340,10 +2367,11 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
           if (!confirmed) return prev
         }
 
-        for (const closing of closingTabs) {
-          // `pushClosedTab` is idempotent per tab id, which is what makes this
-          // safe inside an updater React may invoke more than once.
-          const closed = snapshotFileTab(closing)
+        // `pushClosedTab` is idempotent per tab id, which is what makes this
+        // safe inside an updater React may invoke more than once.
+        const slots = batchCloseSlots(prev, (tab) => tab.id !== tabId)
+        for (const [closing, slot] of slots) {
+          const closed = snapshotFileTab(closing, slot)
           if (closed) pushClosedTab(closed)
           inFlightLoadsRef.current.delete(closing.id)
         }
@@ -2363,8 +2391,8 @@ export function WorkspaceProvider({ children }: WorkspaceProviderProps) {
         if (!confirmed) return prev
       }
 
-      for (const tab of prev) {
-        const closed = snapshotFileTab(tab)
+      for (const [tab, slot] of batchCloseSlots(prev)) {
+        const closed = snapshotFileTab(tab, slot)
         if (closed) pushClosedTab(closed)
       }
 

--- a/src/lib/closed-tab-stack.test.ts
+++ b/src/lib/closed-tab-stack.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import {
   CLOSED_TAB_STACK_LIMIT,
+  batchCloseSlots,
   peekClosedTab,
   popClosedTab,
   pushClosedTab,
@@ -14,15 +15,18 @@ afterEach(() => {
   resetClosedTabStackForTests()
 })
 
-function conversation(id: number) {
-  return snapshotConversationTab({
-    id: `conv-${id}`,
-    folderId: 1,
-    conversationId: id,
-    agentType: "claude_code",
-    title: `t${id}`,
-    isPinned: false,
-  })
+function conversation(id: number, index = 0) {
+  return snapshotConversationTab(
+    {
+      id: `conv-${id}`,
+      folderId: 1,
+      conversationId: id,
+      agentType: "claude_code",
+      title: `t${id}`,
+      isPinned: false,
+    },
+    index
+  )
 }
 
 function drainKeys(): string[] {
@@ -37,24 +41,30 @@ function drainKeys(): string[] {
 describe("closed tab stack", () => {
   it("restores the most recently closed tab first", () => {
     pushClosedTab(
-      snapshotConversationTab({
-        id: "conv-10",
-        folderId: 1,
-        conversationId: 10,
-        agentType: "claude_code",
-        title: "first",
-        isPinned: false,
-      })
+      snapshotConversationTab(
+        {
+          id: "conv-10",
+          folderId: 1,
+          conversationId: 10,
+          agentType: "claude_code",
+          title: "first",
+          isPinned: false,
+        },
+        0
+      )
     )
     pushClosedTab(
-      snapshotConversationTab({
-        id: "conv-11",
-        folderId: 1,
-        conversationId: 11,
-        agentType: "codex",
-        title: "second",
-        isPinned: true,
-      })
+      snapshotConversationTab(
+        {
+          id: "conv-11",
+          folderId: 1,
+          conversationId: 11,
+          agentType: "codex",
+          title: "second",
+          isPinned: true,
+        },
+        1
+      )
     )
     expect(peekClosedTab()?.kind).toBe("conversation")
     expect(popClosedTab()).toMatchObject({
@@ -68,14 +78,17 @@ describe("closed tab stack", () => {
   it("drops the oldest entry past the browser-like cap", () => {
     for (let i = 0; i < CLOSED_TAB_STACK_LIMIT + 3; i += 1) {
       pushClosedTab(
-        snapshotConversationTab({
-          id: `conv-${i}`,
-          folderId: 1,
-          conversationId: i,
-          agentType: "grok",
-          title: `t${i}`,
-          isPinned: false,
-        })
+        snapshotConversationTab(
+          {
+            id: `conv-${i}`,
+            folderId: 1,
+            conversationId: i,
+            agentType: "grok",
+            title: `t${i}`,
+            isPinned: false,
+          },
+          i
+        )
       )
     }
     const first = popClosedTab()
@@ -115,18 +128,22 @@ describe("closed tab stack", () => {
 
   it("skips a file tab with no path", () => {
     expect(
-      snapshotFileTab({ id: "f", kind: "file", path: null, folderId: 1 })
+      snapshotFileTab({ id: "f", kind: "file", path: null, folderId: 1 }, 0)
     ).toBeNull()
     expect(
-      snapshotFileTab({
-        id: "file:/repo/a.ts",
-        kind: "file",
-        path: "/repo/a.ts",
-        folderId: 2,
-      })
+      snapshotFileTab(
+        {
+          id: "file:/repo/a.ts",
+          kind: "file",
+          path: "/repo/a.ts",
+          folderId: 2,
+        },
+        3
+      )
     ).toEqual({
       kind: "file",
       key: "file:/repo/a.ts",
+      index: 3,
       path: "/repo/a.ts",
       folderId: 2,
     })
@@ -138,13 +155,42 @@ describe("closed tab stack", () => {
   it("skips a diff tab even though it carries a path", () => {
     for (const kind of ["diff", "rich-diff"]) {
       expect(
-        snapshotFileTab({
-          id: `${kind}:/repo/a.ts`,
-          kind,
-          path: "/repo/a.ts",
-          folderId: 2,
-        })
+        snapshotFileTab(
+          {
+            id: `${kind}:/repo/a.ts`,
+            kind,
+            path: "/repo/a.ts",
+            folderId: 2,
+          },
+          0
+        )
       ).toBeNull()
     }
+  })
+
+  it("records the strip slot the tab was closed from", () => {
+    expect(conversation(1, 3).index).toBe(3)
+  })
+
+  // A batch close records every member against the same strip, but the stack
+  // is popped newest-first. Each slot is where the tab would sit once the
+  // members before it are gone, so reopening in reverse walks the strip back.
+  it("gives a batch close the slots that rebuild the strip in reverse", () => {
+    const strip = ["a", "b", "c", "d"]
+    expect(batchCloseSlots(strip)).toEqual([
+      ["a", 0],
+      ["b", 0],
+      ["c", 0],
+      ["d", 0],
+    ])
+    expect(batchCloseSlots(strip, (tab) => tab !== "b")).toEqual([
+      ["a", 0],
+      ["c", 1],
+      ["d", 1],
+    ])
+    expect(batchCloseSlots(strip, (tab) => tab > "b")).toEqual([
+      ["c", 2],
+      ["d", 2],
+    ])
   })
 })

--- a/src/lib/closed-tab-stack.ts
+++ b/src/lib/closed-tab-stack.ts
@@ -6,6 +6,12 @@ export type ClosedConversationTab = {
   kind: "conversation"
   /** The closed tab's id. Identity for the repeat-push guard in `pushClosedTab`. */
   key: string
+  /**
+   * The strip slot the tab was closed from. Reopening splices the tab back in
+   * there, clamped to the strip's current length, instead of appending it:
+   * a restored tab goes back where it was, the way a browser puts it.
+   */
+  index: number
   folderId: number
   conversationId: number | null
   agentType: AgentType
@@ -18,6 +24,8 @@ export type ClosedFileTab = {
   kind: "file"
   /** The closed tab's id. Identity for the repeat-push guard in `pushClosedTab`. */
   key: string
+  /** See `ClosedConversationTab.index`. */
+  index: number
   path: string
   folderId: number | null
 }
@@ -78,18 +86,47 @@ export function resetClosedTabStackForTests(): void {
   stack = []
 }
 
-export function snapshotConversationTab(tab: {
-  id: string
-  folderId: number
-  conversationId: number | null
-  agentType: AgentType
-  title: string
-  workingDir?: string
-  isPinned: boolean
-}): ClosedConversationTab {
+/**
+ * The slot to record for each member of a batch close, in strip order. The
+ * stack is popped newest-first, so a member's slot is where it would sit once
+ * the members before it are already gone, as if the batch had closed one tab
+ * at a time: `[a, b, c]` closed together records every tab at 0, and reopening
+ * c, then b, then a rebuilds `[a, b, c]` ahead of whatever replaced them.
+ * Closing all but `b` records a@0, c@1, d@1 and rebuilds `[a, b, c, d]`. A
+ * closed member that is never recorded (a diff tab) still shifts what follows.
+ */
+export function batchCloseSlots<T>(
+  strip: readonly T[],
+  closing: (tab: T) => boolean = () => true
+): Array<[tab: T, slot: number]> {
+  const out: Array<[T, number]> = []
+  strip.forEach((tab, i) => {
+    if (closing(tab)) out.push([tab, i - out.length])
+  })
+  return out
+}
+
+/**
+ * `index` is the tab's slot in its strip as it closes. A batch close (close
+ * others, close all) takes it from `batchCloseSlots`, not from the pre-close
+ * strip.
+ */
+export function snapshotConversationTab(
+  tab: {
+    id: string
+    folderId: number
+    conversationId: number | null
+    agentType: AgentType
+    title: string
+    workingDir?: string
+    isPinned: boolean
+  },
+  index: number
+): ClosedConversationTab {
   return {
     kind: "conversation",
     key: tab.id,
+    index,
     folderId: tab.folderId,
     conversationId: tab.conversationId,
     agentType: tab.agentType,
@@ -106,13 +143,22 @@ export function snapshotConversationTab(tab: {
  * compares, not what the tab shows — restoring it would silently swap the diff
  * for the editor. A pathless tab (the whole-worktree diff) has nothing to key on.
  */
-export function snapshotFileTab(tab: {
-  id: string
-  kind: string
-  path: string | null
-  folderId: number | null
-}): ClosedFileTab | null {
+export function snapshotFileTab(
+  tab: {
+    id: string
+    kind: string
+    path: string | null
+    folderId: number | null
+  },
+  index: number
+): ClosedFileTab | null {
   if (tab.kind !== "file") return null
   if (!tab.path) return null
-  return { kind: "file", key: tab.id, path: tab.path, folderId: tab.folderId }
+  return {
+    kind: "file",
+    key: tab.id,
+    index,
+    path: tab.path,
+    folderId: tab.folderId,
+  }
 }

--- a/src/stores/tab-store-reopen-position.test.ts
+++ b/src/stores/tab-store-reopen-position.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  popClosedTab,
+  resetClosedTabStackForTests,
+  type ClosedWorkspaceTab,
+} from "@/lib/closed-tab-stack"
+import { saveOpenedTabs } from "@/lib/api"
+import {
+  resetAppWorkspaceStore,
+  useAppWorkspaceStore,
+} from "./app-workspace-store"
+import { resetTabStore, useTabStore, type TabItemInternal } from "./tab-store"
+import type { FolderDetail } from "@/lib/types"
+
+vi.mock("@/lib/api", () => ({
+  listOpenedTabs: vi.fn(),
+  saveOpenedTabs: vi.fn(),
+  getFolderConversation: vi.fn(),
+}))
+
+vi.mock("@/lib/platform", () => ({
+  subscribe: vi.fn(),
+  onTransportReconnect: vi.fn(),
+}))
+
+const folder = {
+  id: 1,
+  name: "repo",
+  path: "/repo",
+} as unknown as FolderDetail
+
+function tabId(conversationId: number): string {
+  return `conv-1-claude_code-${conversationId}`
+}
+
+function conversationTab(
+  conversationId: number,
+  isPinned = true
+): TabItemInternal {
+  return {
+    id: tabId(conversationId),
+    kind: "conversation",
+    folderId: 1,
+    conversationId,
+    agentType: "claude_code",
+    title: `t${conversationId}`,
+    isPinned,
+  }
+}
+
+function draftTab(id: string): TabItemInternal {
+  return {
+    id,
+    kind: "conversation",
+    folderId: 1,
+    conversationId: null,
+    agentType: "claude_code",
+    title: "draft",
+    isPinned: true,
+    workingDir: "/repo",
+  }
+}
+
+function seedTabs(tabs: TabItemInternal[], activeTabId = tabs[0].id) {
+  useAppWorkspaceStore.setState({ folders: [folder], allFolders: [folder] })
+  useTabStore.setState({ rawTabs: tabs, activeTabId })
+}
+
+function ids(): string[] {
+  return useTabStore.getState().rawTabs.map((tab) => tab.id)
+}
+
+/** What the reopen shortcut does with the entry it pops: hand the store the
+ *  identity AND the slot the tab was closed from. */
+function reopen(closed: ClosedWorkspaceTab | null) {
+  if (!closed || closed.kind !== "conversation") {
+    throw new Error("expected a closed conversation tab")
+  }
+  const store = useTabStore.getState()
+  if (closed.conversationId == null) {
+    store.openNewConversationTab(closed.folderId, closed.workingDir ?? "", {
+      index: closed.index,
+    })
+    return
+  }
+  store.openTab(
+    closed.folderId,
+    closed.conversationId,
+    closed.agentType,
+    closed.isPinned,
+    closed.title,
+    { index: closed.index }
+  )
+}
+
+function reopenLast() {
+  reopen(popClosedTab())
+}
+
+beforeEach(() => {
+  resetTabStore()
+  resetAppWorkspaceStore()
+  resetClosedTabStackForTests()
+})
+
+afterEach(() => {
+  resetClosedTabStackForTests()
+  vi.useRealTimers()
+})
+
+describe("where reopen-last-closed-tab puts the tab back", () => {
+  it("restores the tab at the slot it was closed from", () => {
+    seedTabs([conversationTab(1), conversationTab(2), conversationTab(3)])
+    useTabStore.getState().closeTab(tabId(2))
+    expect(ids()).toEqual([tabId(1), tabId(3)])
+
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(2), tabId(3)])
+    expect(useTabStore.getState().activeTabId).toBe(tabId(2))
+  })
+
+  it("clamps the slot to the strip when it has shrunk since", () => {
+    seedTabs([
+      conversationTab(1),
+      conversationTab(2),
+      conversationTab(3),
+      conversationTab(4),
+    ])
+    useTabStore.getState().closeTab(tabId(4))
+    useTabStore.getState().closeTab(tabId(2), { recordForReopen: false })
+    useTabStore.getState().closeTab(tabId(3), { recordForReopen: false })
+    expect(ids()).toEqual([tabId(1)])
+
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(4)])
+  })
+
+  it("puts tabs closed one at a time back in reverse, each where it was", () => {
+    seedTabs([
+      conversationTab(1),
+      conversationTab(2),
+      conversationTab(3),
+      conversationTab(4),
+      conversationTab(5),
+    ])
+    useTabStore.getState().closeTab(tabId(2))
+    useTabStore.getState().closeTab(tabId(4))
+    expect(ids()).toEqual([tabId(1), tabId(3), tabId(5)])
+
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(3), tabId(4), tabId(5)])
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(2), tabId(3), tabId(4), tabId(5)])
+  })
+
+  // "Close other tabs" records every tab against the same strip. Reopening
+  // walks the stack newest-first, so each entry has to carry the slot the tab
+  // would have had if the batch had closed one tab at a time.
+  it("walks a close-others batch back into its original order", () => {
+    seedTabs(
+      [
+        conversationTab(1),
+        conversationTab(2),
+        conversationTab(3),
+        conversationTab(4),
+      ],
+      tabId(2)
+    )
+    useTabStore.getState().closeOtherTabs(tabId(2))
+    expect(ids()).toEqual([tabId(2)])
+
+    reopenLast()
+    expect(ids()).toEqual([tabId(2), tabId(4)])
+    reopenLast()
+    expect(ids()).toEqual([tabId(2), tabId(3), tabId(4)])
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(2), tabId(3), tabId(4)])
+  })
+
+  it("rebuilds a closed-all strip ahead of the draft that replaced it", () => {
+    seedTabs([conversationTab(1), conversationTab(2), conversationTab(3)])
+    useTabStore.getState().closeAllTabs()
+    const [draft] = ids()
+    expect(useTabStore.getState().rawTabs[0].conversationId).toBeNull()
+
+    reopenLast()
+    reopenLast()
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(2), tabId(3), draft])
+  })
+
+  it("restores a closed draft at its slot", () => {
+    seedTabs([conversationTab(1), draftTab("new-1"), conversationTab(3)])
+    useTabStore.getState().closeTab("new-1")
+    expect(ids()).toEqual([tabId(1), tabId(3)])
+
+    reopenLast()
+    const { rawTabs, activeTabId } = useTabStore.getState()
+    expect(rawTabs.map((tab) => tab.conversationId)).toEqual([1, null, 3])
+    expect(rawTabs[1].workingDir).toBe("/repo")
+    expect(activeTabId).toBe(rawTabs[1].id)
+  })
+
+  it("keeps a reopened kept tab out of the group's preview slot", () => {
+    seedTabs(
+      [conversationTab(1), conversationTab(2), conversationTab(3, false)],
+      tabId(2)
+    )
+    useTabStore.getState().closeTab(tabId(2))
+
+    reopenLast()
+    const { rawTabs, previewReplacedTabIds } = useTabStore.getState()
+    expect(rawTabs.map((tab) => [tab.id, tab.isPinned])).toEqual([
+      [tabId(1), true],
+      [tabId(2), true],
+      [tabId(3), false],
+    ])
+    expect(previewReplacedTabIds).toEqual([])
+  })
+
+  it("lands a reopened preview at its slot when the group has no preview", () => {
+    seedTabs(
+      [conversationTab(1), conversationTab(2, false), conversationTab(3)],
+      tabId(2)
+    )
+    useTabStore.getState().closeTab(tabId(2))
+
+    reopenLast()
+    expect(
+      useTabStore.getState().rawTabs.map((tab) => [tab.id, tab.isPinned])
+    ).toEqual([
+      [tabId(1), true],
+      [tabId(2), false],
+      [tabId(3), true],
+    ])
+  })
+
+  // A group holds one preview. A reopened preview still takes that slot when
+  // another preview opened in the meantime; the slot only decides where a tab
+  // that needs a NEW slot goes.
+  it("lets a reopened preview replace the preview that took its place", () => {
+    seedTabs(
+      [conversationTab(1), conversationTab(2, false), conversationTab(3)],
+      tabId(2)
+    )
+    useTabStore.getState().closeTab(tabId(2))
+    useTabStore.getState().openTab(1, 4, "claude_code", false)
+    expect(ids()).toEqual([tabId(1), tabId(3), tabId(4)])
+
+    reopenLast()
+    const { rawTabs, previewReplacedTabIds } = useTabStore.getState()
+    expect(rawTabs.map((tab) => [tab.id, tab.isPinned])).toEqual([
+      [tabId(1), true],
+      [tabId(3), true],
+      [tabId(2), false],
+    ])
+    expect(previewReplacedTabIds).toEqual([tabId(4)])
+  })
+
+  it("focuses a conversation that is open again rather than adding a tab", () => {
+    seedTabs([conversationTab(1), conversationTab(2), conversationTab(3)])
+    useTabStore.getState().closeTab(tabId(2))
+    // Reopened from the sidebar in the meantime (which does not pop).
+    useTabStore.getState().openTab(1, 2, "claude_code", true)
+    useTabStore.getState().switchTab(tabId(1))
+    expect(ids()).toEqual([tabId(1), tabId(3), tabId(2)])
+
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), tabId(3), tabId(2)])
+    expect(useTabStore.getState().activeTabId).toBe(tabId(2))
+  })
+
+  it("saves the restored order as the persisted positions", async () => {
+    vi.useFakeTimers()
+    vi.mocked(saveOpenedTabs).mockResolvedValue({
+      accepted: true,
+      version: 1,
+      tabs: [],
+    })
+    seedTabs([conversationTab(1), conversationTab(2), conversationTab(3)])
+    useTabStore.setState({ tabsHydrated: true })
+    useTabStore.getState().closeTab(tabId(2))
+    reopenLast()
+
+    useTabStore.getState().runSaveEffect()
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(saveOpenedTabs).toHaveBeenCalledTimes(1)
+    const [items] = vi.mocked(saveOpenedTabs).mock.calls[0]
+    expect(items.map((it) => [it.conversation_id, it.position])).toEqual([
+      [1, 0],
+      [2, 1],
+      [3, 2],
+    ])
+  })
+})

--- a/src/stores/tab-store-reopen-position.test.ts
+++ b/src/stores/tab-store-reopen-position.test.ts
@@ -190,6 +190,21 @@ describe("where reopen-last-closed-tab puts the tab back", () => {
     expect(ids()).toEqual([tabId(1), tabId(2), tabId(3), draft])
   })
 
+  // The replacement draft a close-all spawns IS what a reopened draft entry
+  // resolves to (per-group draft singleton), so it has to take the closed
+  // draft's slot — otherwise the strip comes back with the draft shunted to
+  // the end.
+  it("rebuilds a closed-all strip that held a draft", () => {
+    seedTabs([conversationTab(1), draftTab("new-1"), conversationTab(3)])
+    useTabStore.getState().closeAllTabs()
+    const [draft] = ids()
+
+    reopenLast()
+    reopenLast()
+    reopenLast()
+    expect(ids()).toEqual([tabId(1), draft, tabId(3)])
+  })
+
   it("restores a closed draft at its slot", () => {
     seedTabs([conversationTab(1), draftTab("new-1"), conversationTab(3)])
     useTabStore.getState().closeTab("new-1")

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -265,9 +265,10 @@ export interface TabStoreState {
        *  agent (e.g. "ask about this selection" continues the conversation the
        *  text came from), not merely suggest one. */
       forceAgent?: AgentType
-      /** rawTabs slot for a NEW draft (clamped); omitted = append. Reopening
-       *  a closed draft passes the slot it was closed from. Ignored when the
-       *  target group's existing draft is reused instead. */
+      /** rawTabs slot for the draft (clamped); omitted = append / leave put.
+       *  Reopening a closed draft passes the slot it was closed from — and
+       *  since the per-group singleton may hand it the group's EXISTING draft
+       *  instead of a new tab, that draft is moved to the slot. */
       index?: number
     }
   ) => OpenedDraftTarget
@@ -467,6 +468,11 @@ function findTabIndexForConversation(
   )
 }
 
+/** A requested slot clamped to a strip of `length`. */
+function clampSlot(index: number, length: number): number {
+  return Math.max(0, Math.min(index, length))
+}
+
 /** `tabs` with `tab` inserted at `index`, clamped to the array, or appended
  *  when no index is given. Reopening a closed tab passes the slot it was
  *  closed from, so it goes back where it was rather than to the end. */
@@ -475,9 +481,25 @@ function insertTab(
   tab: TabItemInternal,
   index: number | undefined
 ): TabItemInternal[] {
-  const at =
-    index == null ? tabs.length : Math.max(0, Math.min(index, tabs.length))
+  const at = index == null ? tabs.length : clampSlot(index, tabs.length)
   return [...tabs.slice(0, at), tab, ...tabs.slice(at)]
+}
+
+/** `tabs` with the tab already at `tabId` moved to `index` (clamped) — the same
+ *  array back when it is absent or already there, so callers can skip the write.
+ *  Reopening a closed DRAFT lands here: the per-group draft singleton hands the
+ *  reopen an existing draft instead of a new tab, and that draft still has to
+ *  take the closed one's slot. */
+function moveTabToSlot(
+  tabs: TabItemInternal[],
+  tabId: string,
+  index: number
+): TabItemInternal[] {
+  const from = tabs.findIndex((t) => t.id === tabId)
+  if (from < 0) return tabs
+  const without = tabs.filter((t) => t.id !== tabId)
+  if (clampSlot(index, without.length) === from) return tabs
+  return insertTab(without, tabs[from], index)
 }
 
 /** Field-wise equality for derived tab items. Backs the cross-derive reuse in
@@ -1725,8 +1747,20 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
     const provisionalChanged =
       (existingTab.agentTypeProvisional ?? false) !== provisional
 
+    // The singleton means a reopened draft resolves to THIS draft rather than a
+    // tab of its own, so the slot it was closed from has to move this one — a
+    // close-all walked back would otherwise leave the draft shunted to the end
+    // of the strip it is meant to rebuild. Only the reopen path passes an
+    // index, and drafts never reach `buildPersistItems`, so no save fires.
+    const nextRawTabs =
+      options?.index == null
+        ? prevState.rawTabs
+        : moveTabToSlot(prevState.rawTabs, existingTab.id, options.index)
+    const moved = nextRawTabs !== prevState.rawTabs
+
     if (folderChanged || agentChanged) {
       set({
+        ...(moved ? { rawTabs: nextRawTabs } : {}),
         draftRetargetRequests: [
           ...prevState.draftRetargetRequests,
           {
@@ -1740,15 +1774,19 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
         ],
       })
       focusTab(existingTab.id)
+      if (moved) recomputeTabs()
     } else if (workingDirChanged || provisionalChanged) {
       set({
-        rawTabs: prevState.rawTabs.map((tab) =>
+        rawTabs: nextRawTabs.map((tab) =>
           tab.id === existingTab.id
             ? { ...tab, workingDir, agentTypeProvisional: provisional }
             : tab
         ),
         activeTabId: existingTab.id,
       })
+      recomputeTabs()
+    } else if (moved) {
+      set({ rawTabs: nextRawTabs, activeTabId: existingTab.id })
       recomputeTabs()
     } else {
       focusTab(existingTab.id)

--- a/src/stores/tab-store.ts
+++ b/src/stores/tab-store.ts
@@ -36,7 +36,11 @@ import {
   sweepOrphanDraftKeys,
 } from "@/lib/message-input-draft"
 import { discardAskSelectionPrompts } from "@/lib/ask-selection-handoff"
-import { pushClosedTab, snapshotConversationTab } from "@/lib/closed-tab-stack"
+import {
+  batchCloseSlots,
+  pushClosedTab,
+  snapshotConversationTab,
+} from "@/lib/closed-tab-stack"
 import type {
   AgentType,
   ConversationChange,
@@ -197,7 +201,14 @@ export interface TabStoreState {
     conversationId: number,
     agentType: AgentType,
     pin?: boolean,
-    title?: string
+    title?: string,
+    opts?: {
+      /** rawTabs slot for a tab that needs a NEW slot (clamped); omitted =
+       *  append. Reopening a closed tab passes the slot it was closed from. A
+       *  conversation that is already open is focused where it is, and a
+       *  preview still replaces the group's current preview in place. */
+      index?: number
+    }
   ) => void
   /**
    * `recordForReopen: false` closes without offering the tab to
@@ -254,6 +265,10 @@ export interface TabStoreState {
        *  agent (e.g. "ask about this selection" continues the conversation the
        *  text came from), not merely suggest one. */
       forceAgent?: AgentType
+      /** rawTabs slot for a NEW draft (clamped); omitted = append. Reopening
+       *  a closed draft passes the slot it was closed from. Ignored when the
+       *  target group's existing draft is reused instead. */
+      index?: number
     }
   ) => OpenedDraftTarget
   openChatModeTab: (options?: {
@@ -450,6 +465,19 @@ function findTabIndexForConversation(
       t.conversationId === conversationId &&
       t.agentType === agentType
   )
+}
+
+/** `tabs` with `tab` inserted at `index`, clamped to the array, or appended
+ *  when no index is given. Reopening a closed tab passes the slot it was
+ *  closed from, so it goes back where it was rather than to the end. */
+function insertTab(
+  tabs: TabItemInternal[],
+  tab: TabItemInternal,
+  index: number | undefined
+): TabItemInternal[] {
+  const at =
+    index == null ? tabs.length : Math.max(0, Math.min(index, tabs.length))
+  return [...tabs.slice(0, at), tab, ...tabs.slice(at)]
 }
 
 /** Field-wise equality for derived tab items. Backs the cross-derive reuse in
@@ -1061,7 +1089,7 @@ function initialTabState() {
 export const useTabStore = create<TabStoreState>()((set, get) => ({
   ...initialTabState(),
 
-  openTab: (folderId, conversationId, agentType, pin = false, title) => {
+  openTab: (folderId, conversationId, agentType, pin = false, title, opts) => {
     const prevState = get()
     const existingIndex = findTabIndexForConversation(
       prevState.rawTabs,
@@ -1117,7 +1145,7 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
 
     if (pin) {
       set({
-        rawTabs: [...prevState.rawTabs, newTab],
+        rawTabs: insertTab(prevState.rawTabs, newTab, opts?.index),
         activeTabId: tabId,
         groupOf: { ...prevState.groupOf, [tabId]: targetGroup },
       })
@@ -1127,7 +1155,7 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
     }
 
     // Preview replacement stays within the focused group — a preview parked in
-    // another group is left alone (the new tab appends instead).
+    // another group is left alone (the new tab gets a slot of its own instead).
     const previewIndex = prevState.rawTabs.findIndex(
       (t) =>
         !t.isPinned &&
@@ -1153,7 +1181,7 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
     }
 
     set({
-      rawTabs: [...prevState.rawTabs, newTab],
+      rawTabs: insertTab(prevState.rawTabs, newTab, opts?.index),
       activeTabId: tabId,
       groupOf: { ...prevState.groupOf, [tabId]: targetGroup },
     })
@@ -1169,7 +1197,7 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
     if (index >= 0) {
       const closingTab = prevState.rawTabs[index]
       if (options?.recordForReopen !== false) {
-        pushClosedTab(snapshotConversationTab(closingTab))
+        pushClosedTab(snapshotConversationTab(closingTab, index))
       }
       const next = prevState.rawTabs.filter((t) => t.id !== tabId)
       // A closing draft's composer text is scoped to that tab's key. Drop it —
@@ -1277,10 +1305,12 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
       return
     }
     const keepIds = new Set(keep.map((tab) => tab.id))
-    for (const tab of prevState.rawTabs) {
-      if (!keepIds.has(tab.id)) {
-        pushClosedTab(snapshotConversationTab(tab))
-      }
+    const closing = batchCloseSlots(
+      prevState.rawTabs,
+      (tab) => !keepIds.has(tab.id)
+    )
+    for (const [tab, slot] of closing) {
+      pushClosedTab(snapshotConversationTab(tab, slot))
     }
     set({ rawTabs: keep, activeTabId: tabId })
     recomputeTabs()
@@ -1292,8 +1322,8 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
       if (prevState.rawTabs.length === 0 && prevState.activeTabId == null) {
         return
       }
-      for (const tab of prevState.rawTabs) {
-        pushClosedTab(snapshotConversationTab(tab))
+      for (const [tab, slot] of batchCloseSlots(prevState.rawTabs)) {
+        pushClosedTab(snapshotConversationTab(tab, slot))
       }
       set({ rawTabs: [], activeTabId: null })
       recomputeTabs()
@@ -1306,8 +1336,8 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
       prevState.rawTabs.find((t) => t.id === prevState.activeTabId) ??
       prevState.rawTabs[0]
     const replacementTab = makeReplacementDraftTab(seedTab)
-    for (const tab of prevState.rawTabs) {
-      pushClosedTab(snapshotConversationTab(tab))
+    for (const [tab, slot] of batchCloseSlots(prevState.rawTabs)) {
+      pushClosedTab(snapshotConversationTab(tab, slot))
     }
     set({ rawTabs: [replacementTab], activeTabId: replacementTab.id })
     recomputeTabs()
@@ -1680,7 +1710,7 @@ export const useTabStore = create<TabStoreState>()((set, get) => ({
         agentTypeProvisional: provisional,
       }
       set({
-        rawTabs: [...prevState.rawTabs, newTab],
+        rawTabs: insertTab(prevState.rawTabs, newTab, options?.index),
         activeTabId: tabId,
         groupOf: { ...prevState.groupOf, [tabId]: targetGroup },
       })


### PR DESCRIPTION
Ctrl/Cmd+Shift+T brought a closed tab back at the end of the strip instead of where it had been.

The closed-tab entry now records the slot the tab was closed from, and reopening splices it back in there, clamped to the current strip length, the way a browser restores a tab. Close-others and close-all record each tab against the strip as it would be once the earlier ones are gone, so repeated reopens walk the strip back into its original order. Conversation, draft and file tabs all go through it; activation, the dedupe of an already-open conversation, the preview slot rule and the stack cap are unchanged.

Follow-up to #502.
