### PR TITLE
feat(sidebar): paginate folder conversations

### DIFF
--- a/docs/superpowers/plans/2026-09-07-folder-conversation-pagination.md
+++ b/docs/superpowers/plans/2026-09-07-folder-conversation-pagination.md
@@ -1,0 +1,414 @@
+# Folder Conversation Pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show folder conversations six at a time, reveal six more per click,
+and reset a folder to six when it is collapsed.
+
+**Architecture:** Keep all conversation data loaded and sorted as it is today.
+Extend the pure sidebar row builder with a folder-scoped footer row and pass it
+a session-only visible-count map from `SidebarConversationList`; this preserves
+the existing `virtua` row indexes, sticky headers, and folder/worktree nesting.
+
+**Tech Stack:** React 19, TypeScript strict mode, Next.js 16, next-intl,
+Vitest, Testing Library, Tailwind CSS v4, Lucide React, virtua.
+
+## Global Constraints
+
+- The folder page size is exactly 6 conversations.
+- Each load-more click reveals exactly 6 additional conversations for only the
+  clicked folder.
+- Collapsing a folder resets only that folder to the first 6 conversations.
+- Collapsing all folders clears all folder pagination state.
+- Existing folder sort order remains authoritative, including its current
+  newest-first behavior.
+- Delegation children remain attached to their visible parent and do not consume
+  page slots.
+- Pinned, Chat, and Recent sections retain their existing behavior.
+- Visible counts are session-only and are not written to local storage or the
+  backend.
+- No dependencies or backend APIs are added.
+
+---
+
+## File Structure
+
+- `src/components/conversations/sidebar-conversation-grouping.ts`: defines the
+  page size, folder footer row type, and pure row slicing behavior.
+- `src/components/conversations/sidebar-conversation-grouping.test.ts`: verifies
+  the pure row model independently of React rendering.
+- `src/components/conversations/sidebar-conversation-list.tsx`: owns per-folder
+  visible counts, resets them on folder collapse, and renders the footer button.
+- `src/components/conversations/sidebar-conversation-list.test.tsx`: verifies
+  the complete click, completion, collapse, and reopen flow.
+- `src/i18n/messages/{ar,de,en,es,fr,ja,ko,pt,zh-CN,zh-TW}.json`: provides the
+  localized folder load-more label.
+
+### Task 1: Implement Folder Conversation Pagination End To End
+
+**Files:**
+
+- Modify: `src/components/conversations/sidebar-conversation-grouping.test.ts`
+- Modify: `src/components/conversations/sidebar-conversation-grouping.ts`
+- Modify: `src/components/conversations/sidebar-conversation-list.test.tsx`
+- Modify: `src/components/conversations/sidebar-conversation-list.tsx`
+- Modify: `src/i18n/messages/ar.json`
+- Modify: `src/i18n/messages/de.json`
+- Modify: `src/i18n/messages/en.json`
+- Modify: `src/i18n/messages/es.json`
+- Modify: `src/i18n/messages/fr.json`
+- Modify: `src/i18n/messages/ja.json`
+- Modify: `src/i18n/messages/ko.json`
+- Modify: `src/i18n/messages/pt.json`
+- Modify: `src/i18n/messages/zh-CN.json`
+- Modify: `src/i18n/messages/zh-TW.json`
+
+**Interfaces:**
+
+- Consumes: already sorted `byFolder: Map<number, DbConversationSummary[]>`.
+- Produces: `FOLDER_CONVERSATION_PAGE_SIZE = 6`,
+  `FolderMoreRow`, and the optional
+  `folderConversationLimits?: Readonly<Record<number, number>>` argument on
+  `buildRows`.
+- `FolderMoreRow` has exact shape
+  `{ kind: "folder-more"; folderId: number; depth: number; remaining: number }`.
+- Produces the `Folder.sidebar.loadMoreFolderConversations` translation key.
+
+- [ ] **Step 1: Write the failing pure row-model test**
+
+Update `folderRows` in
+`src/components/conversations/sidebar-conversation-grouping.test.ts` so its last
+parameters and `buildRows` call are:
+
+```typescript
+function folderRows(
+  orderedFolderIds: number[],
+  byFolder: Map<number, DbConversationSummary[]>,
+  folderExpanded: Record<number, boolean>,
+  folderTotalCounts: Map<number, number>,
+  foldersExpanded = true,
+  folderConversationLimits: Readonly<Record<number, number>> = {}
+): SidebarRow[] {
+  const rows = buildRows({
+    pinned: [],
+    pinnedExpanded: true,
+    orderedFolderIds,
+    byFolder,
+    folderExpanded,
+    folderTotalCounts,
+    foldersExpanded,
+    chatConversations: [],
+    chatsExpanded: true,
+    folderConversationLimits,
+  })
+  const chatsIdx = rows.findIndex(
+    (r) => r.kind === "section" && r.section === "chats"
+  )
+  return chatsIdx === -1 ? rows : rows.slice(0, chatsIdx)
+}
+```
+
+Add this test inside `describe("buildRows")`:
+
+```typescript
+it("pages each folder independently in batches of six", () => {
+  const conversations = Array.from({ length: 13 }, (_, i) => conv(i + 1, 10))
+  const byFolder = new Map([[10, conversations]])
+  const counts = new Map([[10, conversations.length]])
+
+  const initial = folderRows([10], byFolder, { 10: true }, counts)
+  expect(initial.filter((row) => row.kind === "conversation")).toHaveLength(6)
+  expect(initial.at(-1)).toEqual({
+    kind: "folder-more",
+    folderId: 10,
+    depth: 0,
+    remaining: 7,
+  })
+
+  const nextPage = folderRows(
+    [10],
+    byFolder,
+    { 10: true },
+    counts,
+    true,
+    { 10: 12 }
+  )
+  expect(nextPage.filter((row) => row.kind === "conversation")).toHaveLength(
+    12
+  )
+  expect(nextPage.at(-1)).toEqual({
+    kind: "folder-more",
+    folderId: 10,
+    depth: 0,
+    remaining: 1,
+  })
+})
+```
+
+- [ ] **Step 2: Write the failing component interaction test**
+
+Add this describe block to
+`src/components/conversations/sidebar-conversation-list.test.tsx`:
+
+```typescript
+describe("SidebarConversationList - folder conversation paging", () => {
+  const folderConversationCount = () =>
+    document.querySelectorAll("[data-conversation-id]").length
+  const loadMoreButton = () =>
+    Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Load more")
+    )
+  const folderToggle = () =>
+    document.querySelector<HTMLButtonElement>(
+      '[data-folder-id="1"][aria-expanded]'
+    )
+
+  beforeEach(() => {
+    localStorage.clear()
+    const folders = [folder(1, "Repo")]
+    useAppWorkspaceStore.setState({
+      folders,
+      allFolders: folders,
+      conversations: Array.from({ length: 13 }, (_, i) => conv(i + 1, 1)),
+    })
+  })
+
+  it("reveals six at a time and resets after the folder is collapsed", () => {
+    render(tree())
+
+    expect(folderConversationCount()).toBe(6)
+    expect(loadMoreButton()?.textContent).toContain("7")
+
+    act(() => fireEvent.click(loadMoreButton()!))
+    expect(folderConversationCount()).toBe(12)
+    expect(loadMoreButton()?.textContent).toContain("1")
+
+    act(() => fireEvent.click(loadMoreButton()!))
+    expect(folderConversationCount()).toBe(13)
+    expect(loadMoreButton()).toBeUndefined()
+
+    act(() => fireEvent.click(folderToggle()!))
+    expect(folderConversationCount()).toBe(0)
+
+    act(() => fireEvent.click(folderToggle()!))
+    expect(folderConversationCount()).toBe(6)
+    expect(loadMoreButton()?.textContent).toContain("7")
+  })
+})
+```
+
+- [ ] **Step 3: Run both focused tests and verify RED before production edits**
+
+Run:
+
+```bash
+pnpm test src/components/conversations/sidebar-conversation-grouping.test.ts src/components/conversations/sidebar-conversation-list.test.tsx
+```
+
+Expected: both new tests FAIL because all 13 folder conversations are emitted;
+the initial visible count is 13 instead of 6.
+
+- [ ] **Step 4: Add folder pagination to the pure row model**
+
+Near `RECENT_PAGE_SIZE` in
+`src/components/conversations/sidebar-conversation-grouping.ts`, add:
+
+```typescript
+export const FOLDER_CONVERSATION_PAGE_SIZE = 6
+
+const EMPTY_FOLDER_CONVERSATION_LIMITS: Readonly<Record<number, number>> = {}
+```
+
+Near the other folder row interfaces, add:
+
+```typescript
+export interface FolderMoreRow {
+  kind: "folder-more"
+  folderId: number
+  depth: number
+  remaining: number
+}
+```
+
+Add `FolderMoreRow` to the `SidebarRow` union. Add this optional `buildRows`
+input after `folderTotalCounts`:
+
+```typescript
+folderConversationLimits?: Readonly<Record<number, number>>
+```
+
+Destructure it with the shared empty default:
+
+```typescript
+folderConversationLimits = EMPTY_FOLDER_CONVERSATION_LIMITS,
+```
+
+Replace the conversation loop in `pushFolderBody` with:
+
+```typescript
+const limit = Math.max(
+  0,
+  folderConversationLimits[folderId] ?? FOLDER_CONVERSATION_PAGE_SIZE
+)
+const shown = convs.slice(0, limit)
+for (const conv of shown) {
+  pushConversationRow(
+    rows,
+    conv,
+    baseDepth,
+    conversationExpanded,
+    childrenByParent,
+    childrenLoading
+  )
+}
+const remaining = convs.length - shown.length
+if (remaining > 0) {
+  rows.push({
+    kind: "folder-more",
+    folderId,
+    depth: baseDepth,
+    remaining,
+  })
+}
+```
+
+The slice occurs before `pushConversationRow`, so expanded delegation children
+stay attached to a visible parent without consuming a top-level page slot.
+
+- [ ] **Step 5: Add per-folder state, increment, and reset actions**
+
+Import `FOLDER_CONVERSATION_PAGE_SIZE` from
+`./sidebar-conversation-grouping`. Near the existing `recentLimit` state in
+`src/components/conversations/sidebar-conversation-list.tsx`, add:
+
+```typescript
+const [folderConversationLimits, setFolderConversationLimits] = useState<
+  Record<number, number>
+>({})
+const revealMoreFolderConversations = useCallback((folderId: number) => {
+  setFolderConversationLimits((prev) => ({
+    ...prev,
+    [folderId]:
+      (prev[folderId] ?? FOLDER_CONVERSATION_PAGE_SIZE) +
+      FOLDER_CONVERSATION_PAGE_SIZE,
+  }))
+}, [])
+const resetFolderConversationLimit = useCallback((folderId: number) => {
+  setFolderConversationLimits((prev) => {
+    if (prev[folderId] == null) return prev
+    const next = { ...prev }
+    delete next[folderId]
+    return next
+  })
+}, [])
+```
+
+Call `resetFolderConversationLimit(folderId)` at the start of both
+`toggleFolder` and `toggleRootGroup`, and add the callback to their dependency
+arrays. In `collapseAll`, clear every folder limit with:
+
+```typescript
+setFolderConversationLimits({})
+```
+
+Pass `folderConversationLimits` into `buildRows` and add it to the row
+`useMemo` dependency list.
+
+- [ ] **Step 6: Render the folder footer and add its unique key**
+
+Add this branch in `renderRow` before the Recent footer branch:
+
+```tsx
+if (row.kind === "folder-more") {
+  const railLeft = `calc(var(--conv-rail-axis, 0.875rem) + ${row.depth} * ${CONV_RAIL_DEPTH_STEP})`
+  return (
+    <div className="relative h-[2rem]">
+      <button
+        type="button"
+        onClick={() => revealMoreFolderConversations(row.folderId)}
+        className="relative flex h-[1.9375rem] w-full items-center rounded-full pr-[0.25rem] text-left text-[0.75rem] text-muted-foreground/80 outline-none transition-colors duration-[120ms] hover:bg-[color-mix(in_oklab,var(--sidebar-accent),var(--sidebar-foreground)_2%)] hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+        style={{
+          paddingLeft: `calc(var(--conv-rail-axis, 0.875rem) + ${row.depth} * ${CONV_RAIL_DEPTH_STEP} + 0.875rem)`,
+        }}
+      >
+        <span
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 flex h-[0.875rem] w-[0.875rem] -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+          style={{ left: railLeft }}
+        >
+          <ChevronDown className="h-[0.75rem] w-[0.75rem]" />
+        </span>
+        <span className="truncate">
+          {t("loadMoreFolderConversations", { count: row.remaining })}
+        </span>
+      </button>
+    </div>
+  )
+}
+```
+
+Add this branch to `rowKey`:
+
+```typescript
+if (row.kind === "folder-more") return `foldermore-${row.folderId}`
+```
+
+- [ ] **Step 7: Add the localized label to all ten message files**
+
+Add `loadMoreFolderConversations` beside `showMoreRecent` under
+`Folder.sidebar` with these exact values:
+
+```text
+ar.json:    "تحميل المزيد ({count})"
+de.json:    "Mehr laden ({count})"
+en.json:    "Load more ({count})"
+es.json:    "Cargar más ({count})"
+fr.json:    "Charger plus ({count})"
+ja.json:    "さらに読み込む（{count}）"
+ko.json:    "더 불러오기 ({count})"
+pt.json:    "Carregar mais ({count})"
+zh-CN.json: "加载更多（{count}）"
+zh-TW.json: "載入更多（{count}）"
+```
+
+- [ ] **Step 8: Run the focused suites and verify GREEN**
+
+Run:
+
+```bash
+pnpm test src/components/conversations/sidebar-conversation-grouping.test.ts src/components/conversations/sidebar-conversation-list.test.tsx
+```
+
+Expected: PASS with both files green.
+
+- [ ] **Step 9: Run frontend regression verification**
+
+Run each command separately:
+
+```bash
+pnpm eslint src/components/conversations/sidebar-conversation-grouping.ts src/components/conversations/sidebar-conversation-grouping.test.ts src/components/conversations/sidebar-conversation-list.tsx src/components/conversations/sidebar-conversation-list.test.tsx
+pnpm test
+pnpm build
+```
+
+Expected: ESLint exits 0, all Vitest suites pass, and Next.js completes the
+static export build.
+
+- [ ] **Step 10: Review and commit the completed feature**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only the planned source, test, and locale
+files are modified.
+
+Commit:
+
+```bash
+git add src/components/conversations/sidebar-conversation-grouping.ts src/components/conversations/sidebar-conversation-grouping.test.ts src/components/conversations/sidebar-conversation-list.tsx src/components/conversations/sidebar-conversation-list.test.tsx src/i18n/messages/ar.json src/i18n/messages/de.json src/i18n/messages/en.json src/i18n/messages/es.json src/i18n/messages/fr.json src/i18n/messages/ja.json src/i18n/messages/ko.json src/i18n/messages/pt.json src/i18n/messages/zh-CN.json src/i18n/messages/zh-TW.json
+git commit -m "feat(sidebar): load folder conversations in batches"
+```

