### PR TITLE
feat(tray): open saved remote workspaces

### DIFF
--- a/src-tauri/src/commands/remote_workspace.rs
+++ b/src-tauri/src/commands/remote_workspace.rs
@@ -118,29 +118,33 @@ pub async fn test_remote_workspace_connection(
 #[cfg(feature = "tauri-runtime")]
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
 pub async fn create_remote_workspace_connection(
+    app: AppHandle,
     db: tauri::State<'_, AppDatabase>,
     input: RemoteWorkspaceConnectionInput,
 ) -> Result<RemoteWorkspaceConnectionInfo, AppCommandError> {
     validate_remote_health(&input.base_url, &input.token, &input.headers).await?;
-    remote_workspace_connection_service::create(
+    let connection = remote_workspace_connection_service::create(
         &db.conn,
         &input.name,
         &input.base_url,
         &input.token,
         &input.headers,
     )
-    .await
+    .await?;
+    crate::commands::windows::remote_tray::refresh_saved_connections(&app).await;
+    Ok(connection)
 }
 
 #[cfg(feature = "tauri-runtime")]
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
 pub async fn update_remote_workspace_connection(
+    app: AppHandle,
     db: tauri::State<'_, AppDatabase>,
     id: i32,
     input: RemoteWorkspaceConnectionInput,
 ) -> Result<RemoteWorkspaceConnectionInfo, AppCommandError> {
     validate_remote_health(&input.base_url, &input.token, &input.headers).await?;
-    remote_workspace_connection_service::update(
+    let connection = remote_workspace_connection_service::update(
         &db.conn,
         id,
         &input.name,
@@ -148,27 +152,35 @@ pub async fn update_remote_workspace_connection(
         &input.token,
         &input.headers,
     )
-    .await
+    .await?;
+    crate::commands::windows::remote_tray::refresh_saved_connections(&app).await;
+    Ok(connection)
 }
 
 #[cfg(feature = "tauri-runtime")]
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
 pub async fn delete_remote_workspace_connection(
+    app: AppHandle,
     db: tauri::State<'_, AppDatabase>,
     id: i32,
 ) -> Result<(), AppCommandError> {
     remote_workspace_connection_service::delete(&db.conn, id)
         .await
-        .map_err(AppCommandError::db)
+        .map_err(AppCommandError::db)?;
+    crate::commands::windows::remote_tray::refresh_saved_connections(&app).await;
+    Ok(())
 }
 
 #[cfg(feature = "tauri-runtime")]
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
 pub async fn reorder_remote_workspace_connections(
+    app: AppHandle,
     db: tauri::State<'_, AppDatabase>,
     ids: Vec<i32>,
 ) -> Result<(), AppCommandError> {
-    remote_workspace_connection_service::reorder(&db.conn, ids).await
+    remote_workspace_connection_service::reorder(&db.conn, ids).await?;
+    crate::commands::windows::remote_tray::refresh_saved_connections(&app).await;
+    Ok(())
 }
 
 #[cfg(feature = "tauri-runtime")]
@@ -185,6 +197,9 @@ pub async fn open_remote_workspace(
 
     let label = format!("remote-workspace-{id}");
     if let Some(existing) = app.get_webview_window(&label) {
+        existing.show().map_err(|e| {
+            AppCommandError::window("Failed to show remote workspace", e.to_string())
+        })?;
         let _ = existing.unminimize();
         existing.set_focus().map_err(|e| {
             AppCommandError::window("Failed to focus remote workspace", e.to_string())

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -1914,6 +1914,8 @@ pub async fn update_appearance_mode(
     Ok(())
 }
 
+pub(crate) mod remote_tray;
+
 // ─── System tray icon ──────────────────────────────────────────────────
 
 /// Monochrome template image for the macOS menu bar. AppKit treats an
@@ -1979,6 +1981,7 @@ pub fn show_main_window(app: &AppHandle) {
 #[cfg(feature = "tauri-runtime")]
 struct TrayLabels {
     show_workspace: &'static str,
+    remote_workspaces: &'static str,
     quit: &'static str,
 }
 
@@ -1988,42 +1991,52 @@ fn tray_labels_for(locale: crate::models::system::AppLocale) -> TrayLabels {
     match locale {
         AppLocale::ZhCn => TrayLabels {
             show_workspace: "显示工作台",
+            remote_workspaces: "远程工作区",
             quit: "退出 Codeg",
         },
         AppLocale::ZhTw => TrayLabels {
             show_workspace: "顯示工作臺",
+            remote_workspaces: "遠端工作區",
             quit: "退出 Codeg",
         },
         AppLocale::Ja => TrayLabels {
             show_workspace: "ワークスペースを表示",
+            remote_workspaces: "リモートワークスペース",
             quit: "Codeg を終了",
         },
         AppLocale::Ko => TrayLabels {
             show_workspace: "워크스페이스 표시",
+            remote_workspaces: "원격 워크스페이스",
             quit: "Codeg 종료",
         },
         AppLocale::Es => TrayLabels {
             show_workspace: "Mostrar el área de trabajo",
+            remote_workspaces: "Áreas de trabajo remotas",
             quit: "Salir de Codeg",
         },
         AppLocale::De => TrayLabels {
             show_workspace: "Arbeitsbereich anzeigen",
+            remote_workspaces: "Remote-Arbeitsbereiche",
             quit: "Codeg beenden",
         },
         AppLocale::Fr => TrayLabels {
             show_workspace: "Afficher l'espace de travail",
+            remote_workspaces: "Espaces de travail distants",
             quit: "Quitter Codeg",
         },
         AppLocale::Pt => TrayLabels {
             show_workspace: "Mostrar área de trabalho",
+            remote_workspaces: "Áreas de trabalho remotas",
             quit: "Sair do Codeg",
         },
         AppLocale::Ar => TrayLabels {
             show_workspace: "إظهار مساحة العمل",
+            remote_workspaces: "مساحات العمل البعيدة",
             quit: "إنهاء Codeg",
         },
         AppLocale::En => TrayLabels {
             show_workspace: "Show Workspace",
+            remote_workspaces: "Remote Workspaces",
             quit: "Quit Codeg",
         },
     }
@@ -2039,22 +2052,10 @@ pub fn install_tray_icon(
     app: &AppHandle,
     locale: crate::models::system::AppLocale,
 ) -> tauri::Result<()> {
-    use tauri::menu::{MenuBuilder, MenuItem, PredefinedMenuItem};
     use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 
-    let labels = tray_labels_for(locale);
-    let show_item = MenuItem::with_id(
-        app,
-        TRAY_MENU_ID_SHOW,
-        labels.show_workspace,
-        true,
-        None::<&str>,
-    )?;
-    let separator = PredefinedMenuItem::separator(app)?;
-    let quit_item = MenuItem::with_id(app, TRAY_MENU_ID_QUIT, labels.quit, true, None::<&str>)?;
-    let menu = MenuBuilder::new(app)
-        .items(&[&show_item, &separator, &quit_item])
-        .build()?;
+    app.manage(remote_tray::RemoteTrayState::new(locale));
+    let menu = build_tray_menu(app, locale, &[])?;
 
     let mut builder = TrayIconBuilder::with_id(TRAY_ICON_ID)
         .tooltip("Codeg")
@@ -2104,23 +2105,21 @@ pub fn install_tray_icon(
         .build(app)?;
 
     TRAY_AVAILABLE.store(true, AtomicOrdering::Relaxed);
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        remote_tray::refresh_saved_connections(&app).await;
+    });
     Ok(())
 }
 
-/// Rebuild the tray menu in the supplied locale and swap it onto the
-/// existing tray icon. No-op if the tray hasn't been installed yet
-/// (e.g. the language change races setup, or the platform refused the
-/// initial install).
+/// Both startup and subsequent refreshes use the same menu structure.
 #[cfg(feature = "tauri-runtime")]
-pub fn refresh_tray_menu(
+fn build_tray_menu(
     app: &AppHandle,
     locale: crate::models::system::AppLocale,
-) -> tauri::Result<()> {
-    use tauri::menu::{MenuBuilder, MenuItem, PredefinedMenuItem};
-
-    let Some(tray) = app.tray_by_id(TRAY_ICON_ID) else {
-        return Ok(());
-    };
+    connections: &[remote_tray::RemoteTrayEntry],
+) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    use tauri::menu::{MenuBuilder, MenuItem, PredefinedMenuItem, Submenu};
 
     let labels = tray_labels_for(locale);
     let show_item = MenuItem::with_id(
@@ -2130,14 +2129,24 @@ pub fn refresh_tray_menu(
         true,
         None::<&str>,
     )?;
+    let mut builder = MenuBuilder::new(app).item(&show_item);
+    if !connections.is_empty() {
+        let submenu = Submenu::new(app, labels.remote_workspaces, true)?;
+        for connection in connections {
+            let item = MenuItem::with_id(
+                app,
+                connection.menu_id(),
+                connection.menu_label(),
+                true,
+                None::<&str>,
+            )?;
+            submenu.append(&item)?;
+        }
+        builder = builder.item(&submenu);
+    }
     let separator = PredefinedMenuItem::separator(app)?;
     let quit_item = MenuItem::with_id(app, TRAY_MENU_ID_QUIT, labels.quit, true, None::<&str>)?;
-    let menu = MenuBuilder::new(app)
-        .items(&[&show_item, &separator, &quit_item])
-        .build()?;
-
-    tray.set_menu(Some(menu))?;
-    Ok(())
+    builder.items(&[&separator, &quit_item]).build()
 }
 
 /// Push the current effective UI locale to the system tray. Called by
@@ -2149,8 +2158,7 @@ pub async fn set_tray_locale(
     app: AppHandle,
     locale: crate::models::system::AppLocale,
 ) -> Result<(), AppCommandError> {
-    refresh_tray_menu(&app, locale)
-        .map_err(|e| AppCommandError::window("Failed to refresh tray menu", e.to_string()))
+    remote_tray::refresh(&app, Some(locale)).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/windows/remote_tray.rs
+++ b/src-tauri/src/commands/windows/remote_tray.rs
@@ -1,0 +1,247 @@
+//! Saved remote workspaces in the native tray; no main webview is required.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use sea_orm::DatabaseConnection;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+
+use crate::app_error::AppCommandError;
+use crate::db::service::remote_workspace_connection_service;
+use crate::db::AppDatabase;
+use crate::models::system::AppLocale;
+
+const REMOTE_MENU_PREFIX: &str = "tray:remote:";
+
+pub(super) struct RemoteTrayState {
+    // Serialize the DB read and menu replacement, so an older snapshot cannot
+    // overwrite a newer save/reorder or language change.
+    locale: tokio::sync::Mutex<AppLocale>,
+    opening: Mutex<HashSet<i32>>,
+}
+
+impl RemoteTrayState {
+    pub(super) fn new(locale: AppLocale) -> Self {
+        Self {
+            locale: tokio::sync::Mutex::new(locale),
+            opening: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct RemoteTrayEntry {
+    id: i32,
+    pub(super) name: String,
+}
+
+impl RemoteTrayEntry {
+    pub(super) fn menu_id(&self) -> String {
+        format!("{REMOTE_MENU_PREFIX}{}", self.id)
+    }
+
+    pub(super) fn menu_label(&self) -> String {
+        // Native menus treat a single ampersand as a mnemonic marker.
+        self.name.replace('&', "&&")
+    }
+}
+
+fn connection_id(menu_id: &str) -> Option<i32> {
+    let raw = menu_id.strip_prefix(REMOTE_MENU_PREFIX)?;
+    if raw.is_empty() || !raw.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    raw.parse::<i32>().ok().filter(|id| *id > 0)
+}
+
+async fn load_entries(conn: &DatabaseConnection) -> Result<Vec<RemoteTrayEntry>, AppCommandError> {
+    Ok(remote_workspace_connection_service::list(conn)
+        .await
+        .map_err(AppCommandError::db)?
+        .into_iter()
+        .map(|connection| RemoteTrayEntry {
+            id: connection.id,
+            name: connection.name,
+        })
+        .collect())
+}
+
+pub(crate) async fn refresh(
+    app: &AppHandle,
+    locale: Option<AppLocale>,
+) -> Result<(), AppCommandError> {
+    let Some(tray) = app.tray_by_id(super::TRAY_ICON_ID) else {
+        return Ok(());
+    };
+    let state = app.state::<RemoteTrayState>();
+    let mut current_locale = state.locale.lock().await;
+    if let Some(locale) = locale {
+        *current_locale = locale;
+    }
+    let db = app.state::<AppDatabase>();
+    let entries = load_entries(&db.conn).await?;
+    let menu = super::build_tray_menu(app, *current_locale, &entries)
+        .map_err(|e| AppCommandError::window("Failed to refresh tray menu", e.to_string()))?;
+    tray.set_menu(Some(menu))
+        .map_err(|e| AppCommandError::window("Failed to refresh tray menu", e.to_string()))
+}
+
+/// A committed save must still report success if a native menu update fails.
+pub(crate) async fn refresh_saved_connections(app: &AppHandle) {
+    if let Err(error) = refresh(app, None).await {
+        tracing::warn!(
+            "[Tray] failed to refresh remote workspaces: {}",
+            error.message
+        );
+    }
+}
+
+pub(crate) fn handle_menu_event(app: &AppHandle, menu_id: &str) {
+    let Some(id) = connection_id(menu_id) else {
+        return;
+    };
+    let state = app.state::<RemoteTrayState>();
+    // Health checks may take several seconds. Ignore another click for this
+    // connection until its first open finishes, but allow other connections.
+    if !state.opening.lock().unwrap().insert(id) {
+        return;
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let result = crate::commands::remote_workspace::open_remote_workspace(
+            app.clone(),
+            app.state::<AppDatabase>(),
+            id,
+        )
+        .await;
+        app.state::<RemoteTrayState>()
+            .opening
+            .lock()
+            .unwrap()
+            .remove(&id);
+        if let Err(error) = result {
+            // The main window can be hidden, so a webview toast is insufficient.
+            app.dialog()
+                .message(error.message)
+                .title("Codeg")
+                .kind(MessageDialogKind::Error)
+                .show(|_| {});
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_menu_ids_round_trip_independently_of_names() {
+        for id in [1, 42, i32::MAX] {
+            let entry = RemoteTrayEntry {
+                id,
+                name: "开发机: staging & production".into(),
+            };
+            assert_eq!(connection_id(&entry.menu_id()), Some(id));
+        }
+    }
+
+    #[test]
+    fn saved_names_escape_native_menu_mnemonics() {
+        let entry = RemoteTrayEntry {
+            id: 1,
+            name: "R&D && 开发".into(),
+        };
+        assert_eq!(entry.menu_label(), "R&&D &&&& 开发");
+    }
+
+    #[test]
+    fn unrelated_and_malformed_menu_ids_do_not_open_connections() {
+        for id in [
+            "tray:show",
+            "tray:quit",
+            "pet:remote:1",
+            "tray:remote:",
+            "tray:remote:0",
+            "tray:remote:-1",
+            "tray:remote:+1",
+            "tray:remote:1:2",
+            "tray:remote:2147483648",
+            "tray:remote: 1",
+        ] {
+            assert_eq!(connection_id(id), None, "{id}");
+        }
+    }
+
+    #[tokio::test]
+    async fn saved_entries_follow_database_names_order_and_deletion() {
+        let db = crate::db::test_helpers::fresh_in_memory_db().await;
+        assert!(load_entries(&db.conn).await.unwrap().is_empty());
+        let first = remote_workspace_connection_service::create(
+            &db.conn,
+            "开发机",
+            "http://localhost:3080",
+            "first-token",
+            &[],
+        )
+        .await
+        .unwrap();
+        // Identical display names must still route to distinct connections.
+        let second = remote_workspace_connection_service::create(
+            &db.conn,
+            "开发机",
+            "http://localhost:3081",
+            "second-token",
+            &[],
+        )
+        .await
+        .unwrap();
+        let entries = load_entries(&db.conn).await.unwrap();
+        assert_eq!(
+            entries.iter().map(|e| e.id).collect::<Vec<_>>(),
+            [first.id, second.id]
+        );
+        assert_ne!(entries[0].menu_id(), entries[1].menu_id());
+
+        remote_workspace_connection_service::update(
+            &db.conn,
+            first.id,
+            "Production",
+            "http://localhost:3080",
+            "new-token",
+            &[],
+        )
+        .await
+        .unwrap();
+        remote_workspace_connection_service::reorder(&db.conn, vec![second.id, first.id])
+            .await
+            .unwrap();
+        assert_eq!(
+            load_entries(&db.conn).await.unwrap(),
+            vec![
+                RemoteTrayEntry {
+                    id: second.id,
+                    name: "开发机".into()
+                },
+                RemoteTrayEntry {
+                    id: first.id,
+                    name: "Production".into()
+                },
+            ]
+        );
+        remote_workspace_connection_service::delete(&db.conn, second.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_entries(&db.conn).await.unwrap(),
+            vec![RemoteTrayEntry {
+                id: first.id,
+                name: "Production".into()
+            },]
+        );
+        remote_workspace_connection_service::delete(&db.conn, first.id)
+            .await
+            .unwrap();
+        assert!(load_entries(&db.conn).await.unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1000,13 +1000,13 @@ mod tauri_app {
                 let id = event.id().as_ref().to_string();
 
                 // Tray menu items act in Rust directly: showing the
-                // workspace and quitting are both pure runtime concerns
-                // with no UI state to coordinate.
+                // workspace, opening a saved remote connection, and quitting do
+                // not need a visible main webview.
                 if id.starts_with(windows::TRAY_MENU_ID_PREFIX) {
                     match id.as_str() {
                         windows::TRAY_MENU_ID_SHOW => windows::show_main_window(app),
                         windows::TRAY_MENU_ID_QUIT => app.exit(0),
-                        _ => {}
+                        _ => windows::remote_tray::handle_menu_event(app, &id),
                     }
                     return;
                 }


### PR DESCRIPTION
Saved remote workspaces can now be opened from a **Remote Workspaces** tray submenu while the main window is hidden. Entries follow the saved names and ordering, and refresh after creating, editing, deleting, or reordering connections and after language changes. The submenu is omitted when no connections are saved.

Tray clicks reuse the existing remote-workspace opening command, including its health/authentication checks and window identity. Existing hidden or minimized windows are restored and focused. Repeated tray clicks for a connection are ignored while its first open is pending, and failures appear in a native dialog even when the main webview is hidden. Connection names containing ampersands are escaped for native menus.

Closes #674.

Validation:
- Desktop library: 3,529 tests passed, 1 ignored, including four new tests for menu IDs, name escaping, and saved-connection create/update/reorder/delete behavior against an in-memory SQLite database.
- `cargo clippy --all-targets --features test-utils -- -D warnings` passed.
- `cargo check --no-default-features --bin codeg-server` passed.
- Frontend static export build passed.

Tests ran on Linux/WSL. The library test build used `--config profile.test.package.codeg.debug=0` to reduce memory use. Native Windows/macOS tray interaction has not been manually verified.