--- a/docs/superpowers/specs/2026-09-07-folder-conversation-pagination-design.md
+++ b/docs/superpowers/specs/2026-09-07-folder-conversation-pagination-design.md
@@ -1,0 +1,74 @@
+# Folder Conversation Pagination Design
+
+## Goal
+
+Keep expanded folders manageable by showing only their six newest conversations
+at first. A footer inside each folder reveals six more conversations per click.
+Collapsing a folder resets that folder so its next expansion starts at six again.
+
+This applies only to conversations in the Folders section. Pinned, Chat, and
+Recent retain their existing behavior.
+
+## Approach
+
+Extend the existing flattened sidebar row model rather than hiding rendered DOM
+rows or paging data at the backend. `buildRows` already owns folder expansion,
+conversation order, worktree nesting, and virtual-list row generation, so it is
+the narrowest layer that can preserve correct row indexes and sticky headers.
+
+The sidebar component will hold a session-only visible-count map keyed by folder
+ID. An absent entry means the initial page size of six. `buildRows` will receive
+that map, slice each already-sorted folder bucket to its visible count, and emit
+a folder-scoped load-more row when conversations remain.
+
+## Interaction
+
+- An expanded folder initially shows its first six conversations in the existing
+  sort order. The current newest-first sorting behavior is unchanged.
+- A `Load more` row appears immediately after the visible conversations when the
+  folder contains more than six conversations.
+- Each click increases only that folder's visible count by six.
+- The footer disappears after the last conversation becomes visible.
+- Changing a folder from expanded to collapsed removes its visible-count entry.
+  Reopening it therefore returns to the default six conversations.
+- Folder-group collapse does not reset member folders because the requested
+  reset gesture is the folder header itself.
+- Pinned, Chat, and Recent sections are not changed.
+
+Delegation children remain attached to their visible parent conversation and do
+not consume a folder page slot. Worktree and root sub-groups use their actual
+folder IDs, so their pagination state remains independent.
+
+## Row Model And Rendering
+
+Add a folder load-more row variant containing the owning folder ID and the
+number of hidden top-level conversations. Its row key includes the folder ID so
+multiple expanded folders can each render a footer without key collisions.
+
+The footer uses the existing sidebar row height, indentation, hover treatment,
+and a Lucide down-chevron. A new localized label is added to all supported
+message files. The action remains keyboard-accessible through a native button.
+
+## State And Data Flow
+
+1. Conversation selectors continue to sort and group all summaries in memory.
+2. The sidebar passes per-folder visible counts into `buildRows`.
+3. `buildRows` emits at most the requested number of top-level conversations for
+   each expanded folder, followed by a footer when more remain.
+4. Clicking the footer increments that folder's count and rebuilds the flat row
+   array.
+5. Collapsing a folder deletes its count before rebuilding the rows.
+
+The visible-count map is not persisted. Reloading the application also returns
+all folders to six, matching the transient nature of a load-more gesture.
+
+## Verification
+
+Pure row-model tests will verify that a folder with more than six conversations
+emits six rows plus a footer and that increasing its count emits the next batch.
+
+A component interaction test will verify the complete flow: six visible rows,
+then twelve, then all remaining rows with no footer, followed by folder collapse
+and re-expansion returning to six. Existing tests ensure that pinned, Chat,
+Recent, sticky-header, worktree, and virtual-list behavior does not regress.
+

--- a/docs/superpowers/specs/2026-09-07-folder-conversation-pagination-design.md
+++ b/docs/superpowers/specs/2026-09-07-folder-conversation-pagination-design.md
@@ -71,4 +71,3 @@ A component interaction test will verify the complete flow: six visible rows,
 then twelve, then all remaining rows with no footer, followed by folder collapse
 and re-expansion returning to six. Existing tests ensure that pinned, Chat,
 Recent, sticky-header, worktree, and virtual-list behavior does not regress.
-

--- a/src/components/conversations/sidebar-conversation-grouping.test.ts
+++ b/src/components/conversations/sidebar-conversation-grouping.test.ts
@@ -379,6 +379,87 @@ describe("buildRows", () => {
     })
   })
 
+  it("keeps each folder's conversation limit independent", () => {
+    const first = Array.from({ length: 13 }, (_, i) => conv(i + 1, 10))
+    const second = Array.from({ length: 8 }, (_, i) => conv(i + 101, 20))
+    const rows = folderRows(
+      [10, 20],
+      new Map([
+        [10, first],
+        [20, second],
+      ]),
+      { 10: true, 20: true },
+      new Map([
+        [10, first.length],
+        [20, second.length],
+      ]),
+      true,
+      { 10: 12 }
+    )
+
+    expect(
+      rows.filter(
+        (row) =>
+          row.kind === "conversation" && row.conversation.folder_id === 10
+      )
+    ).toHaveLength(12)
+    expect(
+      rows.filter(
+        (row) =>
+          row.kind === "conversation" && row.conversation.folder_id === 20
+      )
+    ).toHaveLength(6)
+    expect(rows).toContainEqual({
+      kind: "folder-more",
+      folderId: 10,
+      depth: 0,
+      remaining: 1,
+    })
+    expect(rows).toContainEqual({
+      kind: "folder-more",
+      folderId: 20,
+      depth: 0,
+      remaining: 2,
+    })
+  })
+
+  it("keeps expanded delegation children attached without using a folder page slot", () => {
+    const parent = conv(1, 10, { child_count: 1 })
+    const child = conv(100, 10, { parent_id: 1 })
+    const roots = [
+      parent,
+      ...Array.from({ length: 6 }, (_, i) => conv(i + 2, 10)),
+    ]
+    const rows = buildRows({
+      pinned: [],
+      pinnedExpanded: true,
+      orderedFolderIds: [10],
+      byFolder: new Map([[10, roots]]),
+      folderExpanded: { 10: true },
+      folderTotalCounts: new Map([[10, roots.length]]),
+      foldersExpanded: true,
+      chatConversations: [],
+      chatsExpanded: true,
+      conversationExpanded: new Set([parent.id]),
+      childrenByParent: new Map([[parent.id, [child]]]),
+    })
+
+    expect(
+      rows.filter((row) => row.kind === "conversation" && row.depth === 0)
+    ).toHaveLength(6)
+    expect(rows).toContainEqual({
+      kind: "conversation",
+      conversation: child,
+      depth: 1,
+    })
+    expect(rows).toContainEqual({
+      kind: "folder-more",
+      folderId: 10,
+      depth: 0,
+      remaining: 1,
+    })
+  })
+
   it("emits a Folders section header above the folder rows", () => {
     const byFolder = new Map([[10, [conv(1, 10)]]])
     const rows = folderRows([10], byFolder, { 10: true }, new Map([[10, 1]]))

--- a/src/components/conversations/sidebar-conversation-grouping.test.ts
+++ b/src/components/conversations/sidebar-conversation-grouping.test.ts
@@ -330,7 +330,8 @@ describe("buildRows", () => {
     byFolder: Map<number, DbConversationSummary[]>,
     folderExpanded: Record<number, boolean>,
     folderTotalCounts: Map<number, number>,
-    foldersExpanded = true
+    foldersExpanded = true,
+    folderConversationLimits: Readonly<Record<number, number>> = {}
   ): SidebarRow[] {
     const rows = buildRows({
       pinned: [],
@@ -342,12 +343,41 @@ describe("buildRows", () => {
       foldersExpanded,
       chatConversations: [],
       chatsExpanded: true,
+      folderConversationLimits,
     })
     const chatsIdx = rows.findIndex(
       (r) => r.kind === "section" && r.section === "chats"
     )
     return chatsIdx === -1 ? rows : rows.slice(0, chatsIdx)
   }
+
+  it("pages each folder independently in batches of six", () => {
+    const conversations = Array.from({ length: 13 }, (_, i) => conv(i + 1, 10))
+    const byFolder = new Map([[10, conversations]])
+    const counts = new Map([[10, conversations.length]])
+
+    const initial = folderRows([10], byFolder, { 10: true }, counts)
+    expect(initial.filter((row) => row.kind === "conversation")).toHaveLength(6)
+    expect(initial.at(-1)).toEqual({
+      kind: "folder-more",
+      folderId: 10,
+      depth: 0,
+      remaining: 7,
+    })
+
+    const nextPage = folderRows([10], byFolder, { 10: true }, counts, true, {
+      10: 12,
+    })
+    expect(nextPage.filter((row) => row.kind === "conversation")).toHaveLength(
+      12
+    )
+    expect(nextPage.at(-1)).toEqual({
+      kind: "folder-more",
+      folderId: 10,
+      depth: 0,
+      remaining: 1,
+    })
+  })
 
   it("emits a Folders section header above the folder rows", () => {
     const byFolder = new Map([[10, [conv(1, 10)]]])

--- a/src/components/conversations/sidebar-conversation-grouping.ts
+++ b/src/components/conversations/sidebar-conversation-grouping.ts
@@ -19,6 +19,9 @@ import {
 // (not in the list component) because `buildRows` needs it to tell an untouched
 // first page from an expanded one.
 export const RECENT_PAGE_SIZE = 15
+export const FOLDER_CONVERSATION_PAGE_SIZE = 6
+
+const EMPTY_FOLDER_CONVERSATION_LIMITS: Readonly<Record<number, number>> = {}
 
 export function parseTimestamp(value: string): number {
   const timestamp = Date.parse(value)
@@ -868,6 +871,13 @@ export interface FolderHeaderRow {
   folderId: number
 }
 
+export interface FolderMoreRow {
+  kind: "folder-more"
+  folderId: number
+  depth: number
+  remaining: number
+}
+
 /**
  * The "root" sub-group header shown (only under "Show worktrees") directly below
  * a repo CONTAINER header: it groups the repo's OWN (non-worktree) conversations
@@ -1040,6 +1050,7 @@ export type SidebarRow =
   | FolderGroupHeaderRow
   | GroupEmptyRow
   | FolderHeaderRow
+  | FolderMoreRow
   | RootGroupHeaderRow
   | ConversationRow
   | EmptyHintRow
@@ -1201,6 +1212,7 @@ export function buildRows(args: {
   byFolder: Map<number, DbConversationSummary[]>
   folderExpanded: Record<number, boolean>
   folderTotalCounts: Map<number, number>
+  folderConversationLimits?: Readonly<Record<number, number>>
   foldersExpanded: boolean
   chatConversations: readonly DbConversationSummary[]
   chatsExpanded: boolean
@@ -1271,6 +1283,7 @@ export function buildRows(args: {
     byFolder,
     folderExpanded,
     folderTotalCounts,
+    folderConversationLimits = EMPTY_FOLDER_CONVERSATION_LIMITS,
     foldersExpanded,
     chatConversations,
     chatsExpanded,
@@ -1329,7 +1342,12 @@ export function buildRows(args: {
       })
       return
     }
-    for (const conv of convs) {
+    const limit = Math.max(
+      0,
+      folderConversationLimits[folderId] ?? FOLDER_CONVERSATION_PAGE_SIZE
+    )
+    const shown = convs.slice(0, limit)
+    for (const conv of shown) {
       pushConversationRow(
         rows,
         conv,
@@ -1338,6 +1356,15 @@ export function buildRows(args: {
         childrenByParent,
         childrenLoading
       )
+    }
+    const remaining = convs.length - shown.length
+    if (remaining > 0) {
+      rows.push({
+        kind: "folder-more",
+        folderId,
+        depth: baseDepth,
+        remaining,
+      })
     }
   }
 

--- a/src/components/conversations/sidebar-conversation-list.test.tsx
+++ b/src/components/conversations/sidebar-conversation-list.test.tsx
@@ -805,6 +805,48 @@ describe("SidebarConversationList — scrollToActive across a worktree merge", (
   })
 })
 
+describe("SidebarConversationList — scrollToActive folder pagination", () => {
+  beforeEach(() => {
+    localStorage.clear()
+    const folders = [folder(1, "Repo")]
+    useAppWorkspaceStore.setState({
+      folders,
+      allFolders: folders,
+      conversations: Array.from({ length: 13 }, (_, i) => conv(i + 1, 1)),
+    })
+    store.activeTabId = "tab-7"
+    store.tabSpec = [
+      {
+        id: "tab-7",
+        conversationId: 7,
+        agentType: "claude_code",
+        folderId: 1,
+        title: "conv-7",
+        isPinned: false,
+      },
+    ]
+  })
+
+  it("reveals a paged folder conversation before scrolling to it", () => {
+    const ref = createRef<SidebarConversationListHandle>()
+    render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <SidebarConversationList showCompleted sortMode="created" ref={ref} />
+      </NextIntlClientProvider>
+    )
+
+    expect(document.querySelector('[data-conversation-id="7"]')).toBeNull()
+    expect(virtuaCtl.scrollToIndex).not.toHaveBeenCalled()
+
+    act(() => {
+      ref.current?.scrollToActive()
+    })
+
+    expect(document.querySelector('[data-conversation-id="7"]')).not.toBeNull()
+    expect(virtuaCtl.scrollToIndex).toHaveBeenCalled()
+  })
+})
+
 describe("SidebarConversationList — folder ⋯ opens the same menu as right-click", () => {
   beforeEach(() => {
     probes.card = 0

--- a/src/components/conversations/sidebar-conversation-list.test.tsx
+++ b/src/components/conversations/sidebar-conversation-list.test.tsx
@@ -1170,11 +1170,12 @@ describe("SidebarConversationList — Recent section", () => {
     const PAGE = 15
     const TOTAL = PAGE + 4
 
-    // Recent duplicates every canonical row, so total cards = canonical + recent
-    // slice. Counting the Recent slice alone keeps the assertions readable.
+    // Folder conversations now render their own first page (six rows), so total
+    // cards = visible canonical rows + Recent slice. Counting the Recent slice
+    // alone keeps the assertions readable.
     const recentRowCount = () =>
       Array.from(document.querySelectorAll("[data-conversation-id]")).length -
-      TOTAL
+      Math.min(TOTAL, 6)
 
     const buttonWithText = (text: string) =>
       Array.from(document.querySelectorAll("button")).find((b) =>
@@ -1239,7 +1240,7 @@ describe("SidebarConversationList — Recent section", () => {
       })
       const recentRows = () =>
         Array.from(document.querySelectorAll("[data-conversation-id]")).length -
-        conversations.length
+        6
       expect(recentRows()).toBe(PAGE * 2)
       // Still more to reveal…
       expect(buttonWithText(showMoreLabel(PAGE))).toBeDefined()
@@ -1408,6 +1409,51 @@ describe("SidebarConversationList — expand / collapse all", () => {
 
     expect(localStorage.getItem(SECTION_COLLAPSED_KEY)).toBe(afterFirst)
     for (const label of ALL_SECTIONS) expect(expandedOf(label)).toBe("false")
+  })
+})
+
+describe("SidebarConversationList - folder conversation paging", () => {
+  const folderConversationCount = () =>
+    document.querySelectorAll("[data-conversation-id]").length
+  const loadMoreButton = () =>
+    Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Load more")
+    )
+  const folderToggle = () =>
+    document.querySelector<HTMLButtonElement>(
+      '[data-folder-id="1"][aria-expanded]'
+    )
+
+  beforeEach(() => {
+    localStorage.clear()
+    const folders = [folder(1, "Repo")]
+    useAppWorkspaceStore.setState({
+      folders,
+      allFolders: folders,
+      conversations: Array.from({ length: 13 }, (_, i) => conv(i + 1, 1)),
+    })
+  })
+
+  it("reveals six at a time and resets after the folder is collapsed", () => {
+    render(tree())
+
+    expect(folderConversationCount()).toBe(6)
+    expect(loadMoreButton()?.textContent).toContain("7")
+
+    act(() => fireEvent.click(loadMoreButton()!))
+    expect(folderConversationCount()).toBe(12)
+    expect(loadMoreButton()?.textContent).toContain("1")
+
+    act(() => fireEvent.click(loadMoreButton()!))
+    expect(folderConversationCount()).toBe(13)
+    expect(loadMoreButton()).toBeUndefined()
+
+    act(() => fireEvent.click(folderToggle()!))
+    expect(folderConversationCount()).toBe(0)
+
+    act(() => fireEvent.click(folderToggle()!))
+    expect(folderConversationCount()).toBe(6)
+    expect(loadMoreButton()?.textContent).toContain("7")
   })
 })
 

--- a/src/components/conversations/sidebar-conversation-list.tsx
+++ b/src/components/conversations/sidebar-conversation-list.tsx
@@ -115,6 +115,7 @@ import {
   reconcileLayout,
   computeStickyState,
   flatIndexOfConversation,
+  FOLDER_CONVERSATION_PAGE_SIZE,
   folderHeaderFlatIndices,
   formatRelative,
   groupByFolderWithReuse,
@@ -1019,6 +1020,25 @@ export function SidebarConversationList({
   // "show me more of this list right now" is a reading gesture, not a setting —
   // and a fresh sidebar should open short again.
   const [recentLimit, setRecentLimit] = useState(RECENT_PAGE_SIZE)
+  const [folderConversationLimits, setFolderConversationLimits] = useState<
+    Record<number, number>
+  >({})
+  const revealMoreFolderConversations = useCallback((folderId: number) => {
+    setFolderConversationLimits((prev) => ({
+      ...prev,
+      [folderId]:
+        (prev[folderId] ?? FOLDER_CONVERSATION_PAGE_SIZE) +
+        FOLDER_CONVERSATION_PAGE_SIZE,
+    }))
+  }, [])
+  const resetFolderConversationLimit = useCallback((folderId: number) => {
+    setFolderConversationLimits((prev) => {
+      if (prev[folderId] == null) return prev
+      const next = { ...prev }
+      delete next[folderId]
+      return next
+    })
+  }, [])
   const revealMoreRecent = useCallback(
     () => setRecentLimit((n) => n + RECENT_PAGE_SIZE),
     []
@@ -1513,6 +1533,7 @@ export function SidebarConversationList({
         byFolder,
         folderExpanded,
         folderTotalCounts,
+        folderConversationLimits,
         foldersExpanded,
         chatConversations,
         chatsExpanded,
@@ -1536,6 +1557,7 @@ export function SidebarConversationList({
       byFolder,
       folderExpanded,
       folderTotalCounts,
+      folderConversationLimits,
       foldersExpanded,
       chatConversations,
       chatsExpanded,
@@ -1607,6 +1629,7 @@ export function SidebarConversationList({
       setAllSectionsCollapsed(false)
     },
     collapseAll() {
+      setFolderConversationLimits({})
       setFolderExpanded((prev) => {
         const next: Record<number, boolean> = { ...prev }
         for (const id of reorderableFolderIds) next[id] = false
@@ -1757,24 +1780,32 @@ export function SidebarConversationList({
     chatsExpanded,
   ])
 
-  const toggleFolder = useCallback((folderId: number) => {
-    setFolderExpanded((prev) => {
-      const next = { ...prev, [folderId]: !(prev[folderId] ?? true) }
-      saveFolderExpanded(next)
-      return next
-    })
-  }, [])
+  const toggleFolder = useCallback(
+    (folderId: number) => {
+      resetFolderConversationLimit(folderId)
+      setFolderExpanded((prev) => {
+        const next = { ...prev, [folderId]: !(prev[folderId] ?? true) }
+        saveFolderExpanded(next)
+        return next
+      })
+    },
+    [resetFolderConversationLimit]
+  )
 
   // Toggle a container repo's "root" sub-group (its own sessions). Session-only,
   // so unlike `toggleFolder` there is no persistence write.
-  const toggleRootGroup = useCallback((repoId: number) => {
-    setRootGroupCollapsed((prev) => {
-      const next = new Set(prev)
-      if (next.has(repoId)) next.delete(repoId)
-      else next.add(repoId)
-      return next
-    })
-  }, [])
+  const toggleRootGroup = useCallback(
+    (repoId: number) => {
+      resetFolderConversationLimit(repoId)
+      setRootGroupCollapsed((prev) => {
+        const next = new Set(prev)
+        if (next.has(repoId)) next.delete(repoId)
+        else next.add(repoId)
+        return next
+      })
+    },
+    [resetFolderConversationLimit]
+  )
 
   // Lazily fetch a conversation's direct delegation children into the cache.
   // Deduped against both the cache and in-flight requests so a re-toggle or the
@@ -2894,6 +2925,32 @@ export function SidebarConversationList({
         </div>
       )
     }
+    if (row.kind === "folder-more") {
+      const railLeft = `calc(var(--conv-rail-axis, 0.875rem) + ${row.depth} * ${CONV_RAIL_DEPTH_STEP})`
+      return (
+        <div className="relative h-[2rem]">
+          <button
+            type="button"
+            onClick={() => revealMoreFolderConversations(row.folderId)}
+            className="relative flex h-[1.9375rem] w-full items-center rounded-full pr-[0.25rem] text-left text-[0.75rem] text-muted-foreground/80 outline-none transition-colors duration-[120ms] hover:bg-[color-mix(in_oklab,var(--sidebar-accent),var(--sidebar-foreground)_2%)] hover:text-sidebar-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+            style={{
+              paddingLeft: `calc(var(--conv-rail-axis, 0.875rem) + ${row.depth} * ${CONV_RAIL_DEPTH_STEP} + 0.875rem)`,
+            }}
+          >
+            <span
+              aria-hidden
+              className="pointer-events-none absolute top-1/2 flex h-[0.875rem] w-[0.875rem] -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+              style={{ left: railLeft }}
+            >
+              <ChevronDown className="h-[0.75rem] w-[0.75rem]" />
+            </span>
+            <span className="truncate">
+              {t("loadMoreFolderConversations", { count: row.remaining })}
+            </span>
+          </button>
+        </div>
+      )
+    }
     if (row.kind === "recent-more") {
       // Footer of the paged Recent section — a row, not a hint: each click
       // reveals another page. Its geometry is the conversation card's, so the
@@ -3037,6 +3094,7 @@ export function SidebarConversationList({
     if (row.kind === "folder-group") return `foldergroup-${row.groupId}`
     if (row.kind === "group-empty") return `groupempty-${row.groupId}`
     if (row.kind === "folder") return `folder-${row.folderId}`
+    if (row.kind === "folder-more") return `foldermore-${row.folderId}`
     if (row.kind === "root-group") return `rootgroup-${row.folderId}`
     if (row.kind === "empty") return `empty-${row.folderId}`
     if (row.kind === "chats-empty") return "chats-empty"

--- a/src/components/conversations/sidebar-conversation-list.tsx
+++ b/src/components/conversations/sidebar-conversation-list.tsx
@@ -1747,6 +1747,25 @@ export function SidebarConversationList({
           pendingScrollRef.current = true
           return
         }
+        const folderConversations = byFolder.get(displayFolderId) ?? []
+        const conversationIndex = folderConversations.findIndex(
+          (candidate) =>
+            candidate.id === targetId && candidate.agent_type === targetAgent
+        )
+        const requiredLimit = conversationIndex + 1
+        const currentLimit =
+          folderConversationLimits[displayFolderId] ??
+          FOLDER_CONVERSATION_PAGE_SIZE
+        if (requiredLimit > currentLimit) {
+          setFolderConversationLimits((prev) => {
+            const previousLimit =
+              prev[displayFolderId] ?? FOLDER_CONVERSATION_PAGE_SIZE
+            if (previousLimit >= requiredLimit) return prev
+            return { ...prev, [displayFolderId]: requiredLimit }
+          })
+          pendingScrollRef.current = true
+          return
+        }
       }
       // Off-screen virtualized rows are not in the DOM, so resolve the flat row
       // index and let virtua scroll to it.
@@ -1769,7 +1788,9 @@ export function SidebarConversationList({
   }, [
     selectedConversation,
     conversations,
+    byFolder,
     folderExpanded,
+    folderConversationLimits,
     displayChildToParent,
     showWorktrees,
     childToParent,

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -1847,6 +1847,7 @@
       "noChats": "لا توجد محادثات",
       "noRecent": "لا توجد محادثات حديثة",
       "showMoreRecent": "عرض المزيد ({count})",
+      "loadMoreFolderConversations": "تحميل المزيد ({count})",
       "resetRecentLimit": "إعادة التعيين إلى أول {count}",
       "noFolders": "لا توجد مجلدات مفتوحة",
       "newChatAction": "محادثة جديدة",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -1847,6 +1847,7 @@
       "noChats": "Keine Chats",
       "noRecent": "Keine kürzlichen Konversationen",
       "showMoreRecent": "Mehr anzeigen ({count})",
+      "loadMoreFolderConversations": "Mehr laden ({count})",
       "resetRecentLimit": "Auf die ersten {count} zurücksetzen",
       "noFolders": "Keine Ordner geöffnet",
       "newChatAction": "Neuer Chat",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1847,6 +1847,7 @@
       "noChats": "No chats",
       "noRecent": "No recent conversations",
       "showMoreRecent": "Show more ({count})",
+      "loadMoreFolderConversations": "Load more ({count})",
       "resetRecentLimit": "Reset to the first {count}",
       "noFolders": "No folders open",
       "newChatAction": "New chat",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -1847,6 +1847,7 @@
       "noChats": "Sin chats",
       "noRecent": "Sin conversaciones recientes",
       "showMoreRecent": "Mostrar más ({count})",
+      "loadMoreFolderConversations": "Cargar más ({count})",
       "resetRecentLimit": "Restablecer a los primeros {count}",
       "noFolders": "No hay carpetas abiertas",
       "newChatAction": "Nuevo chat",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1847,6 +1847,7 @@
       "noChats": "Aucune discussion",
       "noRecent": "Aucune conversation récente",
       "showMoreRecent": "Afficher plus ({count})",
+      "loadMoreFolderConversations": "Charger plus ({count})",
       "resetRecentLimit": "Revenir aux {count} premières",
       "noFolders": "Aucun dossier ouvert",
       "newChatAction": "Nouvelle discussion",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1847,6 +1847,7 @@
       "noChats": "チャットがありません",
       "noRecent": "最近の会話はありません",
       "showMoreRecent": "さらに表示（{count}）",
+      "loadMoreFolderConversations": "さらに読み込む（{count}）",
       "resetRecentLimit": "最初の{count}件に戻す",
       "noFolders": "開いているフォルダがありません",
       "newChatAction": "新しいチャット",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1847,6 +1847,7 @@
       "noChats": "채팅 없음",
       "noRecent": "최근 대화 없음",
       "showMoreRecent": "더 보기 ({count})",
+      "loadMoreFolderConversations": "더 불러오기 ({count})",
       "resetRecentLimit": "처음 {count}개로 되돌리기",
       "noFolders": "열린 폴더 없음",
       "newChatAction": "새 채팅",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -1847,6 +1847,7 @@
       "noChats": "Sem chats",
       "noRecent": "Sem conversas recentes",
       "showMoreRecent": "Mostrar mais ({count})",
+      "loadMoreFolderConversations": "Carregar mais ({count})",
       "resetRecentLimit": "Redefinir para as primeiras {count}",
       "noFolders": "Nenhuma pasta aberta",
       "newChatAction": "Novo chat",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -1847,6 +1847,7 @@
       "noChats": "没有聊天",
       "noRecent": "暂无最近会话",
       "showMoreRecent": "显示更多（{count}）",
+      "loadMoreFolderConversations": "加载更多（{count}）",
       "resetRecentLimit": "重置为前 {count} 条",
       "noFolders": "没有打开的文件夹",
       "newChatAction": "新建聊天",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -1847,6 +1847,7 @@
       "noChats": "沒有聊天",
       "noRecent": "暫無最近對話",
       "showMoreRecent": "顯示更多（{count}）",
+      "loadMoreFolderConversations": "載入更多（{count}）",
       "resetRecentLimit": "重設為前 {count} 筆",
       "noFolders": "沒有開啟的資料夾",
       "newChatAction": "新增聊天",


### PR DESCRIPTION
## Summary

- show the six newest conversations when a folder is expanded
- load six more conversations at a time until the folder is fully shown
- reset the visible count after collapsing and reopening a folder
- keep the active conversation visible and add localized load-more labels
- add regression coverage for paging, reset, ordering, and active-session behavior

## Verification

- `pnpm exec vitest run --maxWorkers=2 --minWorkers=1 --reporter=basic` (425 files, 6113 tests)
- `pnpm eslint .` (0 errors; 1 pre-existing warning in `status-bar-mcp.tsx`)
- `pnpm build`
- `git diff --check origin/main...HEAD`