### PR TITLE
feat(skills): 增加按 Agent 控制技能可用性的开关

### DIFF
--- a/docs/superpowers/plans/2026-09-07-agent-skill-switches.md
+++ b/docs/superpowers/plans/2026-09-07-agent-skill-switches.md
@@ -1,0 +1,276 @@
+# Per-Agent Skill Switches Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add real per-agent availability switches to Settings > Skills without letting a shared skill toggle silently affect another Codeg-managed agent.
+
+**Architecture:** Native skill roots remain authoritative. Disabled entries live in deterministic sibling vaults; shared entries are fanned out into agent-unique roots before the shared source is hidden. The existing list/read/save/delete surface is extended so disabled skills remain manageable, and one new command performs serialized toggles over both transports.
+
+**Tech Stack:** Rust 2021, Tauri 2, Axum, Next.js 16, React 19, TypeScript, next-intl, Vitest.
+
+## Global Constraints
+
+- The switch is per agent and per scope; turning a shared skill off for one agent must preserve availability for every other Codeg-managed agent that already sees it.
+- A disabled skill must not remain in any native scan root used by the selected agent.
+- Read-only CLI skills cannot be toggled.
+- Existing user files and unrelated worktree changes must be preserved.
+- Both Tauri desktop and Axum server transports must expose the same behavior.
+
+---
+
+### Task 1: Backend Skill State And Private Toggle
+
+**Files:**
+- Modify: `src-tauri/src/acp/types.rs`
+- Modify: `src-tauri/src/commands/acp.rs`
+
+**Interfaces:**
+- Produces: `AgentSkillItem { enabled: bool, can_toggle: bool, ... }`
+- Produces: `acp_set_agent_skill_enabled(agent_type, scope, skill_id, workspace_path, enabled) -> Result<AgentSkillItem, AcpError>`
+
+- [ ] **Step 1: Write failing filesystem tests**
+
+Add tests that create directory and flat-file skills in temporary active roots,
+then exercise the wished-for helpers:
+
+```rust
+let disabled = disabled_skill_root(&skills);
+set_skill_enabled_in_roots(&peers, AgentType::Codex, AgentSkillScope::Global, "demo", false)?;
+assert!(!skills.join("demo").exists());
+assert!(disabled.join("demo").join("SKILL.md").is_file());
+let listed = list_skills_from_roots(AgentSkillScope::Global, &[skills], kind)?;
+assert!(!listed[0].enabled);
+```
+
+- [ ] **Step 2: Run the focused Rust test and verify RED**
+
+Run:
+
+```bash
+cd src-tauri && cargo test --features test-utils skill_enabled -- --nocapture
+```
+
+Expected: compilation fails because the new state fields and helpers do not
+exist.
+
+- [ ] **Step 3: Implement disabled-root discovery and private moves**
+
+Add deterministic path and entry helpers, active-first list merging, lookup in
+both active and disabled roots, a serialized mutation lock, collision
+preflight, and idempotent private enable/disable moves. Extend read/save/delete
+to resolve disabled entries.
+
+The command contract is:
+
+```rust
+pub async fn acp_set_agent_skill_enabled(
+    agent_type: AgentType,
+    scope: AgentSkillScope,
+    skill_id: String,
+    workspace_path: Option<String>,
+    enabled: bool,
+) -> Result<AgentSkillItem, AcpError>;
+```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the command from Step 2. Expected: private directory/flat-file, lookup,
+idempotency, collision, and read-only tests pass.
+
+### Task 2: Shared Skill Fan-Out And Isolation
+
+**Files:**
+- Modify: `src-tauri/src/commands/acp.rs`
+- Reuse: `src-tauri/src/commands/experts.rs`
+
+**Interfaces:**
+- Consumes: native roots from `skill_storage_spec` and `scoped_skill_dirs`
+- Produces: an internal peer plan containing scan roots and one unique managed root per affected agent
+
+- [ ] **Step 1: Write failing shared-root tests**
+
+Use temporary roots for two peer agents and one shared root. Assert that
+disabling for agent B moves the shared source to its vault, links agent A's
+unique root to the canonical entry, leaves B's unique root empty, and reports A
+enabled/B disabled. Add a peer-without-unique-root case that fails without any
+move.
+
+```rust
+assert!(peer_a.join("demo").join("SKILL.md").is_file());
+assert!(!peer_b.join("demo").exists());
+assert!(shared_disabled.join("demo").join("SKILL.md").is_file());
+```
+
+- [ ] **Step 2: Run the focused Rust test and verify RED**
+
+Run:
+
+```bash
+cd src-tauri && cargo test --features test-utils shared_skill -- --nocapture
+```
+
+Expected: the shared source disappears for both peers or the new planning API
+is missing.
+
+- [ ] **Step 3: Implement shared preflight, fan-out, and rollback**
+
+Derive peers from `all_acp_agents()`, compare resolved scan-root paths, choose a
+root used by exactly one peer, and create compatible directory/file links. Move
+the shared source only after every destination has passed preflight. Track and
+remove links plus restore the source if a later filesystem action fails.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the command from Step 2. Expected: fan-out, isolation, refusal, and rollback
+tests pass.
+
+### Task 3: Expose The Toggle Over Desktop And Server Transports
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src-tauri/src/web/handlers/acp.rs`
+- Modify: `src-tauri/src/web/router.rs`
+- Modify: `src/lib/api.ts`
+- Modify: `src/lib/tauri.ts`
+- Modify: `src/lib/types.ts`
+
+**Interfaces:**
+- Consumes: the backend command from Task 1
+- Produces: `acpSetAgentSkillEnabled(params): Promise<AgentSkillItem>`
+
+- [ ] **Step 1: Add the typed frontend call before registration**
+
+```ts
+export async function acpSetAgentSkillEnabled(params: {
+  agentType: AgentType
+  scope: AgentSkillScope
+  skillId: string
+  workspacePath?: string | null
+  enabled: boolean
+}): Promise<AgentSkillItem>
+```
+
+- [ ] **Step 2: Run TypeScript checking and verify RED**
+
+Run `pnpm exec tsc --noEmit`. Expected: the transport call or the new DTO fields
+are unavailable until all mirrors are updated.
+
+- [ ] **Step 3: Register both transport paths**
+
+Add the Tauri invoke handler, the Axum request DTO/handler, and
+`/acp_set_agent_skill_enabled`; mirror `enabled` and `can_toggle` in TypeScript
+and send camelCase request keys through the shared transport.
+
+- [ ] **Step 4: Run TypeScript and Rust checks**
+
+Run:
+
+```bash
+pnpm exec tsc --noEmit
+cd src-tauri && cargo check
+cd src-tauri && cargo check --no-default-features --bin codeg-server
+```
+
+Expected: all commands exit 0.
+
+### Task 4: Skills Settings Switch And Autocomplete Filtering
+
+**Files:**
+- Create: `src/components/settings/skills-settings.test.tsx`
+- Modify: `src/components/settings/skills-settings.tsx`
+- Create: `src/hooks/use-agent-skills.test.tsx`
+- Modify: `src/hooks/use-agent-skills.ts`
+
+**Interfaces:**
+- Consumes: `AgentSkillItem.enabled`, `AgentSkillItem.can_toggle`, and `acpSetAgentSkillEnabled`
+- Produces: a row switch whose accessible name identifies the skill and selected agent
+
+- [ ] **Step 1: Write failing component and hook tests**
+
+Mock the existing API module, render one enabled skill, click its switch, and
+assert the exact request plus authoritative reload:
+
+```ts
+expect(acpSetAgentSkillEnabled).toHaveBeenCalledWith({
+  agentType: "codex",
+  scope: "global",
+  skillId: "demo",
+  workspacePath: null,
+  enabled: false,
+})
+expect(acpListAgentSkills).toHaveBeenCalledTimes(3)
+```
+
+Also assert that `useAgentSkills` excludes `{ enabled: false }` and that
+read-only/non-toggleable switches are disabled.
+
+- [ ] **Step 2: Run focused Vitest and verify RED**
+
+Run:
+
+```bash
+pnpm test -- src/components/settings/skills-settings.test.tsx src/hooks/use-agent-skills.test.tsx
+```
+
+Expected: switch queries and disabled filtering fail because neither behavior
+exists.
+
+- [ ] **Step 3: Implement the switch behavior**
+
+Add a stable switch to each list row, stop its click from changing row
+selection, track one in-flight skill ID, call the new API, invalidate the cache,
+reload the authoritative list, and show localized success/error feedback. Filter
+disabled items in `useAgentSkills` before caching.
+
+- [ ] **Step 4: Run focused Vitest and verify GREEN**
+
+Run the command from Step 2. Expected: all focused tests pass.
+
+### Task 5: Localization And Final Verification
+
+**Files:**
+- Modify: `src/i18n/messages/ar.json`
+- Modify: `src/i18n/messages/de.json`
+- Modify: `src/i18n/messages/en.json`
+- Modify: `src/i18n/messages/es.json`
+- Modify: `src/i18n/messages/fr.json`
+- Modify: `src/i18n/messages/ja.json`
+- Modify: `src/i18n/messages/ko.json`
+- Modify: `src/i18n/messages/pt.json`
+- Modify: `src/i18n/messages/zh-CN.json`
+- Modify: `src/i18n/messages/zh-TW.json`
+
+**Interfaces:**
+- Produces: matching keys for switch labels, enabled/disabled success, failure, and unavailable hints in every locale
+
+- [ ] **Step 1: Add the same message-key shape to all locales**
+
+Add `availability.enabled`, `availability.disabled`,
+`availability.toggleAria`, `availability.readOnly`,
+`availability.cannotIsolate`, and the corresponding toggle toast keys.
+
+- [ ] **Step 2: Run final frontend verification**
+
+```bash
+pnpm eslint .
+pnpm test
+pnpm build
+```
+
+Expected: each command exits 0 with no failing tests.
+
+- [ ] **Step 3: Run final shared-backend verification**
+
+```bash
+cd src-tauri && cargo test --features test-utils
+cd src-tauri && cargo check --no-default-features --bin codeg-server
+cd src-tauri && cargo test --no-default-features --bin codeg-server --lib
+```
+
+Expected: each command exits 0 with no failing tests.
+
+- [ ] **Step 4: Review the diff and commit**
+
+Run `git diff --check`, inspect `git diff --stat` and `git status --short`, then
+commit only the task files on `task/1` without merging, rebasing, or pushing
+`main`.

--- a/docs/superpowers/plans/2026-09-07-agent-skill-switches.md
+++ b/docs/superpowers/plans/2026-09-07-agent-skill-switches.md
@@ -274,3 +274,94 @@ Expected: each command exits 0 with no failing tests.
 Run `git diff --check`, inspect `git diff --stat` and `git status --short`, then
 commit only the task files on `task/1` without merging, rebasing, or pushing
 `main`.
+
+### Task 6: Review Fixes For Incoming Links And Cursor Vaults
+
+**Files:**
+- Modify: `src-tauri/src/commands/acp.rs`
+
+**Interfaces:**
+- Produces: a preflight that enumerates every supported entry in peer active
+  roots and disabled vaults, then rejects a canonical move if an alias or
+  same-name entry directly links to that canonical Skill
+- Produces: a distinct deterministic vault only for Cursor's exact builtin
+  `~/.cursor/skills-cursor` root, while preserving the legacy vault for
+  `~/.cursor/skills` and custom roots that happen to use the same basename
+- Preserves: `AgentSkillItem.can_toggle` and toggle execution report the same
+  feasibility
+
+- [x] **Step 1: Write three failing filesystem regressions**
+
+Add tests for a shared canonical Skill with an incoming link from a peer that
+does not scan the shared root, a private canonical Skill with an incoming peer
+link, and Cursor's global writable Skill root:
+
+```rust
+assert!(result.is_err(), "the canonical move must be refused");
+assert!(canonical.join("SKILL.md").is_file());
+assert!(!listed.can_toggle);
+
+assert_eq!(
+    disabled_skill_root(&home.join(".cursor/skills")),
+    home.join(".cursor/.skills.codeg-disabled")
+);
+assert_ne!(
+    disabled_skill_root(&home.join(".cursor/skills")),
+    disabled_skill_root(&home.join(".cursor/skills-cursor"))
+);
+```
+
+- [x] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```bash
+cd src-tauri
+cargo test --features test-utils incoming_peer_link -- --nocapture
+cargo test --features test-utils cursor_global_skill_round_trip -- --nocapture
+```
+
+Expected: the incoming-link toggles mutate the canonical entry instead of
+refusing, and Cursor advertises a toggle that execution rejects because the two
+sibling roots resolve to one vault.
+
+- [x] **Step 3: Implement the minimal preflight and vault compatibility fix**
+
+Add an entry-level preflight that scans every peer's supported entries in both
+active roots and disabled vaults, then uses `skill_link_targets` to identify
+direct incoming links. Allow only the exact same-name active links that the
+shared restore plan will remove itself; reject aliases, case variants, and
+links in a peer's other roots before moving the canonical entry. Invoke the
+same preflight from capability calculation and command execution.
+
+Keep `.cursor/skills` and all unrelated custom roots on their existing
+`.skills.codeg-disabled` vaults so disabled entries remain discoverable. Map
+only the read-only `.cursor/skills-cursor` root to
+`.cursor/.skills-cursor.codeg-disabled` so it no longer claims the writable
+root's vault.
+
+- [x] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cd src-tauri
+cargo test --features test-utils incoming_peer_link -- --nocapture
+cargo test --features test-utils cursor_global_skill_round_trip -- --nocapture
+cargo test --features test-utils skill_capability -- --nocapture
+cargo test --features test-utils shared_skill -- --nocapture
+```
+
+Expected: all focused regressions and existing Skill isolation tests pass.
+
+- [x] **Step 5: Run the complete repository verification matrix and review**
+
+Run the frontend checks and every desktop, server, and `codeg-mcp` Rust command
+listed in `AGENTS.md`, followed by `git diff --check`. Request an independent
+read-only review of the final commit range, resolve all Critical or Important
+findings, and commit the fixes on `task/1`.
+
+The first review found alias/case-variant links outside the exact Skill ID and
+custom roots named `skills-cursor` were still unsafe. Those cases now have
+RED/GREEN regressions, and the follow-up review reported no remaining Critical
+or Important findings.

--- a/docs/superpowers/plans/2026-09-07-agent-skill-switches.md
+++ b/docs/superpowers/plans/2026-09-07-agent-skill-switches.md
@@ -4,15 +4,15 @@
 
 **Goal:** Add real per-agent availability switches to Settings > Skills without letting a shared skill toggle silently affect another Codeg-managed agent.
 
-**Architecture:** Native skill roots remain authoritative. Disabled entries live in deterministic sibling vaults; shared entries are fanned out into agent-unique roots before the shared source is hidden. The existing list/read/save/delete surface is extended so disabled skills remain manageable, and one new command performs serialized toggles over both transports.
+**Architecture:** Codex uses its official ordered `skills.config` rules, so toggles never move Codex files and can cover read-only system skills. Other agents keep native skill roots authoritative: disabled entries live in deterministic sibling vaults, and shared entries are fanned out into agent-unique roots before the shared source is hidden. The existing list/read/save/delete surface is extended so disabled skills remain manageable, and one new command performs serialized toggles over both transports.
 
 **Tech Stack:** Rust 2021, Tauri 2, Axum, Next.js 16, React 19, TypeScript, next-intl, Vitest.
 
 ## Global Constraints
 
 - The switch is per agent and per scope; turning a shared skill off for one agent must preserve availability for every other Codeg-managed agent that already sees it.
-- A disabled skill must not remain in any native scan root used by the selected agent.
-- Read-only CLI skills cannot be toggled.
+- A disabled skill must be excluded from the selected agent's effective native discovery result. Codex does this through `skills.config`; other agents use filesystem isolation.
+- Read-only CLI skills cannot be moved or edited. Codex system skills can still be toggled because its official configuration controls availability without mutating skill content.
 - Existing user files and unrelated worktree changes must be preserved.
 - Both Tauri desktop and Axum server transports must expose the same behavior.
 
@@ -35,7 +35,7 @@ then exercise the wished-for helpers:
 
 ```rust
 let disabled = disabled_skill_root(&skills);
-set_skill_enabled_in_roots(&peers, AgentType::Codex, AgentSkillScope::Global, "demo", false)?;
+set_skill_enabled_in_roots(&peers, AgentType::Gemini, AgentSkillScope::Global, "demo", false)?;
 assert!(!skills.join("demo").exists());
 assert!(disabled.join("demo").join("SKILL.md").is_file());
 let listed = list_skills_from_roots(AgentSkillScope::Global, &[skills], kind)?;

--- a/docs/superpowers/specs/2026-09-07-agent-skill-switches-design.md
+++ b/docs/superpowers/specs/2026-09-07-agent-skill-switches-design.md
@@ -27,17 +27,39 @@ disabled state.
 - A switch shows an in-progress state while the filesystem operation runs.
 - On failure, the authoritative list is reloaded, the switch returns to its
   prior state, and a localized error toast is shown.
-- CLI-owned read-only skills remain visible but cannot be toggled.
+- For non-Codex agents, CLI-owned read-only skills remain visible but cannot be
+  toggled. Codex system skills remain toggleable because Codeg changes only
+  Codex's official availability configuration, not the skill files.
 - A skill whose shared installation cannot be separated without changing
   another configured agent is marked non-toggleable instead of pretending the
   operation succeeded.
 - A new or reconnected agent session is required when an already-running agent
   caches its skill inventory.
 
-## Storage Model
+## Agent-Specific Control Models
 
-No database flag is authoritative. The filesystem remains the source of truth
-because the agent CLIs scan it directly.
+No database flag is authoritative. Codeg changes the native state consumed by
+each agent so its own discovery result remains the source of truth.
+
+### Codex Native Configuration
+
+Codeg does not move Codex skill files. It reads and atomically updates
+`CODEX_HOME/config.toml` using Codex's official `skills.config` entries. Rules
+are evaluated in file order and the last matching `path` or `name` selector
+wins. When a broader or later selector would override the requested state,
+Codeg appends a path-specific rule so the requested state is effective without
+rewriting the user's broader rule. A repeated toggle updates that trailing
+path rule instead of growing the configuration indefinitely.
+
+This applies to project, user, plugin, and system skills, including skill files
+that are read-only. Their files and displayed locations remain unchanged. A
+new Codex session is required because an existing session may have cached its
+skill inventory.
+
+### Filesystem Isolation For Other Agents
+
+Agents without a native availability configuration continue to use filesystem
+isolation because their CLIs scan native skill roots directly.
 
 For each native skill root, Codeg uses a sibling vault that is outside the
 agent's scan path:
@@ -92,9 +114,11 @@ enabled: bool
 can_toggle: bool
 ```
 
-The list command scans active roots first and disabled vaults second. Active
-entries win when the same ID occurs more than once. This means a peer link is
-reported enabled even though its canonical source is held in a shared vault.
+For non-Codex agents, the list command scans active roots first and disabled
+vaults second. Active entries win when the same ID occurs more than once. This
+means a peer link is reported enabled even though its canonical source is held
+in a shared vault. For Codex, the list command overlays the effective native
+configuration state on every discovered skill and keeps its original path.
 
 A new command is available over both Tauri and Axum transports:
 
@@ -122,14 +146,18 @@ and the generic `useAgentSkills` hook returns enabled entries only.
 - Repeated enable or disable requests are idempotent.
 - Symbolic links are moved as links, never followed and copied during private
   disable operations.
-- Built-in system paths retain the existing backend write protection.
+- Built-in system paths retain the existing backend content-write protection.
+  Codex availability remains configurable because toggling writes only the
+  Codex config file.
 
 ## Tests
 
-Rust tests cover private directory and flat-file toggles, disabled discovery,
-idempotency, shared fan-out, peer isolation, collision refusal, rollback, and
-read-only rejection. Existing skill storage tests continue to pin each agent's
-native roots.
+Rust tests cover Codex rule precedence, both supported TOML array forms,
+read-only/system-skill availability, stable paths, atomic config writes, and
+new-session behavior. They also cover private directory and flat-file toggles,
+disabled discovery, idempotency, shared fan-out, peer isolation, collision
+refusal, rollback, and non-Codex read-only rejection. Existing skill storage
+tests continue to pin each agent's native roots.
 
 Frontend tests cover switch state, the exact toggle request, cache invalidation,
 authoritative reload, disabled autocomplete filtering, read-only/non-toggleable

--- a/docs/superpowers/specs/2026-09-07-agent-skill-switches-design.md
+++ b/docs/superpowers/specs/2026-09-07-agent-skill-switches-design.md
@@ -1,0 +1,138 @@
+# Per-Agent Skill Switches Design
+
+## Goal
+
+Add an availability switch to Settings > Skills so the same skill can be
+enabled for one agent and disabled for another, matching the per-agent meaning
+of MCP assignments.
+
+An off switch must change what the selected agent can discover. Hiding a skill
+only from Codeg autocomplete is not sufficient.
+
+## Current Behavior
+
+Codeg discovers skills by scanning each agent's native global or project skill
+directories. Some directories belong to one agent, such as
+`~/.codex/skills`. Others, especially `.agents/skills`, are read by several
+agents. The settings list currently exposes only discovered entries and has no
+disabled state.
+
+## User Experience
+
+- Every skill row has an availability switch for the currently selected agent.
+- An enabled skill remains discoverable by that agent. A disabled skill remains
+  visible in Settings so it can be previewed, edited, deleted, or re-enabled,
+  but it is omitted from Codeg skill autocomplete and from the agent's native
+  scan roots.
+- A switch shows an in-progress state while the filesystem operation runs.
+- On failure, the authoritative list is reloaded, the switch returns to its
+  prior state, and a localized error toast is shown.
+- CLI-owned read-only skills remain visible but cannot be toggled.
+- A skill whose shared installation cannot be separated without changing
+  another configured agent is marked non-toggleable instead of pretending the
+  operation succeeded.
+- A new or reconnected agent session is required when an already-running agent
+  caches its skill inventory.
+
+## Storage Model
+
+No database flag is authoritative. The filesystem remains the source of truth
+because the agent CLIs scan it directly.
+
+For each native skill root, Codeg uses a sibling vault that is outside the
+agent's scan path:
+
+```text
+~/.codex/skills/pdf/SKILL.md
+~/.codex/.skills.codeg-disabled/pdf/SKILL.md
+```
+
+Directory skills and flat Markdown skills retain their original entry name and
+layout in the vault. Renaming within the same parent filesystem makes a private
+skill toggle reversible and preserves all supporting assets and symlink
+identity.
+
+### Private Root
+
+Disabling moves the entry from the native root to its sibling vault. Enabling
+moves it back. Destination collisions are rejected before mutation.
+
+### Shared Root
+
+Before hiding an entry from a shared root, Codeg identifies every configured
+agent that currently relies on that root. For each peer other than the agent
+being disabled, it creates a link in an agent-unique native root. The shared
+entry is then moved into the shared root's sibling vault and becomes the
+canonical link target.
+
+Example:
+
+```text
+before:
+  ~/.agents/skills/pdf                  # Codex and Gemini can both see it
+
+after disabling only Gemini:
+  ~/.agents/.skills.codeg-disabled/pdf  # canonical content, not scanned
+  ~/.codex/skills/pdf -> canonical      # Codex still sees it
+  ~/.gemini/skills/pdf                  # absent, so Gemini does not see it
+```
+
+If a peer has no unique native skill root, or a conflicting entry blocks a
+required link, Codeg rejects the operation before moving the shared source.
+This preserves the per-agent contract for all agents managed by Codeg. Tools
+outside Codeg that independently consume `.agents/skills` are outside this
+assignment model.
+
+## API And Data Flow
+
+`AgentSkillItem` gains:
+
+```text
+enabled: bool
+can_toggle: bool
+```
+
+The list command scans active roots first and disabled vaults second. Active
+entries win when the same ID occurs more than once. This means a peer link is
+reported enabled even though its canonical source is held in a shared vault.
+
+A new command is available over both Tauri and Axum transports:
+
+```text
+acp_set_agent_skill_enabled(
+  agent_type,
+  scope,
+  skill_id,
+  workspace_path,
+  enabled
+) -> AgentSkillItem
+```
+
+Read, save, and delete operations resolve both active and disabled entries so
+turning a skill off does not make it unmanageable. Saving a new skill creates
+an enabled entry. The frontend invalidates its skill cache after every toggle,
+and the generic `useAgentSkills` hook returns enabled entries only.
+
+## Consistency And Failure Handling
+
+- Skill mutations are serialized inside the backend.
+- Validation and destination/link collision checks run before the first move.
+- Shared fan-out records links created by the operation. If a later step fails,
+  those links are removed and a moved source is restored.
+- Repeated enable or disable requests are idempotent.
+- Symbolic links are moved as links, never followed and copied during private
+  disable operations.
+- Built-in system paths retain the existing backend write protection.
+
+## Tests
+
+Rust tests cover private directory and flat-file toggles, disabled discovery,
+idempotency, shared fan-out, peer isolation, collision refusal, rollback, and
+read-only rejection. Existing skill storage tests continue to pin each agent's
+native roots.
+
+Frontend tests cover switch state, the exact toggle request, cache invalidation,
+authoritative reload, disabled autocomplete filtering, read-only/non-toggleable
+rows, and failure rollback. The final gate runs focused tests followed by the
+repository's frontend lint/test/build and Rust desktop/server checks appropriate
+to the touched shared backend.

--- a/docs/superpowers/specs/2026-09-07-agent-skill-switches-design.md
+++ b/docs/superpowers/specs/2026-09-07-agent-skill-switches-design.md
@@ -22,8 +22,8 @@ disabled state.
 - Every skill row has an availability switch for the currently selected agent.
 - An enabled skill remains discoverable by that agent. A disabled skill remains
   visible in Settings so it can be previewed, edited, deleted, or re-enabled,
-  but it is omitted from Codeg skill autocomplete and from the agent's native
-  scan roots.
+  but it is omitted from Codeg skill autocomplete and from the agent's
+  effective native discovery result.
 - A switch shows an in-progress state while the filesystem operation runs.
 - On failure, the authoritative list is reloaded, the switch returns to its
   prior state, and a localized error toast is shown.
@@ -91,11 +91,11 @@ Example:
 
 ```text
 before:
-  ~/.agents/skills/pdf                  # Codex and Gemini can both see it
+  ~/.agents/skills/pdf                  # Cursor and Gemini can both see it
 
 after disabling only Gemini:
   ~/.agents/.skills.codeg-disabled/pdf  # canonical content, not scanned
-  ~/.codex/skills/pdf -> canonical      # Codex still sees it
+  ~/.cursor/skills/pdf -> canonical     # Cursor still sees it
   ~/.gemini/skills/pdf                  # absent, so Gemini does not see it
 ```
 

--- a/src-tauri/src/acp/types.rs
+++ b/src-tauri/src/acp/types.rs
@@ -1510,6 +1510,11 @@ pub struct AgentSkillItem {
     pub scope: AgentSkillScope,
     pub layout: AgentSkillLayout,
     pub path: String,
+    /// Whether the skill currently lives in an agent-visible skills root.
+    pub enabled: bool,
+    /// Whether codeg may move the skill between its active root and disabled
+    /// vault. Built-in CLI skills are visible but cannot be toggled.
+    pub can_toggle: bool,
     /// Best-effort `description:` extracted from the SKILL.md YAML
     /// frontmatter. `None` when there is no frontmatter or no key.
     pub description: Option<String>,

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8983,7 +8983,7 @@ fn skill_root_writable(root: &Path) -> bool {
     }
 }
 
-fn unique_skill_root(peer: &SkillPeer, peers: &[SkillPeer]) -> Result<PathBuf, AcpError> {
+fn unique_skill_root(peer: &SkillPeer, peers: &[SkillPeer]) -> Result<Option<PathBuf>, AcpError> {
     for root in &peer.roots {
         let resolved = resolved_skill_root(root)?;
         if is_read_only_skill_path(peer.agent, root)
@@ -9004,13 +9004,116 @@ fn unique_skill_root(peer: &SkillPeer, peers: &[SkillPeer]) -> Result<PathBuf, A
             }
         }
         if unique {
-            return Ok(root.clone());
+            return Ok(Some(root.clone()));
         }
     }
-    Err(AcpError::protocol(format!(
-        "shared skill root: {} has no unique writable root",
-        peer.agent
-    )))
+    Ok(None)
+}
+
+fn shared_skill_affected_peers<'a>(
+    selected: &SkillPeer,
+    peers: &'a [SkillPeer],
+    root: &Path,
+    layout: AgentSkillLayout,
+) -> Result<Vec<&'a SkillPeer>, AcpError> {
+    let resolved_root = resolved_skill_root(root)?;
+    let mut affected = Vec::new();
+    for peer in peers {
+        let mut shares = false;
+        for scan in &peer.roots {
+            let resolved_scan = resolved_skill_root(scan)?;
+            if skill_roots_overlap(&resolved_root, &resolved_scan) {
+                if resolved_root != resolved_scan {
+                    return Err(AcpError::protocol(
+                        "shared skill root has overlapping scan roots that cannot be isolated",
+                    ));
+                }
+                shares = true;
+            }
+        }
+        if shares
+            && (peer.agent != selected.agent || peer.scope != selected.scope)
+            && !(layout == AgentSkillLayout::MarkdownFile
+                && peer.kind == SkillStorageKind::SkillDirectoryOnly)
+        {
+            affected.push(peer);
+        }
+    }
+    Ok(affected)
+}
+
+fn shared_skill_restore_links(
+    affected: &[&SkillPeer],
+    id: &str,
+    canonical: &Path,
+) -> Result<Vec<PathBuf>, AcpError> {
+    let mut links = Vec::new();
+    for peer in affected {
+        reject_multiple_active_skills(&peer.roots, peer.kind, id)?;
+        let active = locate_existing_skill_across_dirs(&peer.roots, peer.kind, id, peer.scope)
+            .filter(|item| item.enabled)
+            .ok_or_else(|| {
+                AcpError::protocol("shared skill restore would reenable a disabled peer")
+            })?;
+        let path = PathBuf::from(active.path);
+        if !skill_link_targets(&path, canonical) {
+            return Err(AcpError::protocol(
+                "shared skill restore would conflict with an independent peer skill",
+            ));
+        }
+        if !path.parent().is_some_and(skill_root_writable) {
+            return Err(AcpError::protocol(
+                "shared skill restore link root is not writable",
+            ));
+        }
+        links.push(path);
+    }
+    Ok(links)
+}
+
+fn listed_skill_can_toggle(
+    selected: &SkillPeer,
+    peers: &[SkillPeer],
+    skill: &AgentSkillItem,
+    workspace_path: Option<&str>,
+) -> Result<bool, AcpError> {
+    let parent = Path::new(&skill.path).parent();
+    let root = selected
+        .roots
+        .iter()
+        .find(|root| {
+            if skill.enabled {
+                parent == Some(root.as_path())
+            } else {
+                parent == Some(disabled_skill_root(root).as_path())
+            }
+        })
+        .ok_or_else(|| AcpError::protocol("listed skill has no owning native root"))?;
+    if !skill_root_is_shared_with_peers(selected.agent, selected.scope, root, peers)? {
+        return Ok(true);
+    }
+    preflight_shared_skill_owner(root, peers)?;
+    preflight_disabled_skill_root(root, workspace_path)?;
+    let affected = shared_skill_affected_peers(selected, peers, root, skill.layout)?;
+    if skill.enabled {
+        if !skill_root_writable(root) || !skill_root_writable(&disabled_skill_root(root)) {
+            return Ok(false);
+        }
+        for peer in affected {
+            if unique_skill_root(peer, peers)?.is_none() {
+                return Ok(false);
+            }
+        }
+        return Ok(true);
+    }
+    if unique_skill_root(selected, peers)?.is_some() {
+        return Ok(true);
+    }
+    if !skill_root_writable(root) || !skill_root_writable(&disabled_skill_root(root)) {
+        return Ok(false);
+    }
+    shared_skill_restore_links(&affected, &skill.id, Path::new(&skill.path))?;
+    Ok(true)
 }
 
 fn preflight_shared_skill_owner(root: &Path, peers: &[SkillPeer]) -> Result<(), AcpError> {
@@ -9219,83 +9322,35 @@ fn set_shared_skill_enabled(
             preflight_skill_destination(&disabled_skill_root(scan), &id)?;
         }
         preflight_skill_symlink_move(Path::new(&original.path), &vault)?;
-        for peer in peers {
-            let mut shares = false;
-            for scan in &peer.roots {
-                let resolved_scan = resolved_skill_root(scan)?;
-                if skill_roots_overlap(&resolved_root, &resolved_scan) {
-                    if resolved_root != resolved_scan {
-                        return Err(AcpError::protocol(
-                            "shared skill root has overlapping scan roots that cannot be isolated",
-                        ));
-                    }
-                    shares = true;
-                }
-            }
-            if !shares || (peer.agent == selected.agent && peer.scope == selected.scope) {
-                continue;
-            }
-            // A flat markdown file is invisible to directory-only consumers.
-            if canonical_item.layout == AgentSkillLayout::MarkdownFile
-                && peer.kind == SkillStorageKind::SkillDirectoryOnly
-            {
-                continue;
-            }
+        for peer in shared_skill_affected_peers(selected, peers, root, canonical_item.layout)? {
             reject_multiple_active_skills(&peer.roots, peer.kind, &id)?;
             for scan in &peer.roots {
                 preflight_skill_destination(&disabled_skill_root(scan), &id)?;
             }
-            let destination_root = unique_skill_root(peer, peers)?;
+            let destination_root = unique_skill_root(peer, peers)?.ok_or_else(|| {
+                AcpError::protocol(format!(
+                    "shared skill root: {} has no unique writable root",
+                    peer.agent
+                ))
+            })?;
             preflight_skill_destination(&destination_root, &id)?;
             destinations.push(destination_root.join(file_name));
             affected.push(peer);
         }
     } else if enabled {
-        match unique_skill_root(selected, peers) {
-            Ok(destination_root) => {
+        match unique_skill_root(selected, peers)? {
+            Some(destination_root) => {
                 preflight_skill_destination(&destination_root, &id)?;
                 destinations.push(destination_root.join(file_name));
             }
-            Err(error) if error.to_string().contains("no unique writable root") => {
+            None => {
                 preflight_skill_destination(root, &id)?;
                 preflight_skill_symlink_move(&canonical, root)?;
-                for peer in peers {
-                    if peer.agent == selected.agent && peer.scope == selected.scope {
-                        continue;
-                    }
-                    let shares = peer
-                        .roots
-                        .iter()
-                        .map(|scan| resolved_skill_root(scan))
-                        .collect::<Result<Vec<_>, _>>()?
-                        .iter()
-                        .any(|scan| skill_roots_overlap(scan, &resolved_root));
-                    if !shares
-                        || (canonical_item.layout == AgentSkillLayout::MarkdownFile
-                            && peer.kind == SkillStorageKind::SkillDirectoryOnly)
-                    {
-                        continue;
-                    }
-                    reject_multiple_active_skills(&peer.roots, peer.kind, &id)?;
-                    let active =
-                        locate_existing_skill_across_dirs(&peer.roots, peer.kind, &id, peer.scope)
-                            .filter(|item| item.enabled)
-                            .ok_or_else(|| {
-                                AcpError::protocol(
-                                    "shared skill restore would reenable a disabled peer",
-                                )
-                            })?;
-                    if !skill_link_targets(Path::new(&active.path), &canonical) {
-                        return Err(AcpError::protocol(
-                            "shared skill restore would conflict with an independent peer skill",
-                        ));
-                    }
-                    redundant_links.push(PathBuf::from(active.path));
-                    affected.push(peer);
-                }
+                affected =
+                    shared_skill_affected_peers(selected, peers, root, canonical_item.layout)?;
+                redundant_links = shared_skill_restore_links(&affected, &id, &canonical)?;
                 restore_shared = true;
             }
-            Err(error) => return Err(error),
         }
     } else if !skill_link_targets(Path::new(&original.path), &canonical) {
         return Err(AcpError::protocol(
@@ -9407,12 +9462,23 @@ fn skill_root_is_shared(
     workspace_path: Option<&str>,
     root: &Path,
 ) -> Result<bool, AcpError> {
+    skill_root_is_shared_with_peers(agent_type, scope, root, &skill_peers(workspace_path))
+}
+
+fn skill_root_is_shared_with_peers(
+    agent_type: AgentType,
+    scope: AgentSkillScope,
+    root: &Path,
+    peers: &[SkillPeer],
+) -> Result<bool, AcpError> {
     let resolved_root = resolved_skill_root(root)?;
-    for (peer, peer_scope, peer_root) in native_skill_roots(workspace_path) {
-        if (peer != agent_type || peer_scope != scope)
-            && skill_roots_overlap(&resolved_root, &resolved_skill_root(&peer_root)?)
-        {
-            return Ok(true);
+    for peer in peers {
+        if peer.agent != agent_type || peer.scope != scope {
+            for peer_root in &peer.roots {
+                if skill_roots_overlap(&resolved_root, &resolved_skill_root(peer_root)?) {
+                    return Ok(true);
+                }
+            }
         }
     }
     Ok(false)
@@ -13556,8 +13622,18 @@ pub async fn acp_list_agent_skills(
     }
 
     let mut skills = skills_by_key.into_values().collect::<Vec<_>>();
+    let peers = skill_peers(workspace_path.as_deref());
     for skill in &mut skills {
         apply_skill_capabilities(agent_type, skill);
+        if skill.can_toggle {
+            skill.can_toggle = peers
+                .iter()
+                .find(|peer| peer.agent == agent_type && peer.scope == skill.scope)
+                .is_some_and(|selected| {
+                    listed_skill_can_toggle(selected, &peers, skill, workspace_path.as_deref())
+                        .unwrap_or(false)
+                });
+        }
     }
     skills.sort_by(|a, b| {
         scope_rank(a.scope)
@@ -16936,6 +17012,129 @@ wire_api = "chat"
             })
             .collect();
         (shared, peers)
+    }
+
+    fn skill_capability_project_fixture(base: &Path) -> PathBuf {
+        let shared = base.join(".claude/skills");
+        fs::create_dir_all(shared.join("capability-demo")).unwrap();
+        fs::write(shared.join("capability-demo/SKILL.md"), "body").unwrap();
+        shared
+    }
+
+    fn skill_capability_list_project(
+        runtime: &tokio::runtime::Runtime,
+        agent: AgentType,
+        base: &Path,
+    ) -> AgentSkillItem {
+        runtime
+            .block_on(acp_list_agent_skills(
+                agent,
+                Some(base.to_string_lossy().into_owned()),
+            ))
+            .unwrap()
+            .skills
+            .into_iter()
+            .find(|item| item.scope == AgentSkillScope::Project && item.id == "capability-demo")
+            .unwrap()
+    }
+
+    #[test]
+    fn skill_capability_enabled_shared_without_unique_peer_root_is_false() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let item = skill_capability_list_project(&runtime, AgentType::Cline, tmp.path());
+        assert!(item.enabled);
+        assert!(
+            !item.can_toggle,
+            "Claude has no unique root to preserve its enabled state"
+        );
+        assert!(shared.join("capability-demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).exists());
+        assert!(!tmp.path().join(".cline").exists());
+    }
+
+    #[test]
+    fn skill_capability_feasible_shared_and_private_entries_are_true() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let private = tmp.path().join(".codex/skills/capability-demo");
+        fs::create_dir_all(&private).unwrap();
+        fs::write(private.join("SKILL.md"), "private").unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for agent in [AgentType::ClaudeCode, AgentType::Codex] {
+            assert!(skill_capability_list_project(&runtime, agent, tmp.path()).can_toggle);
+        }
+        assert!(!disabled_skill_root(&shared).exists());
+        assert!(!tmp.path().join(".cline").exists());
+    }
+
+    #[test]
+    fn skill_capability_disabled_shared_restore_is_true_when_peers_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::ClaudeCode,
+                AgentSkillScope::Project,
+                "capability-demo".into(),
+                Some(tmp.path().to_string_lossy().into_owned()),
+                false,
+            ))
+            .unwrap();
+        let item = skill_capability_list_project(&runtime, AgentType::ClaudeCode, tmp.path());
+        assert!(!item.enabled);
+        assert!(item.can_toggle);
+        assert!(!shared.join("capability-demo").exists());
+        assert!(disabled_skill_root(&shared)
+            .join("capability-demo/SKILL.md")
+            .is_file());
+        assert!(tmp
+            .path()
+            .join(".cline/skills/capability-demo/SKILL.md")
+            .is_file());
+    }
+
+    #[test]
+    fn skill_capability_disabled_shared_restore_is_false_when_peer_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for agent in [AgentType::ClaudeCode, AgentType::Cline] {
+            runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    agent,
+                    AgentSkillScope::Project,
+                    "capability-demo".into(),
+                    Some(tmp.path().to_string_lossy().into_owned()),
+                    false,
+                ))
+                .unwrap();
+        }
+        let item = skill_capability_list_project(&runtime, AgentType::ClaudeCode, tmp.path());
+        assert!(!item.enabled);
+        assert!(!item.can_toggle, "restoring shared root would enable Cline");
+        assert!(!shared.join("capability-demo").exists());
+        assert!(disabled_skill_root(&shared)
+            .join("capability-demo/SKILL.md")
+            .is_file());
+        assert!(fs::symlink_metadata(tmp.path().join(".cline/skills/capability-demo")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_capability_planning_error_keeps_item_but_disables_toggle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        fs::create_dir_all(tmp.path().join(".clinerules")).unwrap();
+        std::os::unix::fs::symlink("missing", tmp.path().join(".clinerules/skills")).unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let item = skill_capability_list_project(&runtime, AgentType::ClaudeCode, tmp.path());
+        assert!(!item.can_toggle);
+        assert!(item.enabled);
+        assert!(shared.join("capability-demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).exists());
     }
 
     fn shared_skill_custom_def(

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8375,6 +8375,9 @@ fn is_read_only_skill_path(agent_type: AgentType, skill_path: &Path) -> bool {
         AgentType::DeepSeek => crate::parsers::deepseek::resolve_dsh_home_dir()
             .join("skills")
             .join(".system"),
+        AgentType::Antigravity => {
+            crate::parsers::antigravity::resolve_antigravity_cli_dir().join("skills")
+        }
         _ => return false,
     };
     skill_path.starts_with(&ro_root)
@@ -15445,6 +15448,33 @@ wire_api = "chat"
                 .iter()
                 .find(|item| item.id == "task1a-system-demo")
                 .expect("listed system skill");
+
+            assert!(item.enabled);
+            assert!(item.read_only);
+            assert!(!item.can_toggle);
+        });
+    }
+
+    #[test]
+    fn skill_state_antigravity_cli_skill_cannot_toggle() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        temp_env::with_var("GEMINI_HOME", Some(tmp.path()), || {
+            let cli_skill = tmp
+                .path()
+                .join("antigravity-cli/skills/task1a-antigravity-cli-demo");
+            std::fs::create_dir_all(&cli_skill).expect("create CLI skill");
+            std::fs::write(cli_skill.join("SKILL.md"), "CLI-owned\n")
+                .expect("write CLI skill");
+
+            let listed = tokio::runtime::Runtime::new()
+                .expect("runtime")
+                .block_on(acp_list_agent_skills(AgentType::Antigravity, None))
+                .expect("list skills");
+            let item = listed
+                .skills
+                .iter()
+                .find(|item| item.id == "task1a-antigravity-cli-demo")
+                .expect("listed Antigravity CLI skill");
 
             assert!(item.enabled);
             assert!(item.read_only);

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8615,30 +8615,185 @@ pub(crate) fn locate_existing_skill_across_dirs(
     None
 }
 
-#[cfg(test)]
+// All settings mutations share this lock so lookup, preflight and mutation
+// observe one state. No guard is held across an await.
+static SKILL_MUTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn preflight_skill_symlink_move(source: &Path, destination_root: &Path) -> Result<(), AcpError> {
+    let metadata = fs::symlink_metadata(source)
+        .map_err(|e| AcpError::protocol(format!("failed to inspect skill entry: {e}")))?;
+    if !metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    let target = fs::read_link(source)
+        .map_err(|e| AcpError::protocol(format!("failed to read skill symlink: {e}")))?;
+    if target.is_absolute() {
+        return Ok(());
+    }
+    let original_target = fs::canonicalize(source)
+        .map_err(|e| AcpError::protocol(format!("failed to resolve skill symlink: {e}")))?;
+    let moved_target = if destination_root.exists() {
+        fs::canonicalize(destination_root.join(&target))
+    } else {
+        let parent = destination_root
+            .parent()
+            .ok_or_else(|| AcpError::protocol("skill destination has no parent"))?;
+        let name = destination_root
+            .file_name()
+            .ok_or_else(|| AcpError::protocol("skill destination has no directory name"))?;
+        let mut future_root = fs::canonicalize(parent)
+            .map_err(|e| AcpError::protocol(format!("failed to resolve skill destination: {e}")))?
+            .join(name);
+        // The future root is a new directory, so leading parent components
+        // can be evaluated without creating it. Keep subsequent components
+        // intact so canonicalize still follows any symlinks in the target.
+        let mut remaining = target.components();
+        loop {
+            match remaining.clone().next() {
+                Some(std::path::Component::CurDir) => {
+                    remaining.next();
+                }
+                Some(std::path::Component::ParentDir) => {
+                    future_root.pop();
+                    remaining.next();
+                }
+                _ => break,
+            }
+        }
+        fs::canonicalize(future_root.join(remaining.as_path()))
+    };
+    if moved_target.ok().as_ref() != Some(&original_target) {
+        return Err(AcpError::protocol(format!(
+            "relative symlink '{}' would resolve to a different or missing target after moving",
+            source.display()
+        )));
+    }
+    Ok(())
+}
+
+/// The caller must hold SKILL_MUTATION_LOCK when serving a backend command.
 fn set_private_skill_enabled(
-    _root: &Path,
-    _kind: SkillStorageKind,
-    _scope: AgentSkillScope,
-    _skill_id: &str,
-    _enabled: bool,
+    root: &Path,
+    kind: SkillStorageKind,
+    scope: AgentSkillScope,
+    skill_id: &str,
+    enabled: bool,
 ) -> Result<AgentSkillItem, AcpError> {
-    Err(AcpError::protocol(
-        "private skill moves are not implemented in task 1A",
+    let id = validate_skill_id(skill_id)?;
+    let roots = [root.to_path_buf()];
+    let skill = locate_existing_skill_across_dirs(&roots, kind, &id, scope)
+        .ok_or_else(|| AcpError::protocol(format!("skill not found: {id}")))?;
+    if skill.enabled == enabled {
+        return Ok(skill);
+    }
+
+    let vault = disabled_skill_root(root);
+    let destination_root = if enabled { root } else { &vault };
+    let source = Path::new(&skill.path);
+    let file_name = source
+        .file_name()
+        .ok_or_else(|| AcpError::protocol("skill entry has no file name"))?;
+    let destination = destination_root.join(file_name);
+    let mut candidates = vec![destination.clone(), destination_root.join(&id)];
+    if matches!(kind, SkillStorageKind::SkillDirectoryOrMarkdownFile) {
+        candidates.push(destination_root.join(format!("{id}.md")));
+    }
+    for candidate in candidates {
+        match fs::symlink_metadata(&candidate) {
+            Ok(_) => {
+                return Err(AcpError::protocol(format!(
+                    "skill destination collision: '{}' already exists",
+                    candidate.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(AcpError::protocol(format!(
+                    "failed to inspect skill destination '{}': {error}",
+                    candidate.display()
+                )));
+            }
+        }
+    }
+
+    preflight_skill_symlink_move(source, destination_root)?;
+    fs::create_dir_all(destination_root)
+        .map_err(|e| AcpError::protocol(format!("failed to create skills directory: {e}")))?;
+    // Rename the entry itself, including symlinks; never copy/dereference a
+    // bundle whose supporting files may belong to a separate central store.
+    fs::rename(source, &destination)
+        .map_err(|e| AcpError::protocol(format!("failed to move skill '{id}': {e}")))?;
+    Ok(build_skill_item(
+        id,
+        scope,
+        skill.layout,
+        destination,
+        enabled,
     ))
 }
 
-#[cfg(test)]
-async fn acp_set_agent_skill_enabled(
-    _agent_type: AgentType,
-    _scope: AgentSkillScope,
-    _skill_id: String,
-    _workspace_path: Option<String>,
-    _enabled: bool,
-) -> Result<AgentSkillItem, AcpError> {
-    Err(AcpError::protocol(
-        "skill toggle command is not implemented in task 1A",
-    ))
+fn skill_root_is_shared(
+    agent_type: AgentType,
+    scope: AgentSkillScope,
+    workspace_path: Option<&str>,
+    root: &Path,
+) -> bool {
+    let resolved_root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    registry::all_acp_agents().into_iter().any(|peer| {
+        peer != agent_type
+            && scoped_skill_dirs(peer, scope, workspace_path)
+                .unwrap_or_default()
+                .iter()
+                .any(|peer_root| {
+                    *peer_root == root
+                        || fs::canonicalize(peer_root)
+                            .map(|path| path == resolved_root)
+                            .unwrap_or(false)
+                })
+    })
+}
+
+fn reject_multiple_active_skills(
+    roots: &[PathBuf],
+    kind: SkillStorageKind,
+    skill_id: &str,
+) -> Result<(), AcpError> {
+    let mut matches = 0;
+    for root in roots {
+        let entries = match fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(AcpError::protocol(format!(
+                    "failed to inspect active skills directory '{}': {error}",
+                    root.display()
+                )));
+            }
+        };
+        // Listing intentionally deduplicates IDs; preflight must count both
+        // layouts so disabling a bundle cannot reveal its same-ID flat file.
+        for entry in entries {
+            let path = entry
+                .map_err(|e| AcpError::protocol(format!("failed to inspect active skill: {e}")))?
+                .path();
+            let directory_match = path.file_name().and_then(|name| name.to_str()) == Some(skill_id)
+                && path.is_dir()
+                && path.join("SKILL.md").is_file();
+            let markdown_match = matches!(kind, SkillStorageKind::SkillDirectoryOrMarkdownFile)
+                && path.file_stem().and_then(|name| name.to_str()) == Some(skill_id)
+                && is_markdown_file(&path)
+                && path.is_file();
+            if directory_match || markdown_match {
+                matches += 1;
+                if matches > 1 {
+                    return Err(AcpError::protocol(format!(
+                        "multiple active skills share id '{skill_id}'; resolve duplicates before toggling"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -12686,12 +12841,67 @@ pub async fn acp_list_agent_skills(
 }
 
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
+pub async fn acp_set_agent_skill_enabled(
+    agent_type: AgentType,
+    scope: AgentSkillScope,
+    skill_id: String,
+    workspace_path: Option<String>,
+    enabled: bool,
+) -> Result<AgentSkillItem, AcpError> {
+    let _guard = SKILL_MUTATION_LOCK
+        .lock()
+        .map_err(|_| AcpError::protocol("skill mutation lock poisoned"))?;
+    let spec = skill_storage_spec(agent_type).ok_or_else(|| {
+        AcpError::protocol(format!(
+            "{agent_type} skills are not supported in Settings yet"
+        ))
+    })?;
+    let id = validate_skill_id(&skill_id)?;
+    let dirs = scoped_skill_dirs(agent_type, scope, workspace_path.as_deref())?;
+    let mut skill = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope)
+        .ok_or_else(|| AcpError::protocol(format!("skill not found: {id}")))?;
+    apply_skill_capabilities(agent_type, &mut skill);
+    let parent = Path::new(&skill.path).parent();
+    let root = dirs
+        .iter()
+        .find(|root| {
+            if skill.enabled {
+                parent == Some(root.as_path())
+            } else {
+                parent == Some(disabled_skill_root(root).as_path())
+            }
+        })
+        .ok_or_else(|| AcpError::protocol("skill has no owning native root"))?;
+    if !skill.can_toggle || is_read_only_skill_path(agent_type, root) {
+        return Err(AcpError::protocol(format!(
+            "skill '{id}' is a built-in system skill and cannot be toggled"
+        )));
+    }
+    if skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), root) {
+        // Task 2 owns peer fan-out and per-agent isolation for shared roots.
+        return Err(AcpError::protocol(format!(
+            "shared skill root '{}' requires shared-root toggle support",
+            root.display()
+        )));
+    }
+    reject_multiple_active_skills(&dirs, spec.kind, &id)?;
+    set_private_skill_enabled(root, spec.kind, scope, &id, enabled)?;
+    let mut authoritative = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope)
+        .ok_or_else(|| AcpError::protocol(format!("skill not found after toggle: {id}")))?;
+    apply_skill_capabilities(agent_type, &mut authoritative);
+    Ok(authoritative)
+}
+
+#[cfg_attr(feature = "tauri-runtime", tauri::command)]
 pub async fn acp_read_agent_skill(
     agent_type: AgentType,
     scope: AgentSkillScope,
     skill_id: String,
     workspace_path: Option<String>,
 ) -> Result<AgentSkillContent, AcpError> {
+    let _guard = SKILL_MUTATION_LOCK
+        .lock()
+        .map_err(|_| AcpError::protocol("skill mutation lock poisoned"))?;
     let Some(spec) = skill_storage_spec(agent_type) else {
         return Err(AcpError::protocol(format!(
             "{agent_type} skills are not supported in Settings yet"
@@ -12718,6 +12928,9 @@ pub async fn acp_save_agent_skill(
     workspace_path: Option<String>,
     layout: Option<AgentSkillLayout>,
 ) -> Result<AgentSkillItem, AcpError> {
+    let _guard = SKILL_MUTATION_LOCK
+        .lock()
+        .map_err(|_| AcpError::protocol("skill mutation lock poisoned"))?;
     let Some(spec) = skill_storage_spec(agent_type) else {
         return Err(AcpError::protocol(format!(
             "{agent_type} skills are not supported in Settings yet"
@@ -12726,9 +12939,6 @@ pub async fn acp_save_agent_skill(
     let id = validate_skill_id(&skill_id)?;
     let dirs = scoped_skill_dirs(agent_type, scope, workspace_path.as_deref())?;
     let preferred_dir = preferred_scope_skill_dir(agent_type, scope, workspace_path.as_deref())?;
-
-    fs::create_dir_all(&preferred_dir)
-        .map_err(|e| AcpError::protocol(format!("failed to create skills directory: {e}")))?;
 
     let existing = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope);
     if let Some(ref item) = existing {
@@ -12785,6 +12995,9 @@ pub async fn acp_delete_agent_skill(
     skill_id: String,
     workspace_path: Option<String>,
 ) -> Result<(), AcpError> {
+    let _guard = SKILL_MUTATION_LOCK
+        .lock()
+        .map_err(|_| AcpError::protocol("skill mutation lock poisoned"))?;
     let Some(spec) = skill_storage_spec(agent_type) else {
         return Err(AcpError::protocol(format!(
             "{agent_type} skills are not supported in Settings yet"
@@ -15775,6 +15988,327 @@ wire_api = "chat"
                 assert_eq!(item.enabled, enabled);
             }
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_enabled_private_symlink_round_trip_preserves_link_and_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let target = tmp.path().join("target");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "linked body").unwrap();
+        std::os::unix::fs::symlink("../target", root.join("linked")).unwrap();
+
+        for enabled in [false, true] {
+            let item = set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOnly,
+                AgentSkillScope::Global,
+                "linked",
+                enabled,
+            )
+            .unwrap();
+            assert_eq!(fs::read_link(&item.path).unwrap(), Path::new("../target"));
+            assert_eq!(
+                fs::read_to_string(target.join("SKILL.md")).unwrap(),
+                "linked body"
+            );
+            assert_eq!(item.enabled, enabled);
+        }
+    }
+
+    #[test]
+    fn skill_enabled_private_collision_checks_other_layout_before_mutation() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let vault = disabled_skill_root(&root);
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "active").unwrap();
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(vault.join("demo.md"), "disabled").unwrap();
+
+        let error = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOrMarkdownFile,
+            AgentSkillScope::Global,
+            "demo",
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("collision"));
+        assert_eq!(
+            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+            "active"
+        );
+        assert_eq!(
+            fs::read_to_string(vault.join("demo.md")).unwrap(),
+            "disabled"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_enabled_private_relative_symlink_target_change_is_rejected_before_move() {
+        for vault_exists in [false, true] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let root = tmp.path().join("skills");
+            let vault = disabled_skill_root(&root);
+            fs::create_dir_all(root.join("target")).unwrap();
+            fs::write(root.join("target/SKILL.md"), "original target").unwrap();
+            std::os::unix::fs::symlink("target", root.join("demo")).unwrap();
+            if vault_exists {
+                fs::create_dir_all(vault.join("target")).unwrap();
+                fs::write(vault.join("target/SKILL.md"), "different target").unwrap();
+            }
+            let error = set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOnly,
+                AgentSkillScope::Global,
+                "demo",
+                false,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("relative symlink"));
+            assert_eq!(
+                fs::read_link(root.join("demo")).unwrap(),
+                Path::new("target")
+            );
+            assert_eq!(
+                fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+                "original target"
+            );
+            assert!(!vault.join("demo").exists());
+            assert_eq!(vault.exists(), vault_exists);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_enabled_private_absolute_symlink_round_trip_preserves_link() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let target = tmp.path().join("target.md");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&target, "absolute target").unwrap();
+        std::os::unix::fs::symlink(&target, root.join("demo.md")).unwrap();
+        for enabled in [false, true] {
+            let item = set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOrMarkdownFile,
+                AgentSkillScope::Global,
+                "demo",
+                enabled,
+            )
+            .unwrap();
+            assert_eq!(fs::read_link(&item.path).unwrap(), target);
+            assert_eq!(fs::read_to_string(item.path).unwrap(), "absolute target");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_enabled_private_enable_rejects_dangling_destination_link() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let vault = disabled_skill_root(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&vault).unwrap();
+        fs::write(vault.join("demo.md"), "disabled").unwrap();
+        std::os::unix::fs::symlink("missing", root.join("demo.md")).unwrap();
+
+        let error = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOrMarkdownFile,
+            AgentSkillScope::Global,
+            "demo",
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("collision"));
+        assert_eq!(
+            fs::read_link(root.join("demo.md")).unwrap(),
+            Path::new("missing")
+        );
+        assert_eq!(
+            fs::read_to_string(vault.join("demo.md")).unwrap(),
+            "disabled"
+        );
+    }
+
+    #[test]
+    fn skill_enabled_private_command_leaves_shared_roots_for_task_two() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for (agent, relative) in [
+            (AgentType::Codex, ".agents/skills"),
+            (AgentType::ClaudeCode, ".claude/skills"),
+            (AgentType::Gemini, ".gemini/skills"),
+        ] {
+            let root = tmp.path().join(relative);
+            fs::create_dir_all(root.join("demo")).unwrap();
+            fs::write(root.join("demo/SKILL.md"), "shared").unwrap();
+            let error = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    agent,
+                    AgentSkillScope::Project,
+                    "demo".to_string(),
+                    Some(tmp.path().to_string_lossy().into_owned()),
+                    false,
+                ))
+                .unwrap_err();
+            assert!(error.to_string().contains("shared skill root"));
+            assert!(root.join("demo/SKILL.md").is_file());
+            assert!(!disabled_skill_root(&root).exists());
+        }
+    }
+
+    #[test]
+    fn skill_enabled_private_concurrent_commands_return_requested_state() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join(".codex/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "body").unwrap();
+        let workspace = tmp.path().to_string_lossy().into_owned();
+        std::thread::scope(|threads| {
+            let handles = (0..8)
+                .map(|_| {
+                    let workspace = &workspace;
+                    threads.spawn(move || {
+                        let runtime = tokio::runtime::Runtime::new().unwrap();
+                        for enabled in [false, false, true, true] {
+                            let item = runtime
+                                .block_on(acp_set_agent_skill_enabled(
+                                    AgentType::Codex,
+                                    AgentSkillScope::Project,
+                                    "demo".to_string(),
+                                    Some(workspace.clone()),
+                                    enabled,
+                                ))
+                                .unwrap();
+                            assert_eq!(item.enabled, enabled);
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        });
+        assert_eq!(
+            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+            "body"
+        );
+        assert!(!disabled_skill_root(&root).join("demo").exists());
+    }
+
+    #[test]
+    fn skill_enabled_private_duplicate_active_roots_are_rejected_before_move() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let roots = [
+            tmp.path().join(".codex/skills"),
+            tmp.path().join(".agents/skills"),
+        ];
+        for root in &roots {
+            fs::create_dir_all(root.join("demo")).unwrap();
+            fs::write(root.join("demo/SKILL.md"), "original").unwrap();
+        }
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let error = runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                Some(tmp.path().to_string_lossy().into_owned()),
+                false,
+            ))
+            .unwrap_err();
+        assert!(error.to_string().contains("multiple active"));
+        for root in &roots {
+            assert_eq!(
+                fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+                "original"
+            );
+            assert!(!disabled_skill_root(root).exists());
+        }
+    }
+
+    #[test]
+    fn skill_enabled_private_duplicate_active_layouts_are_rejected_before_move() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join(".codex/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "directory").unwrap();
+        fs::write(root.join("demo.md"), "flat").unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let error = runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                Some(tmp.path().to_string_lossy().into_owned()),
+                false,
+            ))
+            .unwrap_err();
+        assert!(error.to_string().contains("multiple active"));
+        assert_eq!(
+            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+            "directory"
+        );
+        assert_eq!(fs::read_to_string(root.join("demo.md")).unwrap(), "flat");
+        assert!(!disabled_skill_root(&root).exists());
+    }
+
+    #[test]
+    fn skill_enabled_private_save_new_then_edit_disabled_and_reenable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace = Some(tmp.path().to_string_lossy().into_owned());
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let saved = runtime
+            .block_on(acp_save_agent_skill(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                "original".into(),
+                workspace.clone(),
+                None,
+            ))
+            .unwrap();
+        assert!(saved.enabled);
+        assert_eq!(saved.layout, AgentSkillLayout::MarkdownFile);
+        runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                workspace.clone(),
+                false,
+            ))
+            .unwrap();
+        let saved = runtime
+            .block_on(acp_save_agent_skill(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                "updated".into(),
+                workspace.clone(),
+                Some(AgentSkillLayout::SkillDirectory),
+            ))
+            .unwrap();
+        assert!(!saved.enabled);
+        assert_eq!(saved.layout, AgentSkillLayout::MarkdownFile);
+        let enabled = runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                workspace,
+                true,
+            ))
+            .unwrap();
+        assert!(enabled.enabled);
+        assert_eq!(fs::read_to_string(enabled.path).unwrap(), "updated");
     }
 
     #[test]

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -9071,12 +9071,46 @@ fn shared_skill_restore_links(
     Ok(links)
 }
 
+fn plan_shared_skill_fanout<'a>(
+    selected: &SkillPeer,
+    peers: &'a [SkillPeer],
+    root: &Path,
+    skill: &AgentSkillItem,
+) -> Result<Vec<(&'a SkillPeer, PathBuf)>, AcpError> {
+    let vault = disabled_skill_root(root);
+    preflight_skill_destination(&vault, &skill.id)?;
+    for scan in &selected.roots {
+        preflight_skill_destination(&disabled_skill_root(scan), &skill.id)?;
+    }
+    let source = Path::new(&skill.path);
+    preflight_skill_symlink_move(source, &vault)?;
+    let filename = source
+        .file_name()
+        .ok_or_else(|| AcpError::protocol("skill has no filename"))?;
+    let mut destinations = Vec::new();
+    for peer in shared_skill_affected_peers(selected, peers, root, skill.layout)? {
+        reject_multiple_active_skills(&peer.roots, peer.kind, &skill.id)?;
+        for scan in &peer.roots {
+            preflight_skill_destination(&disabled_skill_root(scan), &skill.id)?;
+        }
+        let destination_root = unique_skill_root(peer, peers)?.ok_or_else(|| {
+            AcpError::protocol(format!(
+                "shared skill root: {} has no unique writable root",
+                peer.agent
+            ))
+        })?;
+        preflight_skill_destination(&destination_root, &skill.id)?;
+        destinations.push((peer, destination_root.join(filename)));
+    }
+    Ok(destinations)
+}
+
 fn listed_skill_can_toggle(
     selected: &SkillPeer,
     peers: &[SkillPeer],
     skill: &AgentSkillItem,
-    workspace_path: Option<&str>,
 ) -> Result<bool, AcpError> {
+    reject_multiple_active_skills(&selected.roots, selected.kind, &skill.id)?;
     let parent = Path::new(&skill.path).parent();
     let root = selected
         .roots
@@ -9093,25 +9127,24 @@ fn listed_skill_can_toggle(
         return Ok(true);
     }
     preflight_shared_skill_owner(root, peers)?;
-    preflight_disabled_skill_root(root, workspace_path)?;
-    let affected = shared_skill_affected_peers(selected, peers, root, skill.layout)?;
+    preflight_disabled_skill_root_with_peers(root, peers)?;
     if skill.enabled {
         if !skill_root_writable(root) || !skill_root_writable(&disabled_skill_root(root)) {
             return Ok(false);
         }
-        for peer in affected {
-            if unique_skill_root(peer, peers)?.is_none() {
-                return Ok(false);
-            }
-        }
+        plan_shared_skill_fanout(selected, peers, root, skill)?;
         return Ok(true);
     }
-    if unique_skill_root(selected, peers)?.is_some() {
+    if let Some(destination_root) = unique_skill_root(selected, peers)? {
+        preflight_skill_destination(&destination_root, &skill.id)?;
         return Ok(true);
     }
     if !skill_root_writable(root) || !skill_root_writable(&disabled_skill_root(root)) {
         return Ok(false);
     }
+    preflight_skill_destination(root, &skill.id)?;
+    preflight_skill_symlink_move(Path::new(&skill.path), root)?;
+    let affected = shared_skill_affected_peers(selected, peers, root, skill.layout)?;
     shared_skill_restore_links(&affected, &skill.id, Path::new(&skill.path))?;
     Ok(true)
 }
@@ -9282,23 +9315,7 @@ fn set_shared_skill_enabled(
     let resolved_root = resolved_skill_root(root)?;
     let vault = disabled_skill_root(root);
     let resolved_vault = resolved_skill_root(&vault)?;
-    for peer in peers {
-        for native in &peer.roots {
-            let resolved_native = resolved_skill_root(native)?;
-            if skill_roots_overlap(&resolved_vault, &resolved_native) {
-                return Err(AcpError::protocol(
-                    "disabled skill vault overlaps native scan root",
-                ));
-            }
-            if resolved_native != resolved_root
-                && resolved_skill_root(&disabled_skill_root(native))? == resolved_vault
-            {
-                return Err(AcpError::protocol(
-                    "shared skill storage: disabled vault has multiple native owners",
-                ));
-            }
-        }
-    }
+    preflight_disabled_skill_root_with_peers(root, peers)?;
     let first_disable = original.enabled
         && resolved_skill_root(Path::new(&original.path).parent().expect("skill parent"))?
             == resolved_root;
@@ -9317,24 +9334,8 @@ fn set_shared_skill_enabled(
     let mut restore_shared = false;
     let mut redundant_links = Vec::new();
     if first_disable {
-        preflight_skill_destination(&vault, &id)?;
-        for scan in &selected.roots {
-            preflight_skill_destination(&disabled_skill_root(scan), &id)?;
-        }
-        preflight_skill_symlink_move(Path::new(&original.path), &vault)?;
-        for peer in shared_skill_affected_peers(selected, peers, root, canonical_item.layout)? {
-            reject_multiple_active_skills(&peer.roots, peer.kind, &id)?;
-            for scan in &peer.roots {
-                preflight_skill_destination(&disabled_skill_root(scan), &id)?;
-            }
-            let destination_root = unique_skill_root(peer, peers)?.ok_or_else(|| {
-                AcpError::protocol(format!(
-                    "shared skill root: {} has no unique writable root",
-                    peer.agent
-                ))
-            })?;
-            preflight_skill_destination(&destination_root, &id)?;
-            destinations.push(destination_root.join(file_name));
+        for (peer, destination) in plan_shared_skill_fanout(selected, peers, root, &original)? {
+            destinations.push(destination);
             affected.push(peer);
         }
     } else if enabled {
@@ -9488,11 +9489,18 @@ fn preflight_disabled_skill_root(
     root: &Path,
     workspace_path: Option<&str>,
 ) -> Result<(), AcpError> {
+    preflight_disabled_skill_root_with_peers(root, &skill_peers(workspace_path))
+}
+
+fn preflight_disabled_skill_root_with_peers(
+    root: &Path,
+    peers: &[SkillPeer],
+) -> Result<(), AcpError> {
     let vault = disabled_skill_root(root);
     let resolved_vault = resolved_skill_root(&vault)?;
     let resolved_root = resolved_skill_root(root)?;
-    for (_, _, native_root) in native_skill_roots(workspace_path) {
-        let resolved_native = resolved_skill_root(&native_root)?;
+    for native_root in peers.iter().flat_map(|peer| &peer.roots) {
+        let resolved_native = resolved_skill_root(native_root)?;
         if skill_roots_overlap(&resolved_vault, &resolved_native) {
             return Err(AcpError::protocol(format!(
                 "disabled skill vault '{}' overlaps native scan root '{}'",
@@ -9501,7 +9509,7 @@ fn preflight_disabled_skill_root(
             )));
         }
         if resolved_native != resolved_root
-            && resolved_vault == resolved_skill_root(&disabled_skill_root(&native_root))?
+            && resolved_vault == resolved_skill_root(&disabled_skill_root(native_root))?
         {
             return Err(AcpError::protocol(format!(
                 "shared skill storage: disabled vault '{}' is shared by native roots '{}' and '{}'; toggling is unsupported",
@@ -13630,8 +13638,7 @@ pub async fn acp_list_agent_skills(
                 .iter()
                 .find(|peer| peer.agent == agent_type && peer.scope == skill.scope)
                 .is_some_and(|selected| {
-                    listed_skill_can_toggle(selected, &peers, skill, workspace_path.as_deref())
-                        .unwrap_or(false)
+                    listed_skill_can_toggle(selected, &peers, skill).unwrap_or(false)
                 });
         }
     }
@@ -17133,6 +17140,96 @@ wire_api = "chat"
         let item = skill_capability_list_project(&runtime, AgentType::ClaudeCode, tmp.path());
         assert!(!item.can_toggle);
         assert!(item.enabled);
+        assert!(shared.join("capability-demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[test]
+    fn skill_capability_unique_enable_ignores_unneeded_shared_restore_peers() {
+        use crate::acp::custom_registry::{hydrate, hydrate_test_guard};
+        let _registry_guard = hydrate_test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let workspace = Some(tmp.path().to_string_lossy().into_owned());
+        for agent in [AgentType::ClaudeCode, AgentType::Cline] {
+            runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    agent,
+                    AgentSkillScope::Project,
+                    "capability-demo".into(),
+                    workspace.clone(),
+                    false,
+                ))
+                .unwrap();
+        }
+        let nested = shared.join("nested/skills");
+        fs::create_dir_all(&nested).unwrap();
+        assert!(hydrate(&[shared_skill_custom_def("capability-nested-peer", &nested)]).is_empty());
+        let listed = skill_capability_list_project(&runtime, AgentType::Cline, tmp.path());
+        assert!(!tmp.path().join(".cline/skills/capability-demo").exists());
+        let enabled = runtime.block_on(acp_set_agent_skill_enabled(
+            AgentType::Cline,
+            AgentSkillScope::Project,
+            "capability-demo".into(),
+            workspace,
+            true,
+        ));
+        hydrate(&[]);
+        assert!(
+            enabled.unwrap().enabled,
+            "execution can enable via Cline's unique root"
+        );
+        assert!(
+            listed.can_toggle,
+            "unique enable does not restore the shared root"
+        );
+    }
+
+    #[test]
+    fn skill_capability_shared_peer_duplicate_is_false_before_fanout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let independent = tmp.path().join(".cline/skills/capability-demo");
+        fs::create_dir_all(&independent).unwrap();
+        fs::write(independent.join("SKILL.md"), "independent").unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let listed = skill_capability_list_project(&runtime, AgentType::ClaudeCode, tmp.path());
+        let error = runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::ClaudeCode,
+                AgentSkillScope::Project,
+                "capability-demo".into(),
+                Some(tmp.path().to_string_lossy().into_owned()),
+                false,
+            ))
+            .unwrap_err();
+        assert!(error.to_string().contains("multiple active skills"));
+        assert!(
+            !listed.can_toggle,
+            "existing peer duplicate blocks the same fanout execution"
+        );
+        assert!(shared.join("capability-demo/SKILL.md").is_file());
+        assert_eq!(
+            fs::read_to_string(independent.join("SKILL.md")).unwrap(),
+            "independent"
+        );
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[test]
+    fn skill_capability_existing_fanout_destination_conflict_is_false() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = skill_capability_project_fixture(tmp.path());
+        let peer_root = tmp.path().join(".cline/skills");
+        fs::create_dir_all(&peer_root).unwrap();
+        fs::write(peer_root.join("capability-demo"), "occupied").unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let listed = skill_capability_list_project(&runtime, AgentType::ClaudeCode, tmp.path());
+        assert!(
+            !listed.can_toggle,
+            "existing destination conflicts are deterministic blockers"
+        );
         assert!(shared.join("capability-demo/SKILL.md").is_file());
         assert!(!disabled_skill_root(&shared).exists());
     }

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8923,12 +8923,22 @@ fn preflight_disabled_skill_root(
 ) -> Result<(), AcpError> {
     let vault = disabled_skill_root(root);
     let resolved_vault = resolved_skill_root(&vault)?;
+    let resolved_root = resolved_skill_root(root)?;
     for (_, _, native_root) in native_skill_roots(workspace_path) {
-        if skill_roots_overlap(&resolved_vault, &resolved_skill_root(&native_root)?) {
+        let resolved_native = resolved_skill_root(&native_root)?;
+        if skill_roots_overlap(&resolved_vault, &resolved_native) {
             return Err(AcpError::protocol(format!(
                 "disabled skill vault '{}' overlaps native scan root '{}'",
                 vault.display(),
                 native_root.display()
+            )));
+        }
+        if resolved_native != resolved_root
+            && resolved_vault == resolved_skill_root(&disabled_skill_root(&native_root))?
+        {
+            return Err(AcpError::protocol(format!(
+                "shared skill storage: disabled vault '{}' is shared by native roots '{}' and '{}'; toggling is unsupported",
+                vault.display(), root.display(), native_root.display()
             )));
         }
     }
@@ -16797,6 +16807,161 @@ wire_api = "chat"
             "shared"
         );
         assert!(!disabled_skill_root(&root).exists());
+    }
+
+    #[test]
+    fn skill_enabled_private_safety_sibling_custom_roots_cannot_share_vault() {
+        use crate::acp::custom_registry::{
+            hydrate, hydrate_test_guard, CustomAgentDef, CustomAgentSpec, CustomDistributionKind,
+            NpxSpec,
+        };
+        let _registry_guard = hydrate_test_guard();
+        for enabled in [false, true] {
+            let tmp = tempfile::tempdir().unwrap();
+            let first_root = tmp.path().join("agent-a");
+            let second_root = tmp.path().join("agent-b");
+            fs::create_dir_all(&first_root).unwrap();
+            fs::create_dir_all(&second_root).unwrap();
+            let vault = disabled_skill_root(&first_root);
+            assert_eq!(vault, disabled_skill_root(&second_root));
+            let source = if enabled {
+                vault.join("demo")
+            } else {
+                first_root.join("demo")
+            };
+            fs::create_dir_all(&source).unwrap();
+            fs::write(source.join("SKILL.md"), "owned by agent A").unwrap();
+            let definitions = [
+                ("task1b-vault-a", &first_root),
+                ("task1b-vault-b", &second_root),
+            ]
+            .map(|(id, root)| CustomAgentDef {
+                registry_id: id.into(),
+                name: id.into(),
+                description: String::new(),
+                version: "1.0.0".into(),
+                distribution_kind: CustomDistributionKind::Npx,
+                spec: CustomAgentSpec {
+                    npx: Some(NpxSpec {
+                        package: "test-agent@1.0.0".into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                icon_url: None,
+                skills_shared_store: false,
+                skills_dir: Some(root.to_string_lossy().into_owned()),
+                source: Default::default(),
+                version_probe: None,
+                supports_mcp: true,
+            });
+            assert!(hydrate(&definitions).is_empty());
+            let agent = AgentType::custom(if enabled {
+                "task1b-vault-b"
+            } else {
+                "task1b-vault-a"
+            })
+            .unwrap();
+            let result =
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(acp_set_agent_skill_enabled(
+                        agent,
+                        AgentSkillScope::Global,
+                        "demo".into(),
+                        None,
+                        enabled,
+                    ));
+            hydrate(&[]);
+            assert!(
+                result.is_err(),
+                "shared vault must reject before mutation: {result:?}"
+            );
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("shared skill storage"));
+            assert_eq!(
+                fs::read_to_string(source.join("SKILL.md")).unwrap(),
+                "owned by agent A"
+            );
+            assert!(!second_root.join("demo").exists());
+            assert_eq!(vault.exists(), enabled);
+        }
+    }
+
+    #[test]
+    fn skill_enabled_private_safety_read_only_root_cannot_share_vault() {
+        use crate::acp::custom_registry::{
+            hydrate, hydrate_test_guard, CustomAgentDef, CustomAgentSpec, CustomDistributionKind,
+            NpxSpec,
+        };
+        let _registry_guard = hydrate_test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        temp_env::with_var("GEMINI_HOME", Some(tmp.path()), || {
+            let cli_root =
+                crate::parsers::antigravity::resolve_antigravity_cli_dir().join("skills");
+            let root = cli_root.parent().unwrap().join("custom-skills");
+            fs::create_dir_all(&cli_root).unwrap();
+            fs::create_dir_all(root.join("task1b-readonly-vault-demo")).unwrap();
+            fs::write(
+                root.join("task1b-readonly-vault-demo/SKILL.md"),
+                "owned by custom agent",
+            )
+            .unwrap();
+            assert!(is_read_only_skill_path(AgentType::Antigravity, &cli_root));
+            assert_eq!(disabled_skill_root(&root), disabled_skill_root(&cli_root));
+            let definition = CustomAgentDef {
+                registry_id: "task1b-vault-cli".into(),
+                name: "CLI Vault Test".into(),
+                description: String::new(),
+                version: "1.0.0".into(),
+                distribution_kind: CustomDistributionKind::Npx,
+                spec: CustomAgentSpec {
+                    npx: Some(NpxSpec {
+                        package: "test-agent@1.0.0".into(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                icon_url: None,
+                skills_shared_store: false,
+                skills_dir: Some(root.to_string_lossy().into_owned()),
+                source: Default::default(),
+                version_probe: None,
+                supports_mcp: true,
+            };
+            assert!(hydrate(&[definition]).is_empty());
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let result = runtime.block_on(acp_set_agent_skill_enabled(
+                AgentType::custom("task1b-vault-cli").unwrap(),
+                AgentSkillScope::Global,
+                "task1b-readonly-vault-demo".into(),
+                None,
+                false,
+            ));
+            let listed = runtime
+                .block_on(acp_list_agent_skills(AgentType::Antigravity, None))
+                .unwrap();
+            hydrate(&[]);
+            assert!(
+                result.is_err(),
+                "read-only native root also scans its vault: {result:?}"
+            );
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains("shared skill storage"));
+            assert_eq!(
+                fs::read_to_string(root.join("task1b-readonly-vault-demo/SKILL.md")).unwrap(),
+                "owned by custom agent"
+            );
+            assert!(!disabled_skill_root(&root).exists());
+            assert!(!listed
+                .skills
+                .iter()
+                .any(|item| item.id == "task1b-readonly-vault-demo"));
+        });
     }
 
     #[test]

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8846,27 +8846,18 @@ fn parse_codex_skill_config(
 
 impl CodexSkillConfig {
     fn skill_enabled(&self, path: &Path, name: &str) -> bool {
-        if let Some(enabled) = self
-            .entries
-            .iter()
-            .filter(|entry| {
-                entry
-                    .path
-                    .as_deref()
-                    .is_some_and(|configured| same_skill_config_path(configured, path))
-            })
-            .map(|entry| entry.enabled)
-            .next_back()
-        {
-            return enabled;
-        }
-
-        self.entries
-            .iter()
-            .filter(|entry| entry.name.as_deref() == Some(name))
-            .map(|entry| entry.enabled)
-            .next_back()
-            .unwrap_or(true)
+        self.entries.iter().fold(true, |enabled, entry| {
+            let path_matches = entry
+                .path
+                .as_deref()
+                .is_some_and(|configured| same_skill_config_path(configured, path));
+            let name_matches = entry.name.as_deref() == Some(name);
+            if path_matches || name_matches {
+                entry.enabled
+            } else {
+                enabled
+            }
+        })
     }
 }
 
@@ -8885,6 +8876,7 @@ fn codex_skill_entries_enabled(
 fn apply_codex_skill_enabled_config(
     base_toml: &str,
     codex_home: &Path,
+    skill_name: &str,
     paths: &[PathBuf],
     enabled: bool,
 ) -> Result<String, AcpError> {
@@ -8917,22 +8909,30 @@ fn apply_codex_skill_enabled_config(
     let config = skills
         .get_mut("config")
         .ok_or_else(|| AcpError::protocol("invalid codex config.toml: missing skills.config"))?;
+    // Codex applies matching rules in order. Update an existing path rule only
+    // when it is the final match; otherwise append a path-specific override.
     match config {
         toml_edit::Item::ArrayOfTables(config) => {
             for path in unique_paths {
-                let mut matched = false;
-                for entry in config.iter_mut() {
+                let mut last_matching_path = None;
+                for (index, entry) in config.iter().enumerate() {
                     let path_matches = entry
                         .get("path")
                         .and_then(toml_edit::Item::as_str)
                         .map(|configured| resolve_codex_skill_config_path(configured, codex_home))
                         .is_some_and(|configured| same_skill_config_path(&configured, &path));
-                    if path_matches {
-                        entry.insert("enabled", toml_edit::value(enabled));
-                        matched = true;
+                    let name_matches =
+                        entry.get("name").and_then(toml_edit::Item::as_str) == Some(skill_name);
+                    if path_matches || name_matches {
+                        last_matching_path = path_matches.then_some(index);
                     }
                 }
-                if !matched {
+                if let Some(index) = last_matching_path {
+                    config
+                        .get_mut(index)
+                        .expect("matching Codex skill config entry must exist")
+                        .insert("enabled", toml_edit::value(enabled));
+                } else {
                     let mut entry = toml_edit::Table::new();
                     entry.insert("path", toml_edit::value(path.to_string_lossy().as_ref()));
                     entry.insert("enabled", toml_edit::value(enabled));
@@ -8942,9 +8942,9 @@ fn apply_codex_skill_enabled_config(
         }
         toml_edit::Item::Value(toml_edit::Value::Array(config)) => {
             for path in unique_paths {
-                let mut matched = false;
-                for value in config.iter_mut() {
-                    let entry = value.as_inline_table_mut().ok_or_else(|| {
+                let mut last_matching_path = None;
+                for (index, value) in config.iter().enumerate() {
+                    let entry = value.as_inline_table().ok_or_else(|| {
                         AcpError::protocol(
                             "invalid codex config.toml: skills.config entry must be a table",
                         )
@@ -8954,12 +8954,19 @@ fn apply_codex_skill_enabled_config(
                         .and_then(toml_edit::Value::as_str)
                         .map(|configured| resolve_codex_skill_config_path(configured, codex_home))
                         .is_some_and(|configured| same_skill_config_path(&configured, &path));
-                    if path_matches {
-                        entry.insert("enabled", toml_edit::Value::from(enabled));
-                        matched = true;
+                    let name_matches =
+                        entry.get("name").and_then(toml_edit::Value::as_str) == Some(skill_name);
+                    if path_matches || name_matches {
+                        last_matching_path = path_matches.then_some(index);
                     }
                 }
-                if !matched {
+                if let Some(index) = last_matching_path {
+                    config
+                        .get_mut(index)
+                        .and_then(toml_edit::Value::as_inline_table_mut)
+                        .expect("matching Codex skill config entry must be an inline table")
+                        .insert("enabled", toml_edit::Value::from(enabled));
+                } else {
                     let mut entry = toml_edit::InlineTable::new();
                     entry.insert(
                         "path",
@@ -8997,7 +9004,7 @@ fn set_codex_skill_enabled_native(
         .iter()
         .map(absolute_skill_content_path)
         .collect::<Result<Vec<_>, _>>()?;
-    let next = apply_codex_skill_enabled_config(&base, &codex_home, &paths, enabled)?;
+    let next = apply_codex_skill_enabled_config(&base, &codex_home, &listed.id, &paths, enabled)?;
     let updated = parse_codex_skill_config(&next, &codex_home)?;
     if codex_skill_entries_enabled(active, &updated)? != enabled {
         return Err(AcpError::protocol(
@@ -19024,15 +19031,133 @@ wire_api = "chat"
     }
 
     #[test]
-    fn codex_skill_config_path_selector_overrides_later_name_selector() {
-        let config = parse_codex_skill_config(
+    fn codex_skill_config_last_matching_selector_wins() {
+        let path_then_name = parse_codex_skill_config(
             "[[skills.config]]\npath = \"/tmp/demo/SKILL.md\"\nenabled = true\n\
              \n[[skills.config]]\nname = \"demo\"\nenabled = false\n",
             Path::new("/tmp/codex-home"),
         )
         .unwrap();
+        let name_then_path = parse_codex_skill_config(
+            "[[skills.config]]\nname = \"demo\"\nenabled = false\n\
+             \n[[skills.config]]\npath = \"/tmp/demo/SKILL.md\"\nenabled = true\n",
+            Path::new("/tmp/codex-home"),
+        )
+        .unwrap();
 
-        assert!(config.skill_enabled(Path::new("/tmp/demo/SKILL.md"), "demo"));
+        assert!(!path_then_name.skill_enabled(Path::new("/tmp/demo/SKILL.md"), "demo"));
+        assert!(name_then_path.skill_enabled(Path::new("/tmp/demo/SKILL.md"), "demo"));
+    }
+
+    #[test]
+    fn codex_skill_config_appends_path_override_after_later_name_selector() {
+        let path = PathBuf::from("/tmp/demo/SKILL.md");
+        let updated = apply_codex_skill_enabled_config(
+            "[[skills.config]]\npath = \"/tmp/demo/SKILL.md\"\nenabled = false\n\
+             \n[[skills.config]]\nname = \"demo\"\nenabled = false\n",
+            Path::new("/tmp/codex-home"),
+            "demo",
+            std::slice::from_ref(&path),
+            true,
+        )
+        .unwrap();
+        let parsed = updated.parse::<toml::Value>().unwrap();
+        let entries = parsed["skills"]["config"].as_array().unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(
+            entries
+                .last()
+                .unwrap()
+                .get("path")
+                .and_then(toml::Value::as_str),
+            path.to_str()
+        );
+        assert_eq!(
+            entries
+                .last()
+                .unwrap()
+                .get("enabled")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert!(
+            parse_codex_skill_config(&updated, Path::new("/tmp/codex-home"))
+                .unwrap()
+                .skill_enabled(&path, "demo")
+        );
+
+        let updated_again = apply_codex_skill_enabled_config(
+            &updated,
+            Path::new("/tmp/codex-home"),
+            "demo",
+            std::slice::from_ref(&path),
+            false,
+        )
+        .unwrap();
+        let parsed = updated_again.parse::<toml::Value>().unwrap();
+        let entries = parsed["skills"]["config"].as_array().unwrap();
+        assert_eq!(entries.len(), 3, "repeated toggles reuse the path override");
+        assert!(
+            !parse_codex_skill_config(&updated_again, Path::new("/tmp/codex-home"))
+                .unwrap()
+                .skill_enabled(&path, "demo")
+        );
+    }
+
+    #[test]
+    fn codex_skill_config_appends_inline_path_override_after_later_name_selector() {
+        let path = PathBuf::from("/tmp/demo/SKILL.md");
+        let updated = apply_codex_skill_enabled_config(
+            "[skills]\nconfig = [{ path = \"/tmp/demo/SKILL.md\", enabled = false }, { name = \"demo\", enabled = false }]\n",
+            Path::new("/tmp/codex-home"),
+            "demo",
+            std::slice::from_ref(&path),
+            true,
+        )
+        .unwrap();
+        let parsed = updated.parse::<toml::Value>().unwrap();
+        let entries = parsed["skills"]["config"].as_array().unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(
+            entries
+                .last()
+                .unwrap()
+                .get("path")
+                .and_then(toml::Value::as_str),
+            path.to_str()
+        );
+        assert_eq!(
+            entries
+                .last()
+                .unwrap()
+                .get("enabled")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert!(
+            parse_codex_skill_config(&updated, Path::new("/tmp/codex-home"))
+                .unwrap()
+                .skill_enabled(&path, "demo")
+        );
+
+        let updated_again = apply_codex_skill_enabled_config(
+            &updated,
+            Path::new("/tmp/codex-home"),
+            "demo",
+            std::slice::from_ref(&path),
+            false,
+        )
+        .unwrap();
+        let parsed = updated_again.parse::<toml::Value>().unwrap();
+        let entries = parsed["skills"]["config"].as_array().unwrap();
+        assert_eq!(entries.len(), 3, "repeated toggles reuse the path override");
+        assert!(
+            !parse_codex_skill_config(&updated_again, Path::new("/tmp/codex-home"))
+                .unwrap()
+                .skill_enabled(&path, "demo")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8343,6 +8343,7 @@ fn build_skill_item(
     scope: AgentSkillScope,
     layout: AgentSkillLayout,
     path: PathBuf,
+    enabled: bool,
 ) -> AgentSkillItem {
     let description = read_skill_description(&skill_content_path(layout, &path));
     AgentSkillItem {
@@ -8351,6 +8352,8 @@ fn build_skill_item(
         scope,
         layout,
         path: path.to_string_lossy().to_string(),
+        enabled,
+        can_toggle: true,
         description,
         read_only: false,
     }
@@ -8375,6 +8378,13 @@ fn is_read_only_skill_path(agent_type: AgentType, skill_path: &Path) -> bool {
         _ => return false,
     };
     skill_path.starts_with(&ro_root)
+}
+
+fn apply_skill_capabilities(agent_type: AgentType, skill: &mut AgentSkillItem) {
+    if is_read_only_skill_path(agent_type, Path::new(&skill.path)) {
+        skill.read_only = true;
+        skill.can_toggle = false;
+    }
 }
 
 fn skill_content_path(layout: AgentSkillLayout, skill_path: &Path) -> PathBuf {
@@ -8439,6 +8449,15 @@ pub(crate) fn list_skills_from_dir(
     dir: &Path,
     kind: SkillStorageKind,
 ) -> Result<Vec<AgentSkillItem>, AcpError> {
+    list_skills_from_dir_with_state(scope, dir, kind, true)
+}
+
+fn list_skills_from_dir_with_state(
+    scope: AgentSkillScope,
+    dir: &Path,
+    kind: SkillStorageKind,
+    enabled: bool,
+) -> Result<Vec<AgentSkillItem>, AcpError> {
     if !dir.exists() {
         return Ok(Vec::new());
     }
@@ -8469,7 +8488,13 @@ pub(crate) fn list_skills_from_dir(
             }
             by_id.insert(
                 id.clone(),
-                build_skill_item(id, scope, AgentSkillLayout::SkillDirectory, path),
+                build_skill_item(
+                    id,
+                    scope,
+                    AgentSkillLayout::SkillDirectory,
+                    path,
+                    enabled,
+                ),
             );
             continue;
         }
@@ -8488,8 +8513,39 @@ pub(crate) fn list_skills_from_dir(
             }
             by_id.insert(
                 stem.clone(),
-                build_skill_item(stem, scope, AgentSkillLayout::MarkdownFile, path),
+                build_skill_item(stem, scope, AgentSkillLayout::MarkdownFile, path, enabled),
             );
+        }
+    }
+
+    Ok(by_id.into_values().collect())
+}
+
+pub(crate) fn disabled_skill_root(active_root: &Path) -> PathBuf {
+    active_root
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .join(".skills.codeg-disabled")
+}
+
+pub(crate) fn list_skills_from_roots(
+    scope: AgentSkillScope,
+    roots: &[PathBuf],
+    kind: SkillStorageKind,
+) -> Result<Vec<AgentSkillItem>, AcpError> {
+    let mut by_id = BTreeMap::new();
+
+    // Scan every active root before considering any vault so an active copy
+    // wins even when its root follows the vault-owning root in precedence.
+    for root in roots {
+        for skill in list_skills_from_dir_with_state(scope, root, kind, true)? {
+            by_id.entry(skill.id.clone()).or_insert(skill);
+        }
+    }
+    for root in roots {
+        let vault = disabled_skill_root(root);
+        for skill in list_skills_from_dir_with_state(scope, &vault, kind, false)? {
+            by_id.entry(skill.id.clone()).or_insert(skill);
         }
     }
 
@@ -8501,6 +8557,7 @@ fn locate_existing_skill(
     kind: SkillStorageKind,
     skill_id: &str,
     scope: AgentSkillScope,
+    enabled: bool,
 ) -> Option<AgentSkillItem> {
     if matches!(
         kind,
@@ -8513,6 +8570,7 @@ fn locate_existing_skill(
                 scope,
                 AgentSkillLayout::SkillDirectory,
                 skill_dir,
+                enabled,
             ));
         }
     }
@@ -8525,6 +8583,7 @@ fn locate_existing_skill(
                 scope,
                 AgentSkillLayout::MarkdownFile,
                 file_path,
+                enabled,
             ));
         }
     }
@@ -8539,11 +8598,44 @@ pub(crate) fn locate_existing_skill_across_dirs(
     scope: AgentSkillScope,
 ) -> Option<AgentSkillItem> {
     for dir in dirs {
-        if let Some(found) = locate_existing_skill(dir, kind, skill_id, scope) {
+        if let Some(found) = locate_existing_skill(dir, kind, skill_id, scope, true) {
+            return Some(found);
+        }
+    }
+    for dir in dirs {
+        if let Some(found) =
+            locate_existing_skill(&disabled_skill_root(dir), kind, skill_id, scope, false)
+        {
             return Some(found);
         }
     }
     None
+}
+
+#[cfg(test)]
+fn set_private_skill_enabled(
+    _root: &Path,
+    _kind: SkillStorageKind,
+    _scope: AgentSkillScope,
+    _skill_id: &str,
+    _enabled: bool,
+) -> Result<AgentSkillItem, AcpError> {
+    Err(AcpError::protocol(
+        "private skill moves are not implemented in task 1A",
+    ))
+}
+
+#[cfg(test)]
+async fn acp_set_agent_skill_enabled(
+    _agent_type: AgentType,
+    _scope: AgentSkillScope,
+    _skill_id: String,
+    _workspace_path: Option<String>,
+    _enabled: bool,
+) -> Result<AgentSkillItem, AcpError> {
+    Err(AcpError::protocol(
+        "skill toggle command is not implemented in task 1A",
+    ))
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -12534,11 +12626,14 @@ pub async fn acp_list_agent_skills(
             path: dir.to_string_lossy().to_string(),
             exists: dir.exists(),
         });
-        let listed = list_skills_from_dir(AgentSkillScope::Global, dir, spec.kind)?;
-        for skill in listed {
-            let key = format!("global:{}", skill.id);
-            skills_by_key.entry(key).or_insert(skill);
-        }
+    }
+    for skill in list_skills_from_roots(
+        AgentSkillScope::Global,
+        &spec.global_dirs,
+        spec.kind,
+    )? {
+        let key = format!("global:{}", skill.id);
+        skills_by_key.entry(key).or_insert(skill);
     }
 
     if let Some(workspace) = workspace_path.as_deref().map(str::trim) {
@@ -12548,28 +12643,30 @@ pub async fn acp_list_agent_skills(
             // onto the workspace here instead would make a skill saved from a
             // nested workspace vanish from the list that is meant to show it.
             let base = project_skill_base(agent_type, workspace);
-            for relative in &spec.project_rel_dirs {
-                let project_dir = base.join(relative);
+            let project_dirs = spec
+                .project_rel_dirs
+                .iter()
+                .map(|relative| base.join(relative))
+                .collect::<Vec<_>>();
+            for project_dir in &project_dirs {
                 locations.push(AgentSkillLocation {
                     scope: AgentSkillScope::Project,
                     path: project_dir.to_string_lossy().to_string(),
                     exists: project_dir.exists(),
                 });
-                let listed =
-                    list_skills_from_dir(AgentSkillScope::Project, &project_dir, spec.kind)?;
-                for skill in listed {
-                    let key = format!("project:{}", skill.id);
-                    skills_by_key.entry(key).or_insert(skill);
-                }
+            }
+            for skill in
+                list_skills_from_roots(AgentSkillScope::Project, &project_dirs, spec.kind)?
+            {
+                let key = format!("project:{}", skill.id);
+                skills_by_key.entry(key).or_insert(skill);
             }
         }
     }
 
     let mut skills = skills_by_key.into_values().collect::<Vec<_>>();
     for skill in &mut skills {
-        if is_read_only_skill_path(agent_type, Path::new(&skill.path)) {
-            skill.read_only = true;
-        }
+        apply_skill_capabilities(agent_type, skill);
     }
     skills.sort_by(|a, b| {
         scope_rank(a.scope)
@@ -12602,9 +12699,7 @@ pub async fn acp_read_agent_skill(
 
     let mut skill = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope)
         .ok_or_else(|| AcpError::protocol(format!("skill not found: {id}")))?;
-    if is_read_only_skill_path(agent_type, Path::new(&skill.path)) {
-        skill.read_only = true;
-    }
+    apply_skill_capabilities(agent_type, &mut skill);
     let content_path = skill_content_path(skill.layout, Path::new(&skill.path));
     let content = fs::read_to_string(&content_path)
         .map_err(|e| AcpError::protocol(format!("failed to read skill content: {e}")))?;
@@ -12653,7 +12748,7 @@ pub async fn acp_save_agent_skill(
             AgentSkillLayout::SkillDirectory => preferred_dir.join(&id),
             AgentSkillLayout::MarkdownFile => preferred_dir.join(format!("{id}.md")),
         };
-        build_skill_item(id.clone(), scope, new_layout, skill_path)
+        build_skill_item(id.clone(), scope, new_layout, skill_path, true)
     };
 
     let skill_path = PathBuf::from(&skill.path);
@@ -15222,6 +15317,469 @@ wire_api = "chat"
             "the listed project location must be the git root: {:?}",
             listed.locations
         );
+    }
+
+    #[test]
+    fn skill_state_active_entry_wins_over_disabled_entries_across_roots() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let first = tmp.path().join("first/skills");
+        let second = tmp.path().join("second/skills");
+        std::fs::create_dir_all(first.join("demo")).expect("create active skill");
+        std::fs::write(first.join("demo/SKILL.md"), "active\n").expect("write active skill");
+        std::fs::create_dir_all(disabled_skill_root(&second).join("demo"))
+            .expect("create disabled skill");
+        std::fs::write(
+            disabled_skill_root(&second).join("demo/SKILL.md"),
+            "disabled\n",
+        )
+        .expect("write disabled skill");
+
+        assert_eq!(
+            disabled_skill_root(&first),
+            tmp.path().join("first/.skills.codeg-disabled")
+        );
+
+        let roots = [second, first.clone()];
+        let listed = list_skills_from_roots(
+            AgentSkillScope::Global,
+            &roots,
+            SkillStorageKind::SkillDirectoryOnly,
+        )
+        .expect("list skills");
+        let located = locate_existing_skill_across_dirs(
+            &roots,
+            SkillStorageKind::SkillDirectoryOnly,
+            "demo",
+            AgentSkillScope::Global,
+        )
+        .expect("locate skill");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].path, first.join("demo").to_string_lossy());
+        assert!(listed[0].enabled);
+        assert!(listed[0].can_toggle);
+        assert_eq!(located.path, first.join("demo").to_string_lossy());
+        assert!(located.enabled);
+    }
+
+    #[test]
+    fn skill_state_lists_and_locates_disabled_directory_layout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let disabled = disabled_skill_root(&root).join("demo");
+        std::fs::create_dir_all(&disabled).expect("create disabled skill");
+        std::fs::write(disabled.join("SKILL.md"), "disabled\n")
+            .expect("write disabled skill");
+
+        let listed = list_skills_from_roots(
+            AgentSkillScope::Project,
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOnly,
+        )
+        .expect("list skills");
+        let located = locate_existing_skill_across_dirs(
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOnly,
+            "demo",
+            AgentSkillScope::Project,
+        )
+        .expect("locate disabled skill");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "demo");
+        assert_eq!(listed[0].layout, AgentSkillLayout::SkillDirectory);
+        assert_eq!(listed[0].path, disabled.to_string_lossy());
+        assert!(!listed[0].enabled);
+        assert!(listed[0].can_toggle);
+        assert_eq!(located.path, disabled.to_string_lossy());
+        assert!(!located.enabled);
+    }
+
+    #[test]
+    fn skill_state_lists_and_locates_disabled_markdown_layout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let disabled = disabled_skill_root(&root).join("flat.md");
+        std::fs::create_dir_all(disabled.parent().expect("disabled parent"))
+            .expect("create disabled vault");
+        std::fs::write(&disabled, "disabled\n").expect("write disabled skill");
+
+        let listed = list_skills_from_roots(
+            AgentSkillScope::Global,
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOrMarkdownFile,
+        )
+        .expect("list skills");
+        let located = locate_existing_skill_across_dirs(
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOrMarkdownFile,
+            "flat",
+            AgentSkillScope::Global,
+        )
+        .expect("locate disabled skill");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "flat");
+        assert_eq!(listed[0].layout, AgentSkillLayout::MarkdownFile);
+        assert_eq!(listed[0].path, disabled.to_string_lossy());
+        assert!(!listed[0].enabled);
+        assert_eq!(located.layout, AgentSkillLayout::MarkdownFile);
+        assert!(!located.enabled);
+    }
+
+    #[test]
+    fn skill_state_read_only_builtin_cannot_toggle() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        temp_env::with_var("CODEX_HOME", Some(tmp.path()), || {
+            let system_skill = tmp.path().join("skills/.system/task1a-system-demo");
+            std::fs::create_dir_all(&system_skill).expect("create system skill");
+            std::fs::write(system_skill.join("SKILL.md"), "system\n")
+                .expect("write system skill");
+
+            let listed = tokio::runtime::Runtime::new()
+                .expect("runtime")
+                .block_on(acp_list_agent_skills(AgentType::Codex, None))
+                .expect("list skills");
+            let item = listed
+                .skills
+                .iter()
+                .find(|item| item.id == "task1a-system-demo")
+                .expect("listed system skill");
+
+            assert!(item.enabled);
+            assert!(item.read_only);
+            assert!(!item.can_toggle);
+        });
+    }
+
+    #[test]
+    fn skill_enabled_private_directory_round_trips_through_disabled_vault() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let skill = root.join("demo");
+        std::fs::create_dir_all(&skill).expect("create skill");
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: demo\ndescription: private demo\n---\nbody\n",
+        )
+        .expect("write skill");
+        std::fs::write(skill.join("asset.txt"), "asset").expect("write asset");
+
+        let disabled = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Global,
+            "demo",
+            false,
+        )
+        .expect("disable skill");
+
+        assert!(!root.join("demo").exists());
+        assert!(
+            disabled_skill_root(&root)
+                .join("demo")
+                .join("SKILL.md")
+                .is_file()
+        );
+        assert_eq!(
+            std::fs::read_to_string(disabled_skill_root(&root).join("demo/asset.txt"))
+                .expect("read asset"),
+            "asset"
+        );
+        assert!(!disabled.enabled);
+
+        let listed = list_skills_from_roots(
+            AgentSkillScope::Global,
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOnly,
+        )
+        .expect("list disabled skill");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "demo");
+        assert!(!listed[0].enabled);
+
+        let enabled = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Global,
+            "demo",
+            true,
+        )
+        .expect("enable skill");
+
+        assert!(root.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&root).join("demo").exists());
+        assert!(enabled.enabled);
+    }
+
+    #[test]
+    fn skill_enabled_private_markdown_file_round_trips_without_renaming_id() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        std::fs::create_dir_all(&root).expect("create skills root");
+        std::fs::write(
+            root.join("flat.md"),
+            "---\nname: flat\ndescription: flat demo\n---\nbody\n",
+        )
+        .expect("write flat skill");
+
+        let disabled = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOrMarkdownFile,
+            AgentSkillScope::Project,
+            "flat",
+            false,
+        )
+        .expect("disable flat skill");
+
+        assert!(!root.join("flat.md").exists());
+        assert!(disabled_skill_root(&root).join("flat.md").is_file());
+        assert_eq!(disabled.layout, AgentSkillLayout::MarkdownFile);
+        assert_eq!(disabled.scope, AgentSkillScope::Project);
+        assert!(!disabled.enabled);
+
+        let enabled = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOrMarkdownFile,
+            AgentSkillScope::Project,
+            "flat",
+            true,
+        )
+        .expect("enable flat skill");
+
+        assert!(root.join("flat.md").is_file());
+        assert!(enabled.enabled);
+        assert_eq!(enabled.id, "flat");
+    }
+
+    #[test]
+    fn skill_enabled_private_listing_prefers_active_and_serializes_state() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let first = tmp.path().join("first/skills");
+        let second = tmp.path().join("second/skills");
+        std::fs::create_dir_all(first.join("demo")).expect("create active skill");
+        std::fs::write(first.join("demo/SKILL.md"), "active\n").expect("write active skill");
+        std::fs::create_dir_all(disabled_skill_root(&second).join("demo"))
+            .expect("create disabled skill");
+        std::fs::write(
+            disabled_skill_root(&second).join("demo/SKILL.md"),
+            "disabled\n",
+        )
+        .expect("write disabled skill");
+
+        assert_eq!(
+            disabled_skill_root(&first),
+            tmp.path().join("first/.skills.codeg-disabled")
+        );
+        let listed = list_skills_from_roots(
+            AgentSkillScope::Global,
+            &[second, first.clone()],
+            SkillStorageKind::SkillDirectoryOnly,
+        )
+        .expect("list skills");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].path, first.join("demo").to_string_lossy());
+        assert!(listed[0].enabled);
+        assert!(listed[0].can_toggle);
+        let json = serde_json::to_value(&listed[0]).expect("serialize skill");
+        assert_eq!(json["enabled"], true);
+        assert_eq!(json["can_toggle"], true);
+    }
+
+    #[test]
+    fn skill_enabled_private_repeated_requests_are_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        std::fs::create_dir_all(root.join("demo")).expect("create skill");
+        std::fs::write(root.join("demo/SKILL.md"), "body\n").expect("write skill");
+
+        for _ in 0..2 {
+            let skill = set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOnly,
+                AgentSkillScope::Global,
+                "demo",
+                false,
+            )
+            .expect("disable skill");
+            assert!(!skill.enabled);
+        }
+        for _ in 0..2 {
+            let skill = set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOnly,
+                AgentSkillScope::Global,
+                "demo",
+                true,
+            )
+            .expect("enable skill");
+            assert!(skill.enabled);
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(root.join("demo/SKILL.md")).expect("read skill"),
+            "body\n"
+        );
+        assert!(!disabled_skill_root(&root).join("demo").exists());
+    }
+
+    #[test]
+    fn skill_enabled_private_collision_is_rejected_before_move() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("skills");
+        let disabled = disabled_skill_root(&root);
+        std::fs::create_dir_all(root.join("demo")).expect("create active skill");
+        std::fs::write(root.join("demo/SKILL.md"), "active\n").expect("write active skill");
+        std::fs::create_dir_all(disabled.join("demo")).expect("create disabled collision");
+        std::fs::write(disabled.join("demo/SKILL.md"), "disabled\n")
+            .expect("write disabled collision");
+
+        let error = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Global,
+            "demo",
+            false,
+        )
+        .expect_err("collision must fail");
+
+        assert!(error.to_string().contains("collision"));
+        assert_eq!(
+            std::fs::read_to_string(root.join("demo/SKILL.md")).expect("read active"),
+            "active\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(disabled.join("demo/SKILL.md")).expect("read disabled"),
+            "disabled\n"
+        );
+    }
+
+    #[test]
+    fn skill_enabled_private_disabled_skill_remains_readable_editable_and_deletable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        temp_env::with_var("CODEX_HOME", Some(tmp.path()), || {
+            let root = tmp.path().join("skills");
+            std::fs::create_dir_all(root.join("task1-disabled-demo"))
+                .expect("create skill");
+            std::fs::write(
+                root.join("task1-disabled-demo/SKILL.md"),
+                "original\n",
+            )
+            .expect("write skill");
+            set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOrMarkdownFile,
+                AgentSkillScope::Global,
+                "task1-disabled-demo",
+                false,
+            )
+            .expect("disable skill");
+
+            let runtime = tokio::runtime::Runtime::new().expect("runtime");
+            let read = runtime
+                .block_on(acp_read_agent_skill(
+                    AgentType::Codex,
+                    AgentSkillScope::Global,
+                    "task1-disabled-demo".to_string(),
+                    None,
+                ))
+                .expect("read disabled skill");
+            assert_eq!(read.content, "original\n");
+            assert!(!read.skill.enabled);
+
+            let saved = runtime
+                .block_on(acp_save_agent_skill(
+                    AgentType::Codex,
+                    AgentSkillScope::Global,
+                    "task1-disabled-demo".to_string(),
+                    "updated\n".to_string(),
+                    None,
+                    None,
+                ))
+                .expect("save disabled skill");
+            assert!(!saved.enabled);
+            assert!(!root.join("task1-disabled-demo").exists());
+            assert_eq!(
+                std::fs::read_to_string(
+                    disabled_skill_root(&root).join("task1-disabled-demo/SKILL.md")
+                )
+                .expect("read updated skill"),
+                "updated\n"
+            );
+
+            runtime
+                .block_on(acp_delete_agent_skill(
+                    AgentType::Codex,
+                    AgentSkillScope::Global,
+                    "task1-disabled-demo".to_string(),
+                    None,
+                ))
+                .expect("delete disabled skill");
+            assert!(!disabled_skill_root(&root)
+                .join("task1-disabled-demo")
+                .exists());
+        });
+    }
+
+    #[test]
+    fn skill_enabled_private_command_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        temp_env::with_var("CODEX_HOME", Some(tmp.path()), || {
+            let root = tmp.path().join("skills");
+            std::fs::create_dir_all(root.join("task1-command-demo")).expect("create skill");
+            std::fs::write(root.join("task1-command-demo/SKILL.md"), "body\n")
+                .expect("write skill");
+            let runtime = tokio::runtime::Runtime::new().expect("runtime");
+
+            for enabled in [false, false, true, true] {
+                let item = runtime
+                    .block_on(acp_set_agent_skill_enabled(
+                        AgentType::Codex,
+                        AgentSkillScope::Global,
+                        "task1-command-demo".to_string(),
+                        None,
+                        enabled,
+                    ))
+                    .expect("toggle skill");
+                assert_eq!(item.enabled, enabled);
+            }
+        });
+    }
+
+    #[test]
+    fn skill_enabled_private_read_only_skill_cannot_be_toggled() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        temp_env::with_var("CODEX_HOME", Some(tmp.path()), || {
+            let system_skill = tmp.path().join("skills/.system/task1-system-demo");
+            std::fs::create_dir_all(&system_skill).expect("create system skill");
+            std::fs::write(system_skill.join("SKILL.md"), "system\n")
+                .expect("write system skill");
+            let runtime = tokio::runtime::Runtime::new().expect("runtime");
+
+            let listed = runtime
+                .block_on(acp_list_agent_skills(AgentType::Codex, None))
+                .expect("list skills");
+            let item = listed
+                .skills
+                .iter()
+                .find(|item| item.id == "task1-system-demo")
+                .expect("listed system skill");
+            assert!(item.read_only);
+            assert!(!item.can_toggle);
+
+            let error = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Global,
+                    "task1-system-demo".to_string(),
+                    None,
+                    false,
+                ))
+                .expect_err("system skill toggle must fail");
+            assert!(error.to_string().contains("cannot be toggled"));
+            assert!(system_skill.join("SKILL.md").is_file());
+        });
     }
 
     #[test]

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -9013,6 +9013,27 @@ fn unique_skill_root(peer: &SkillPeer, peers: &[SkillPeer]) -> Result<PathBuf, A
     )))
 }
 
+fn preflight_shared_skill_owner(root: &Path, peers: &[SkillPeer]) -> Result<(), AcpError> {
+    let resolved = resolved_skill_root(root)?;
+    for peer in peers {
+        for native in &peer.roots {
+            let resolved_native = resolved_skill_root(native)?;
+            if let Ok(relative) = resolved.strip_prefix(&resolved_native) {
+                // Evaluate the owner's lexical path so aliases cannot erase
+                // that owner's builtin-directory policy.
+                if is_read_only_skill_path(peer.agent, &native.join(relative)) {
+                    return Err(AcpError::protocol(format!(
+                        "shared skill root '{}' is read-only for owning agent {}",
+                        root.display(),
+                        peer.agent
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn create_skill_link(source: &Path, destination: &Path) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -9154,6 +9175,7 @@ fn set_shared_skill_enabled(
     if original.enabled == enabled {
         return Ok(original);
     }
+    preflight_shared_skill_owner(root, peers)?;
     let resolved_root = resolved_skill_root(root)?;
     let vault = disabled_skill_root(root);
     let resolved_vault = resolved_skill_root(&vault)?;
@@ -9430,7 +9452,11 @@ fn reject_multiple_active_skills(
     skill_id: &str,
 ) -> Result<(), AcpError> {
     let mut matches = 0;
+    let mut seen_roots = std::collections::HashSet::new();
     for root in roots {
+        if !seen_roots.insert(resolved_skill_root(root)?) {
+            continue;
+        }
         let entries = match fs::read_dir(root) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
@@ -13747,20 +13773,29 @@ pub async fn acp_delete_agent_skill(
         )));
     }
     let skill_path = PathBuf::from(&skill.path);
-    for root in &dirs {
-        if !skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), root)? {
-            continue;
-        }
-        if let Some(canonical) =
-            locate_existing_skill(&disabled_skill_root(root), spec.kind, &id, scope, false)
-        {
-            let canonical_path = Path::new(&canonical.path);
-            if skill_path == canonical_path || skill_link_targets(&skill_path, canonical_path) {
-                let peers = skill_peers(workspace_path.as_deref());
-                preflight_disabled_skill_root(root, workspace_path.as_deref())?;
-                return delete_shared_skill(canonical_path, &peers, &id, |from, to| {
-                    fs::rename(from, to)
-                });
+    let peers = skill_peers(workspace_path.as_deref());
+    // A shared root alias can own a vault outside this agent's lexical roots.
+    // Only a direct link to a known peer vault entry establishes ownership.
+    for peer in &peers {
+        for root in &peer.roots {
+            if !skill_root_is_shared(peer.agent, peer.scope, workspace_path.as_deref(), root)? {
+                continue;
+            }
+            if let Some(canonical) = locate_existing_skill(
+                &disabled_skill_root(root),
+                peer.kind,
+                &id,
+                peer.scope,
+                false,
+            ) {
+                let canonical_path = Path::new(&canonical.path);
+                if skill_path == canonical_path || skill_link_targets(&skill_path, canonical_path) {
+                    preflight_shared_skill_owner(root, &peers)?;
+                    preflight_disabled_skill_root(root, workspace_path.as_deref())?;
+                    return delete_shared_skill(canonical_path, &peers, &id, |from, to| {
+                        fs::rename(from, to)
+                    });
+                }
             }
         }
     }
@@ -16901,6 +16936,169 @@ wire_api = "chat"
             })
             .collect();
         (shared, peers)
+    }
+
+    fn shared_skill_custom_def(
+        id: &str,
+        root: &Path,
+    ) -> crate::acp::custom_registry::CustomAgentDef {
+        use crate::acp::custom_registry::{
+            CustomAgentDef, CustomAgentSpec, CustomDistributionKind, NpxSpec,
+        };
+        CustomAgentDef {
+            registry_id: id.into(),
+            name: id.into(),
+            description: String::new(),
+            version: "1.0.0".into(),
+            distribution_kind: CustomDistributionKind::Npx,
+            spec: CustomAgentSpec {
+                npx: Some(NpxSpec {
+                    package: "test-agent@1.0.0".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            icon_url: None,
+            skills_shared_store: false,
+            skills_dir: Some(root.to_string_lossy().into_owned()),
+            source: Default::default(),
+            version_probe: None,
+            supports_mcp: true,
+        }
+    }
+
+    #[test]
+    fn shared_skill_reparse_probe_is_accessible_from_acp() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!crate::commands::experts::path_is_reparse_point(tmp.path()));
+    }
+
+    #[test]
+    fn shared_skill_custom_owner_cannot_disable_another_agents_builtin_root() {
+        use crate::acp::custom_registry::{hydrate, hydrate_test_guard};
+        let _registry_guard = hydrate_test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        temp_env::with_var("GEMINI_HOME", Some(tmp.path()), || {
+            let root = tmp.path().join("antigravity-cli/skills");
+            fs::create_dir_all(root.join("demo")).unwrap();
+            fs::write(root.join("demo/SKILL.md"), "builtin").unwrap();
+            assert!(hydrate(&[shared_skill_custom_def("task2-readonly-owner", &root)]).is_empty());
+            let result =
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(acp_set_agent_skill_enabled(
+                        AgentType::custom("task2-readonly-owner").unwrap(),
+                        AgentSkillScope::Global,
+                        "demo".into(),
+                        None,
+                        false,
+                    ));
+            hydrate(&[]);
+            assert!(result.unwrap_err().to_string().contains("read-only"));
+            assert_eq!(
+                fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+                "builtin"
+            );
+            assert!(!disabled_skill_root(&root).exists());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_skill_alias_roots_do_not_duplicate_followup_toggles() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = tmp.path().join(".claude/skills");
+        let cline = tmp.path().join(".cline/skills");
+        fs::create_dir_all(shared.join("demo")).unwrap();
+        fs::write(shared.join("demo/SKILL.md"), "body").unwrap();
+        fs::create_dir_all(&cline).unwrap();
+        fs::create_dir_all(tmp.path().join(".clinerules")).unwrap();
+        std::os::unix::fs::symlink(&cline, tmp.path().join(".clinerules/skills")).unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for (agent, enabled) in [
+            (AgentType::ClaudeCode, false),
+            (AgentType::Cline, false),
+            (AgentType::Cline, true),
+            (AgentType::ClaudeCode, true),
+        ] {
+            let item = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    agent,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    Some(tmp.path().to_string_lossy().into_owned()),
+                    enabled,
+                ))
+                .unwrap();
+            assert_eq!(item.enabled, enabled);
+        }
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(fs::symlink_metadata(cline.join("demo")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_skill_delete_via_alias_canonical_link_is_global() {
+        use crate::acp::custom_registry::{hydrate, hydrate_test_guard};
+        let _registry_guard = hydrate_test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        temp_env::with_vars(
+            [
+                ("HOME", Some(tmp.path())),
+                ("CODEX_HOME", None::<&Path>),
+                ("GEMINI_HOME", None),
+                ("PI_CODING_AGENT_DIR", None),
+                ("DSH_HOME", None),
+                ("DSH_AGENTS_HOME", None),
+                ("QODER_CONFIG_DIR", None),
+                ("QODER_CLI_HOME", None),
+            ],
+            || {
+                let shared = tmp.path().join(".agents/skills");
+                let alias = tmp.path().join("custom/skills");
+                fs::create_dir_all(shared.join("demo")).unwrap();
+                fs::write(shared.join("demo/SKILL.md"), "body").unwrap();
+                fs::create_dir_all(alias.parent().unwrap()).unwrap();
+                std::os::unix::fs::symlink(&shared, &alias).unwrap();
+                assert!(
+                    hydrate(&[shared_skill_custom_def("task2-alias-owner", &alias)]).is_empty()
+                );
+                let runtime = tokio::runtime::Runtime::new().unwrap();
+                let result = runtime.block_on(async {
+                    acp_set_agent_skill_enabled(
+                        AgentType::custom("task2-alias-owner").unwrap(),
+                        AgentSkillScope::Global,
+                        "demo".into(),
+                        None,
+                        false,
+                    )
+                    .await?;
+                    acp_delete_agent_skill(
+                        AgentType::Codex,
+                        AgentSkillScope::Global,
+                        "demo".into(),
+                        None,
+                    )
+                    .await
+                });
+                let peers = skill_peers(None);
+                hydrate(&[]);
+                result.unwrap();
+                assert!(
+                    !disabled_skill_root(&alias).join("demo").exists(),
+                    "canonical installation remains"
+                );
+                for peer in peers {
+                    for root in peer.roots {
+                        assert!(
+                            fs::symlink_metadata(root.join("demo")).is_err(),
+                            "leftover peer entry: {}",
+                            root.display()
+                        );
+                    }
+                }
+            },
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -2675,6 +2676,14 @@ fn codex_config_toml_path() -> PathBuf {
     codex_home_dir().join("config.toml")
 }
 
+static CODEX_CONFIG_MUTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock_codex_config_mutation() -> Result<std::sync::MutexGuard<'static, ()>, AcpError> {
+    CODEX_CONFIG_MUTATION_LOCK
+        .lock()
+        .map_err(|_| AcpError::protocol("codex config mutation lock poisoned"))
+}
+
 fn codex_auth_json_path() -> PathBuf {
     codex_home_dir().join("auth.json")
 }
@@ -3320,6 +3329,7 @@ fn persist_codex_local_config(config_patch_json: Option<&str>) -> Result<(), Acp
         model,
         env,
     } = runtime;
+    let _config_guard = lock_codex_config_mutation()?;
 
     let config_path = codex_config_toml_path();
     let mut toml_value = if config_path.exists() {
@@ -3412,15 +3422,11 @@ fn persist_codex_local_config(config_patch_json: Option<&str>) -> Result<(), Acp
         }
     }
 
-    let serialized_toml = toml::to_string_pretty(&toml_value)
-        .map_err(|e| AcpError::protocol(format!("serialize codex toml failed: {e}")))?;
-    if let Some(parent) = config_path.parent() {
-        fs::create_dir_all(parent).map_err(|e| {
-            AcpError::protocol(format!("create codex config directory failed: {e}"))
-        })?;
-    }
-    fs::write(&config_path, format!("{serialized_toml}\n"))
-        .map_err(|e| AcpError::protocol(format!("write codex config failed: {e}")))?;
+    let serialized_toml = format!(
+        "{}\n",
+        toml::to_string_pretty(&toml_value)
+            .map_err(|e| AcpError::protocol(format!("serialize codex toml failed: {e}")))?
+    );
 
     let auth_path = codex_auth_json_path();
     let mut auth_value = if auth_path.exists() {
@@ -3448,34 +3454,58 @@ fn persist_codex_local_config(config_patch_json: Option<&str>) -> Result<(), Acp
             auth_obj.remove("OPENAI_API_KEY");
         }
     }
-    let serialized_auth = serde_json::to_string_pretty(&auth_value)
-        .map_err(|e| AcpError::protocol(format!("serialize codex auth failed: {e}")))?;
-    if let Some(parent) = auth_path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| AcpError::protocol(format!("create codex auth directory failed: {e}")))?;
-    }
-    fs::write(&auth_path, format!("{serialized_auth}\n"))
-        .map_err(|e| AcpError::protocol(format!("write codex auth failed: {e}")))?;
+    let serialized_auth = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&auth_value)
+            .map_err(|e| AcpError::protocol(format!("serialize codex auth failed: {e}")))?
+    );
 
+    persist_codex_native_config_files_unlocked(Some(&serialized_auth), Some(&serialized_toml))
+}
+
+fn codex_atomic_write_target(path: &Path) -> std::io::Result<PathBuf> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => fs::canonicalize(path),
+        Ok(_) => Ok(path.to_path_buf()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path.to_path_buf()),
+        Err(error) => Err(error),
+    }
+}
+
+fn write_codex_file_atomic(path: &Path, contents: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let target = codex_atomic_write_target(path)?;
+    let parent = target.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("codex file has no parent: {}", target.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let permissions = fs::metadata(&target)
+        .ok()
+        .map(|metadata| metadata.permissions());
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    staged.write_all(contents.as_bytes())?;
+    if let Some(permissions) = permissions {
+        staged.as_file().set_permissions(permissions)?;
+    }
+    staged.as_file_mut().sync_all()?;
+    staged.persist(&target).map_err(|error| error.error)?;
     Ok(())
 }
 
-fn persist_codex_native_config_files(
+fn persist_codex_native_config_files_unlocked(
     codex_auth_json: Option<&str>,
     codex_config_toml: Option<&str>,
 ) -> Result<(), AcpError> {
     if let Some(raw_toml) = codex_config_toml {
         toml::from_str::<toml::Table>(raw_toml)
             .map_err(|e| AcpError::protocol(format!("invalid codex config.toml: {e}")))?;
-        let path = codex_config_toml_path();
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| AcpError::protocol(format!("create codex directory failed: {e}")))?;
-        }
-        fs::write(&path, raw_toml)
-            .map_err(|e| AcpError::protocol(format!("write codex config.toml failed: {e}")))?;
     }
-
     if let Some(raw_auth) = codex_auth_json {
         let parsed = serde_json::from_str::<serde_json::Value>(raw_auth)
             .map_err(|e| AcpError::protocol(format!("invalid codex auth.json: {e}")))?;
@@ -3484,16 +3514,29 @@ fn persist_codex_native_config_files(
                 "invalid codex auth.json: root must be a JSON object",
             ));
         }
+    }
+
+    if let Some(raw_toml) = codex_config_toml {
+        let path = codex_config_toml_path();
+        write_codex_file_atomic(&path, raw_toml)
+            .map_err(|e| AcpError::protocol(format!("write codex config.toml failed: {e}")))?;
+    }
+
+    if let Some(raw_auth) = codex_auth_json {
         let path = codex_auth_json_path();
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| AcpError::protocol(format!("create codex directory failed: {e}")))?;
-        }
-        fs::write(&path, raw_auth)
+        write_codex_file_atomic(&path, raw_auth)
             .map_err(|e| AcpError::protocol(format!("write codex auth.json failed: {e}")))?;
     }
 
     Ok(())
+}
+
+fn persist_codex_native_config_files(
+    codex_auth_json: Option<&str>,
+    codex_config_toml: Option<&str>,
+) -> Result<(), AcpError> {
+    let _config_guard = lock_codex_config_mutation()?;
+    persist_codex_native_config_files_unlocked(codex_auth_json, codex_config_toml)
 }
 
 /// Read `~/.codex/config.toml` as the base of a structured sandbox merge.
@@ -3672,12 +3715,18 @@ fn remove_codex_catalog_key(
 /// Drop codeg's own `model_catalog_json` reference from the config.toml on disk,
 /// if it carries one. Reads fresh so it also cleans up a key written by an
 /// earlier codeg version or by another window since the panel opened.
-fn drop_codex_catalog_reference() -> Result<(), AcpError> {
+fn drop_codex_catalog_reference_unlocked() -> Result<(), AcpError> {
     let base = read_codex_config_or_empty()?;
     if let Some(next) = remove_codex_catalog_key(&base, &codex_home_dir())? {
-        persist_codex_native_config_files(None, Some(&next))?;
+        persist_codex_native_config_files_unlocked(None, Some(&next))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+fn drop_codex_catalog_reference() -> Result<(), AcpError> {
+    let _config_guard = lock_codex_config_mutation()?;
+    drop_codex_catalog_reference_unlocked()
 }
 
 /// Apply the Codex panel's sandbox / approval PATCH to the raw config.toml text,
@@ -8634,6 +8683,359 @@ pub(crate) fn locate_existing_skill_across_dirs(
     None
 }
 
+fn active_skill_entries(
+    roots: &[PathBuf],
+    kind: SkillStorageKind,
+    skill_id: &str,
+    scope: AgentSkillScope,
+) -> Result<Vec<AgentSkillItem>, AcpError> {
+    let mut matches = Vec::new();
+    let mut seen_roots = std::collections::HashSet::new();
+    for root in roots {
+        if !seen_roots.insert(resolved_skill_root(root)?) {
+            continue;
+        }
+        let entries = match fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(AcpError::protocol(format!(
+                    "failed to inspect active skills directory '{}': {error}",
+                    root.display()
+                )))
+            }
+        };
+        for entry in entries {
+            let path = entry
+                .map_err(|error| {
+                    AcpError::protocol(format!("failed to inspect active skill: {error}"))
+                })?
+                .path();
+            let Some(layout) = skill_entry_layout(&path, kind) else {
+                continue;
+            };
+            let id = match layout {
+                AgentSkillLayout::SkillDirectory => path.file_name(),
+                AgentSkillLayout::MarkdownFile => path.file_stem(),
+            }
+            .and_then(|name| name.to_str());
+            if id == Some(skill_id) {
+                matches.push(build_skill_item(
+                    skill_id.to_string(),
+                    scope,
+                    layout,
+                    path,
+                    true,
+                ));
+            }
+        }
+    }
+    Ok(matches)
+}
+
+#[derive(Debug, Default)]
+struct CodexSkillConfig {
+    entries: Vec<CodexSkillConfigEntry>,
+}
+
+#[derive(Debug)]
+struct CodexSkillConfigEntry {
+    path: Option<PathBuf>,
+    name: Option<String>,
+    enabled: bool,
+}
+
+fn resolve_codex_skill_config_path(raw: &str, codex_home: &Path) -> PathBuf {
+    if raw == "~" {
+        return home_dir_or_default();
+    }
+    if let Some(relative) = raw.strip_prefix("~/") {
+        return home_dir_or_default().join(relative);
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        codex_home.join(path)
+    }
+}
+
+fn absolute_skill_content_path(skill: &AgentSkillItem) -> Result<PathBuf, AcpError> {
+    let path = skill_content_path(skill.layout, Path::new(&skill.path));
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .map_err(|error| {
+                AcpError::protocol(format!("failed to resolve current directory: {error}"))
+            })
+    }
+}
+
+fn same_skill_config_path(first: &Path, second: &Path) -> bool {
+    first == second
+        || fs::canonicalize(first)
+            .ok()
+            .zip(fs::canonicalize(second).ok())
+            .is_some_and(|(first, second)| first == second)
+}
+
+fn parse_codex_skill_config(
+    raw_toml: &str,
+    codex_home: &Path,
+) -> Result<CodexSkillConfig, AcpError> {
+    let root = raw_toml
+        .parse::<toml::Value>()
+        .map_err(|error| AcpError::protocol(format!("invalid codex config.toml: {error}")))?;
+    let Some(config) = root
+        .get("skills")
+        .and_then(toml::Value::as_table)
+        .and_then(|skills| skills.get("config"))
+    else {
+        return Ok(CodexSkillConfig::default());
+    };
+    let config = config.as_array().ok_or_else(|| {
+        AcpError::protocol("invalid codex config.toml: skills.config must be an array")
+    })?;
+    let mut entries = Vec::with_capacity(config.len());
+    for entry in config {
+        let table = entry.as_table().ok_or_else(|| {
+            AcpError::protocol("invalid codex config.toml: skills.config entry must be a table")
+        })?;
+        let path = match table.get("path") {
+            Some(value) => Some(
+                value
+                    .as_str()
+                    .map(|path| resolve_codex_skill_config_path(path, codex_home))
+                    .ok_or_else(|| {
+                        AcpError::protocol(
+                            "invalid codex config.toml: skills.config path must be a string",
+                        )
+                    })?,
+            ),
+            None => None,
+        };
+        let name = match table.get("name") {
+            Some(value) => Some(value.as_str().map(str::to_string).ok_or_else(|| {
+                AcpError::protocol("invalid codex config.toml: skills.config name must be a string")
+            })?),
+            None => None,
+        };
+        let enabled = table
+            .get("enabled")
+            .ok_or_else(|| {
+                AcpError::protocol(
+                    "invalid codex config.toml: skills.config enabled is required",
+                )
+            })?
+            .as_bool()
+            .ok_or_else(|| {
+                AcpError::protocol(
+                    "invalid codex config.toml: skills.config enabled must be a boolean",
+                )
+            })?;
+        entries.push(CodexSkillConfigEntry {
+            path,
+            name,
+            enabled,
+        });
+    }
+    Ok(CodexSkillConfig { entries })
+}
+
+impl CodexSkillConfig {
+    fn skill_enabled(&self, path: &Path, name: &str) -> bool {
+        if let Some(enabled) = self
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry
+                    .path
+                    .as_deref()
+                    .is_some_and(|configured| same_skill_config_path(configured, path))
+            })
+            .map(|entry| entry.enabled)
+            .next_back()
+        {
+            return enabled;
+        }
+
+        self.entries
+            .iter()
+            .filter(|entry| entry.name.as_deref() == Some(name))
+            .map(|entry| entry.enabled)
+            .next_back()
+            .unwrap_or(true)
+    }
+}
+
+fn codex_skill_entries_enabled(
+    entries: &[AgentSkillItem],
+    config: &CodexSkillConfig,
+) -> Result<bool, AcpError> {
+    for skill in entries {
+        if config.skill_enabled(&absolute_skill_content_path(skill)?, &skill.id) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn apply_codex_skill_enabled_config(
+    base_toml: &str,
+    codex_home: &Path,
+    paths: &[PathBuf],
+    enabled: bool,
+) -> Result<String, AcpError> {
+    parse_codex_skill_config(base_toml, codex_home)?;
+    let mut doc = base_toml
+        .parse::<toml_edit::Document>()
+        .map_err(|error| AcpError::protocol(format!("invalid codex config.toml: {error}")))?;
+    if doc.get("skills").is_none() {
+        doc["skills"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+    let skills = doc
+        .get_mut("skills")
+        .and_then(toml_edit::Item::as_table_mut)
+        .ok_or_else(|| AcpError::protocol("invalid codex config.toml: skills must be a table"))?;
+    if skills.get("config").is_none() {
+        skills.insert(
+            "config",
+            toml_edit::Item::ArrayOfTables(toml_edit::ArrayOfTables::new()),
+        );
+    }
+    // Match Codex's native `skills/config/write`: persist the resolved
+    // SKILL.md target so symlink aliases collapse to one stable rule.
+    let mut unique_paths = paths
+        .iter()
+        .map(|path| fs::canonicalize(path).unwrap_or_else(|_| path.clone()))
+        .collect::<Vec<_>>();
+    unique_paths.sort();
+    unique_paths.dedup();
+
+    let config = skills
+        .get_mut("config")
+        .ok_or_else(|| AcpError::protocol("invalid codex config.toml: missing skills.config"))?;
+    match config {
+        toml_edit::Item::ArrayOfTables(config) => {
+            for path in unique_paths {
+                let mut matched = false;
+                for entry in config.iter_mut() {
+                    let path_matches = entry
+                        .get("path")
+                        .and_then(toml_edit::Item::as_str)
+                        .map(|configured| resolve_codex_skill_config_path(configured, codex_home))
+                        .is_some_and(|configured| same_skill_config_path(&configured, &path));
+                    if path_matches {
+                        entry.insert("enabled", toml_edit::value(enabled));
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    let mut entry = toml_edit::Table::new();
+                    entry.insert("path", toml_edit::value(path.to_string_lossy().as_ref()));
+                    entry.insert("enabled", toml_edit::value(enabled));
+                    config.push(entry);
+                }
+            }
+        }
+        toml_edit::Item::Value(toml_edit::Value::Array(config)) => {
+            for path in unique_paths {
+                let mut matched = false;
+                for value in config.iter_mut() {
+                    let entry = value.as_inline_table_mut().ok_or_else(|| {
+                        AcpError::protocol(
+                            "invalid codex config.toml: skills.config entry must be a table",
+                        )
+                    })?;
+                    let path_matches = entry
+                        .get("path")
+                        .and_then(toml_edit::Value::as_str)
+                        .map(|configured| resolve_codex_skill_config_path(configured, codex_home))
+                        .is_some_and(|configured| same_skill_config_path(&configured, &path));
+                    if path_matches {
+                        entry.insert("enabled", toml_edit::Value::from(enabled));
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    let mut entry = toml_edit::InlineTable::new();
+                    entry.insert(
+                        "path",
+                        toml_edit::Value::from(path.to_string_lossy().as_ref()),
+                    );
+                    entry.insert("enabled", toml_edit::Value::from(enabled));
+                    config.push(toml_edit::Value::InlineTable(entry));
+                }
+            }
+        }
+        _ => {
+            return Err(AcpError::protocol(
+                "invalid codex config.toml: skills.config must be an array of tables",
+            ))
+        }
+    }
+    Ok(doc.to_string())
+}
+
+fn set_codex_skill_enabled_native(
+    mut listed: AgentSkillItem,
+    active: &[AgentSkillItem],
+    enabled: bool,
+) -> Result<AgentSkillItem, AcpError> {
+    let _config_guard = lock_codex_config_mutation()?;
+    let codex_home = codex_home_dir();
+    let base = read_codex_config_or_empty()?;
+    let current = parse_codex_skill_config(&base, &codex_home)?;
+    listed.enabled = codex_skill_entries_enabled(active, &current)?;
+    listed.can_toggle = true;
+    if listed.enabled == enabled {
+        return Ok(listed);
+    }
+    let paths = active
+        .iter()
+        .map(absolute_skill_content_path)
+        .collect::<Result<Vec<_>, _>>()?;
+    let next = apply_codex_skill_enabled_config(&base, &codex_home, &paths, enabled)?;
+    let updated = parse_codex_skill_config(&next, &codex_home)?;
+    if codex_skill_entries_enabled(active, &updated)? != enabled {
+        return Err(AcpError::protocol(
+            "requested Codex skill state was not reached",
+        ));
+    }
+    persist_codex_native_config_files_unlocked(None, Some(&next))?;
+    listed.enabled = enabled;
+    Ok(listed)
+}
+
+fn apply_codex_native_skill_state(
+    agent_type: AgentType,
+    roots: &[PathBuf],
+    kind: SkillStorageKind,
+    skill: &mut AgentSkillItem,
+) {
+    if agent_type != AgentType::Codex || !skill.enabled {
+        return;
+    }
+    let state = active_skill_entries(roots, kind, &skill.id, skill.scope).and_then(|active| {
+        if active.is_empty() {
+            return Err(AcpError::protocol("active Codex skill entry not found"));
+        }
+        let codex_home = codex_home_dir();
+        let raw = read_codex_config_or_empty()?;
+        let config = parse_codex_skill_config(&raw, &codex_home)?;
+        codex_skill_entries_enabled(&active, &config)
+    });
+    match state {
+        Ok(enabled) => {
+            skill.enabled = enabled;
+            skill.can_toggle = true;
+        }
+        Err(_) => skill.can_toggle = false,
+    }
+}
+
 // All settings mutations share this lock so lookup, preflight and mutation
 // observe one state. No guard is held across an await.
 static SKILL_MUTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -10678,6 +11080,7 @@ fn cascade_update_agent_config(
             // model-provider endpoint to cascade into.
         }
         AgentType::Codex => {
+            let _config_guard = lock_codex_config_mutation()?;
             let auth_path = codex_auth_json_path();
             let mut auth_obj = if auth_path.exists() {
                 fs::read_to_string(&auth_path)
@@ -10789,7 +11192,7 @@ fn cascade_update_agent_config(
             let toml_str = toml::to_string_pretty(&toml_value)
                 .map_err(|e| AcpError::protocol(e.to_string()))?;
 
-            persist_codex_native_config_files(Some(&auth_str), Some(&toml_str))?;
+            persist_codex_native_config_files_unlocked(Some(&auth_str), Some(&toml_str))?;
         }
         AgentType::OpenCode => {
             let auth_path = opencode_auth_json_path();
@@ -12190,6 +12593,7 @@ fn apply_codex_root_model_action(action: &CodexModelAction) -> Result<(), AcpErr
     if matches!(action, CodexModelAction::NoOp) {
         return Ok(());
     }
+    let _config_guard = lock_codex_config_mutation()?;
     let config_path = codex_config_toml_path();
     let mut toml_value = if config_path.exists() {
         fs::read_to_string(&config_path)
@@ -12214,7 +12618,7 @@ fn apply_codex_root_model_action(action: &CodexModelAction) -> Result<(), AcpErr
     }
     let toml_str =
         toml::to_string_pretty(&toml_value).map_err(|e| AcpError::protocol(e.to_string()))?;
-    persist_codex_native_config_files(None, Some(&toml_str))?;
+    persist_codex_native_config_files_unlocked(None, Some(&toml_str))?;
     Ok(())
 }
 
@@ -12229,6 +12633,7 @@ fn apply_codex_root_model_action(action: &CodexModelAction) -> Result<(), AcpErr
 /// asks the backend to (re)write the catalog *files* (see
 /// `acp_update_agent_config_core`).
 fn apply_codex_catalog_and_model(raw: Option<&str>) -> Result<(), AcpError> {
+    let _config_guard = lock_codex_config_mutation()?;
     let snapshot = crate::acp::codex_catalog_source::cached_or_bundled_snapshot();
     let injection = crate::acp::codex_model_catalog::write_catalog_files(
         raw.unwrap_or_default(),
@@ -12272,7 +12677,7 @@ fn apply_codex_catalog_and_model(raw: Option<&str>) -> Result<(), AcpError> {
     }
     let toml_str =
         toml::to_string_pretty(&toml_value).map_err(|e| AcpError::protocol(e.to_string()))?;
-    persist_codex_native_config_files(None, Some(&toml_str))?;
+    persist_codex_native_config_files_unlocked(None, Some(&toml_str))?;
     Ok(())
 }
 
@@ -12372,6 +12777,7 @@ pub(crate) async fn acp_update_agent_config_core(
     }
 
     if agent_type == AgentType::Codex {
+        let _config_guard = lock_codex_config_mutation()?;
         // Mirrors the Grok/Cursor flow. The advanced raw editor sends the whole
         // file (`codex_config_toml = Some(text)`), so that text is the verbatim
         // base; the sandbox/approval controls send only a patch, merged onto the
@@ -12389,7 +12795,10 @@ pub(crate) async fn acp_update_agent_config_core(
                 }
                 None => codex_config_toml,
             };
-            persist_codex_native_config_files(codex_auth_json.as_deref(), merged_toml.as_deref())?;
+            persist_codex_native_config_files_unlocked(
+                codex_auth_json.as_deref(),
+                merged_toml.as_deref(),
+            )?;
         }
         // The frontend has already patched config.toml's `model_catalog_json` +
         // root `model` into `codex_config_toml` (comment-preserving text patch);
@@ -12407,7 +12816,7 @@ pub(crate) async fn acp_update_agent_config_core(
                 // The frontend only patches that key when the user *edits* the
                 // model editor, so a save that merely lets a stale removal
                 // dissolve would otherwise leave the two out of sync.
-                Ok(None) => drop_codex_catalog_reference()?,
+                Ok(None) => drop_codex_catalog_reference_unlocked()?,
                 Ok(Some(_)) => {}
                 Err(e) => {
                     tracing::error!("[acp_update_agent_config] write codex catalog failed: {e}")
@@ -13751,8 +14160,29 @@ pub async fn acp_list_agent_skills(
 
     let mut skills = skills_by_key.into_values().collect::<Vec<_>>();
     let peers = skill_peers(workspace_path.as_deref());
+    let codex_skill_config = if agent_type == AgentType::Codex {
+        let codex_home = codex_home_dir();
+        Some(
+            read_codex_config_or_empty()
+                .and_then(|raw| parse_codex_skill_config(&raw, &codex_home)),
+        )
+    } else {
+        None
+    };
     for skill in &mut skills {
         apply_skill_capabilities(agent_type, skill);
+        if agent_type == AgentType::Codex && skill.enabled {
+            let active = scoped_skill_dirs(agent_type, skill.scope, workspace_path.as_deref())
+                .and_then(|roots| active_skill_entries(&roots, spec.kind, &skill.id, skill.scope));
+            match (active, codex_skill_config.as_ref()) {
+                (Ok(active), Some(Ok(config))) if !active.is_empty() => {
+                    skill.enabled = codex_skill_entries_enabled(&active, config)?;
+                    skill.can_toggle = true;
+                }
+                _ => skill.can_toggle = false,
+            }
+            continue;
+        }
         if skill.can_toggle {
             skill.can_toggle = peers
                 .iter()
@@ -13797,6 +14227,10 @@ pub async fn acp_set_agent_skill_enabled(
     let mut skill = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope)
         .ok_or_else(|| AcpError::protocol(format!("skill not found: {id}")))?;
     apply_skill_capabilities(agent_type, &mut skill);
+    if agent_type == AgentType::Codex && skill.enabled {
+        let active = active_skill_entries(&dirs, spec.kind, &id, scope)?;
+        return set_codex_skill_enabled_native(skill, &active, enabled);
+    }
     let parent = Path::new(&skill.path).parent();
     let root = dirs
         .iter()
@@ -13883,6 +14317,7 @@ pub async fn acp_read_agent_skill(
     let mut skill = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope)
         .ok_or_else(|| AcpError::protocol(format!("skill not found: {id}")))?;
     apply_skill_capabilities(agent_type, &mut skill);
+    apply_codex_native_skill_state(agent_type, &dirs, spec.kind, &mut skill);
     let content_path = skill_content_path(skill.layout, Path::new(&skill.path));
     let content = fs::read_to_string(&content_path)
         .map_err(|e| AcpError::protocol(format!("failed to read skill content: {e}")))?;
@@ -13954,6 +14389,7 @@ pub async fn acp_save_agent_skill(
         .map_err(|e| AcpError::protocol(format!("failed to write skill content: {e}")))?;
 
     skill.description = read_skill_description(&content_path);
+    apply_codex_native_skill_state(agent_type, &dirs, spec.kind, &mut skill);
 
     Ok(skill)
 }
@@ -16640,7 +17076,7 @@ wire_api = "chat"
     }
 
     #[test]
-    fn skill_state_read_only_builtin_cannot_toggle() {
+    fn codex_system_skill_is_read_only_but_toggleable() {
         let tmp = tempfile::tempdir().expect("tempdir");
         temp_env::with_var("CODEX_HOME", Some(tmp.path()), || {
             let system_skill = tmp.path().join("skills/.system/task1a-system-demo");
@@ -16660,7 +17096,7 @@ wire_api = "chat"
 
             assert!(item.enabled);
             assert!(item.read_only);
-            assert!(!item.can_toggle);
+            assert!(item.can_toggle);
         });
     }
 
@@ -18247,174 +18683,565 @@ wire_api = "chat"
     #[test]
     fn skill_enabled_private_command_unisolatable_shared_roots_are_rejected() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
-        for (agent, relative) in [
-            (AgentType::Codex, ".agents/skills"),
-            (AgentType::Gemini, ".gemini/skills"),
-        ] {
-            let tmp = tempfile::tempdir().expect("tempdir");
-            let root = tmp.path().join(relative);
-            fs::create_dir_all(root.join("demo")).unwrap();
-            fs::write(root.join("demo/SKILL.md"), "shared").unwrap();
-            let error = runtime
-                .block_on(acp_set_agent_skill_enabled(
-                    agent,
-                    AgentSkillScope::Project,
-                    "demo".to_string(),
-                    Some(tmp.path().to_string_lossy().into_owned()),
-                    false,
-                ))
-                .unwrap_err();
-            assert!(error.to_string().contains("shared skill root"));
-            assert!(root.join("demo/SKILL.md").is_file());
-            assert!(!disabled_skill_root(&root).exists());
-        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join(".gemini/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "shared").unwrap();
+        let error = runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::Gemini,
+                AgentSkillScope::Project,
+                "demo".to_string(),
+                Some(tmp.path().to_string_lossy().into_owned()),
+                false,
+            ))
+            .unwrap_err();
+        assert!(error.to_string().contains("shared skill root"));
+        assert!(root.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&root).exists());
     }
 
     #[test]
     fn skill_enabled_private_concurrent_commands_return_requested_state() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let root = tmp.path().join(".codex/skills");
-        fs::create_dir_all(root.join("demo")).unwrap();
-        fs::write(root.join("demo/SKILL.md"), "body").unwrap();
-        let workspace = tmp.path().to_string_lossy().into_owned();
-        std::thread::scope(|threads| {
-            let handles = (0..8)
-                .map(|_| {
-                    let workspace = &workspace;
-                    threads.spawn(move || {
-                        let runtime = tokio::runtime::Runtime::new().unwrap();
-                        for enabled in [false, false, true, true] {
-                            let item = runtime
-                                .block_on(acp_set_agent_skill_enabled(
-                                    AgentType::Codex,
-                                    AgentSkillScope::Project,
-                                    "demo".to_string(),
-                                    Some(workspace.clone()),
-                                    enabled,
-                                ))
-                                .unwrap();
-                            assert_eq!(item.enabled, enabled);
-                        }
-                    })
-                })
-                .collect::<Vec<_>>();
-            for handle in handles {
-                handle.join().unwrap();
-            }
-        });
-        assert_eq!(
-            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
-            "body"
-        );
-        assert!(!disabled_skill_root(&root).join("demo").exists());
-    }
-
-    #[test]
-    fn skill_enabled_private_duplicate_active_roots_are_rejected_before_move() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let roots = [
-            tmp.path().join(".codex/skills"),
-            tmp.path().join(".agents/skills"),
-        ];
-        for root in &roots {
+        let codex_home = tmp.path().join("codex-home");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            let root = tmp.path().join(".codex/skills");
             fs::create_dir_all(root.join("demo")).unwrap();
-            fs::write(root.join("demo/SKILL.md"), "original").unwrap();
-        }
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let error = runtime
-            .block_on(acp_set_agent_skill_enabled(
-                AgentType::Codex,
-                AgentSkillScope::Project,
-                "demo".into(),
-                Some(tmp.path().to_string_lossy().into_owned()),
-                false,
-            ))
-            .unwrap_err();
-        assert!(error.to_string().contains("multiple active"));
-        for root in &roots {
+            fs::write(root.join("demo/SKILL.md"), "body").unwrap();
+            let workspace = tmp.path().to_string_lossy().into_owned();
+            std::thread::scope(|threads| {
+                let handles = (0..8)
+                    .map(|_| {
+                        let workspace = &workspace;
+                        threads.spawn(move || {
+                            let runtime = tokio::runtime::Runtime::new().unwrap();
+                            for enabled in [false, false, true, true] {
+                                let item = runtime
+                                    .block_on(acp_set_agent_skill_enabled(
+                                        AgentType::Codex,
+                                        AgentSkillScope::Project,
+                                        "demo".to_string(),
+                                        Some(workspace.clone()),
+                                        enabled,
+                                    ))
+                                    .unwrap();
+                                assert_eq!(item.enabled, enabled);
+                            }
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                for handle in handles {
+                    handle.join().unwrap();
+                }
+            });
             assert_eq!(
                 fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
-                "original"
+                "body"
             );
-            assert!(!disabled_skill_root(root).exists());
-        }
+            assert!(!disabled_skill_root(&root).join("demo").exists());
+        });
     }
 
     #[test]
-    fn skill_enabled_private_duplicate_active_layouts_are_rejected_before_move() {
+    fn codex_native_toggle_disables_duplicate_active_roots_without_moving_them() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let root = tmp.path().join(".codex/skills");
-        fs::create_dir_all(root.join("demo")).unwrap();
-        fs::write(root.join("demo/SKILL.md"), "directory").unwrap();
-        fs::write(root.join("demo.md"), "flat").unwrap();
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let error = runtime
-            .block_on(acp_set_agent_skill_enabled(
-                AgentType::Codex,
-                AgentSkillScope::Project,
-                "demo".into(),
-                Some(tmp.path().to_string_lossy().into_owned()),
-                false,
-            ))
-            .unwrap_err();
-        assert!(error.to_string().contains("multiple active"));
-        assert_eq!(
-            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
-            "directory"
-        );
-        assert_eq!(fs::read_to_string(root.join("demo.md")).unwrap(), "flat");
-        assert!(!disabled_skill_root(&root).exists());
+        let codex_home = tmp.path().join("codex-home");
+        let workspace = tmp.path().join("workspace");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            fs::create_dir_all(&codex_home).unwrap();
+            fs::write(
+                codex_home.join("config.toml"),
+                "# keep this comment\nmodel = \"test-model\"\n\n[[skills.config]]\npath = \"/unrelated/SKILL.md\"\nenabled = false\n",
+            )
+            .unwrap();
+            let roots = [
+                workspace.join(".codex/skills"),
+                workspace.join(".agents/skills"),
+            ];
+            for root in &roots {
+                fs::create_dir_all(root.join("demo")).unwrap();
+                fs::write(root.join("demo/SKILL.md"), "original").unwrap();
+            }
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let workspace_path = Some(workspace.to_string_lossy().into_owned());
+            let before = runtime
+                .block_on(acp_list_agent_skills(
+                    AgentType::Codex,
+                    workspace_path.clone(),
+                ))
+                .unwrap()
+                .skills
+                .into_iter()
+                .find(|skill| skill.scope == AgentSkillScope::Project && skill.id == "demo")
+                .unwrap();
+            assert!(before.can_toggle, "Codex can disable every visible path");
+
+            let disabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    workspace_path.clone(),
+                    false,
+                ))
+                .unwrap();
+            assert!(!disabled.enabled);
+            assert_eq!(
+                disabled.path, before.path,
+                "the displayed path stays stable"
+            );
+
+            for root in &roots {
+                assert_eq!(
+                    fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+                    "original"
+                );
+                assert!(!disabled_skill_root(root).exists());
+            }
+
+            let config = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+            assert!(config.contains("# keep this comment\nmodel = \"test-model\""));
+            let parsed = config.parse::<toml::Value>().unwrap();
+            let configured = parsed["skills"]["config"].as_array().unwrap();
+            assert_eq!(configured.len(), 3);
+            for root in &roots {
+                let expected_path = fs::canonicalize(root.join("demo/SKILL.md")).unwrap();
+                let expected = expected_path.to_string_lossy();
+                assert!(configured.iter().any(|entry| {
+                    entry.get("path").and_then(toml::Value::as_str) == Some(expected.as_ref())
+                        && entry.get("enabled").and_then(toml::Value::as_bool) == Some(false)
+                }));
+            }
+
+            let listed = runtime
+                .block_on(acp_list_agent_skills(AgentType::Codex, workspace_path))
+                .unwrap()
+                .skills
+                .into_iter()
+                .find(|skill| skill.scope == AgentSkillScope::Project && skill.id == "demo")
+                .unwrap();
+            assert!(!listed.enabled);
+            assert!(listed.can_toggle);
+            assert_eq!(listed.path, before.path);
+
+            let enabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    Some(workspace.to_string_lossy().into_owned()),
+                    true,
+                ))
+                .unwrap();
+            assert!(enabled.enabled);
+            assert_eq!(enabled.path, before.path);
+            let config = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+            let parsed = config.parse::<toml::Value>().unwrap();
+            for root in &roots {
+                let expected_path = fs::canonicalize(root.join("demo/SKILL.md")).unwrap();
+                let expected = expected_path.to_string_lossy();
+                assert!(parsed["skills"]["config"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|entry| {
+                        entry.get("path").and_then(toml::Value::as_str) == Some(expected.as_ref())
+                            && entry.get("enabled").and_then(toml::Value::as_bool) == Some(true)
+                    }));
+            }
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_native_toggle_keeps_shared_vault_links_in_place() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        let workspace = tmp.path().join("workspace");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            let canonical = workspace
+                .join(".agents/.skills.codeg-disabled")
+                .join("agent-reach");
+            fs::create_dir_all(&canonical).unwrap();
+            fs::write(canonical.join("SKILL.md"), "shared skill").unwrap();
+
+            let links = [
+                workspace.join(".codex/skills/agent-reach"),
+                workspace.join(".gemini/skills/agent-reach"),
+                workspace.join(".cursor/skills/agent-reach"),
+            ];
+            for link in &links {
+                fs::create_dir_all(link.parent().unwrap()).unwrap();
+                std::os::unix::fs::symlink(&canonical, link).unwrap();
+            }
+
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let workspace_path = Some(workspace.to_string_lossy().into_owned());
+            let before = runtime
+                .block_on(acp_list_agent_skills(
+                    AgentType::Codex,
+                    workspace_path.clone(),
+                ))
+                .unwrap()
+                .skills
+                .into_iter()
+                .find(|skill| skill.scope == AgentSkillScope::Project && skill.id == "agent-reach")
+                .unwrap();
+            assert!(before.enabled);
+            assert!(before.can_toggle);
+            assert_eq!(Path::new(&before.path), links[0]);
+
+            let disabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "agent-reach".into(),
+                    workspace_path.clone(),
+                    false,
+                ))
+                .unwrap();
+            assert!(!disabled.enabled);
+            assert_eq!(disabled.path, before.path);
+            assert!(canonical.join("SKILL.md").is_file());
+            for link in &links {
+                assert!(fs::symlink_metadata(link).unwrap().file_type().is_symlink());
+                assert_eq!(fs::read_link(link).unwrap(), canonical);
+            }
+
+            let config = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+            let parsed = config.parse::<toml::Value>().unwrap();
+            let configured = parsed["skills"]["config"].as_array().unwrap();
+            assert_eq!(configured.len(), 1);
+            let canonical_skill_md = fs::canonicalize(canonical.join("SKILL.md")).unwrap();
+            assert_eq!(
+                configured[0].get("path").and_then(toml::Value::as_str),
+                canonical_skill_md.to_str()
+            );
+            assert_eq!(
+                configured[0].get("enabled").and_then(toml::Value::as_bool),
+                Some(false)
+            );
+
+            let listed = runtime
+                .block_on(acp_list_agent_skills(
+                    AgentType::Codex,
+                    workspace_path.clone(),
+                ))
+                .unwrap()
+                .skills
+                .into_iter()
+                .find(|skill| skill.scope == AgentSkillScope::Project && skill.id == "agent-reach")
+                .unwrap();
+            assert!(!listed.enabled);
+            assert!(listed.can_toggle);
+            assert_eq!(listed.path, before.path);
+
+            let enabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "agent-reach".into(),
+                    workspace_path,
+                    true,
+                ))
+                .unwrap();
+            assert!(enabled.enabled);
+            assert_eq!(enabled.path, before.path);
+            for link in &links {
+                assert!(fs::symlink_metadata(link).unwrap().file_type().is_symlink());
+                assert_eq!(fs::read_link(link).unwrap(), canonical);
+            }
+        });
+    }
+
+    #[test]
+    fn codex_native_toggle_honors_name_config_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        let workspace = tmp.path().join("workspace");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            fs::create_dir_all(&codex_home).unwrap();
+            fs::write(
+                codex_home.join("config.toml"),
+                "[[skills.config]]\nname = \"demo\"\nenabled = false\n",
+            )
+            .unwrap();
+            let skill = workspace.join(".codex/skills/demo");
+            fs::create_dir_all(&skill).unwrap();
+            fs::write(
+                skill.join("SKILL.md"),
+                "---\nname: demo\ndescription: Demo\n---\n",
+            )
+            .unwrap();
+
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let workspace_path = Some(workspace.to_string_lossy().into_owned());
+            let listed = runtime
+                .block_on(acp_list_agent_skills(
+                    AgentType::Codex,
+                    workspace_path.clone(),
+                ))
+                .unwrap()
+                .skills
+                .into_iter()
+                .find(|skill| skill.scope == AgentSkillScope::Project && skill.id == "demo")
+                .unwrap();
+            assert!(!listed.enabled);
+            assert!(listed.can_toggle);
+
+            let enabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    workspace_path,
+                    true,
+                ))
+                .unwrap();
+            assert!(enabled.enabled);
+
+            let config = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+            let parsed = config.parse::<toml::Value>().unwrap();
+            let configured = parsed["skills"]["config"].as_array().unwrap();
+            assert_eq!(configured.len(), 2);
+            assert_eq!(
+                configured[0].get("name").and_then(toml::Value::as_str),
+                Some("demo")
+            );
+            assert_eq!(
+                configured[0].get("enabled").and_then(toml::Value::as_bool),
+                Some(false),
+                "a path-scoped toggle must not rewrite the broader name selector"
+            );
+            let expected_path = fs::canonicalize(skill.join("SKILL.md")).unwrap();
+            assert!(configured.iter().any(|entry| {
+                entry.get("path").and_then(toml::Value::as_str)
+                    == expected_path.to_str()
+                    && entry.get("enabled").and_then(toml::Value::as_bool) == Some(true)
+            }));
+        });
+    }
+
+    #[test]
+    fn codex_skill_config_path_selector_overrides_later_name_selector() {
+        let config = parse_codex_skill_config(
+            "[[skills.config]]\npath = \"/tmp/demo/SKILL.md\"\nenabled = true\n\
+             \n[[skills.config]]\nname = \"demo\"\nenabled = false\n",
+            Path::new("/tmp/codex-home"),
+        )
+        .unwrap();
+
+        assert!(config.skill_enabled(Path::new("/tmp/demo/SKILL.md"), "demo"));
+    }
+
+    #[test]
+    fn codex_skill_config_selectorless_entry_matches_no_skill() {
+        let config = parse_codex_skill_config(
+            "[[skills.config]]\nenabled = false\n",
+            Path::new("/tmp/codex-home"),
+        )
+        .expect("Codex accepts selectorless entries");
+
+        assert!(config.skill_enabled(Path::new("/tmp/demo/SKILL.md"), "demo"));
+    }
+
+    #[test]
+    fn codex_skill_config_requires_enabled_field() {
+        let error = parse_codex_skill_config(
+            "[[skills.config]]\nname = \"demo\"\n",
+            Path::new("/tmp/codex-home"),
+        )
+        .expect_err("Codex rejects entries without enabled");
+
+        assert!(error.to_string().contains("enabled"));
+    }
+
+    #[test]
+    fn codex_native_toggle_updates_inline_array_config() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        let workspace = tmp.path().join("workspace");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            let skill = workspace.join(".codex/skills/demo");
+            fs::create_dir_all(&skill).unwrap();
+            fs::write(skill.join("SKILL.md"), "inline config").unwrap();
+            fs::create_dir_all(&codex_home).unwrap();
+            let content_path = fs::canonicalize(skill.join("SKILL.md")).unwrap();
+            fs::write(
+                codex_home.join("config.toml"),
+                format!(
+                    "# inline form is valid Codex TOML\n[skills]\nconfig = [{{ path = \"{}\", enabled = true }}]\n",
+                    content_path.display()
+                ),
+            )
+            .unwrap();
+
+            let disabled = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    Some(workspace.to_string_lossy().into_owned()),
+                    false,
+                ))
+                .expect("inline-array config should remain toggleable");
+            assert!(!disabled.enabled);
+
+            let written = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+            assert!(written.contains("# inline form is valid Codex TOML"));
+            assert!(written.contains("config = ["));
+            let parsed = written.parse::<toml::Value>().unwrap();
+            let entries = parsed["skills"]["config"].as_array().unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(
+                entries[0].get("path").and_then(toml::Value::as_str),
+                content_path.to_str()
+            );
+            assert_eq!(
+                entries[0].get("enabled").and_then(toml::Value::as_bool),
+                Some(false)
+            );
+            assert!(skill.join("SKILL.md").is_file());
+        });
+    }
+
+    #[test]
+    fn codex_config_concurrent_rmw_writes_preserve_both_changes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            fs::create_dir_all(&codex_home).unwrap();
+            let config_path = codex_home.join("config.toml");
+            let padding = "# keep this unrelated config padding\n".repeat(50_000);
+
+            for attempt in 0..4 {
+                fs::write(
+                    &config_path,
+                    format!(
+                        "model = \"old\"\nmodel_catalog_json = \"{}\"\n{padding}",
+                        crate::acp::codex_model_catalog::CATALOG_REL,
+                    ),
+                )
+                .unwrap();
+
+                let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+                std::thread::scope(|threads| {
+                    let first = barrier.clone();
+                    let set_model = threads.spawn(move || {
+                        first.wait();
+                        apply_codex_root_model_action(&CodexModelAction::Set("new".into()))
+                    });
+                    let second = barrier.clone();
+                    let drop_catalog = threads.spawn(move || {
+                        second.wait();
+                        drop_codex_catalog_reference()
+                    });
+                    barrier.wait();
+                    set_model.join().unwrap().unwrap();
+                    drop_catalog.join().unwrap().unwrap();
+                });
+
+                let written = fs::read_to_string(&config_path).unwrap();
+                let parsed = written.parse::<toml::Value>().unwrap();
+                assert_eq!(
+                    parsed.get("model").and_then(toml::Value::as_str),
+                    Some("new"),
+                    "model update was lost on attempt {attempt}",
+                );
+                assert!(
+                    parsed.get("model_catalog_json").is_none(),
+                    "catalog cleanup was lost on attempt {attempt}",
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn codex_native_toggle_disables_duplicate_active_layouts_without_moving_them() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            let root = tmp.path().join("workspace/.codex/skills");
+            fs::create_dir_all(root.join("demo")).unwrap();
+            fs::write(root.join("demo/SKILL.md"), "directory").unwrap();
+            fs::write(root.join("demo.md"), "flat").unwrap();
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let disabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    Some(tmp.path().join("workspace").to_string_lossy().into_owned()),
+                    false,
+                ))
+                .unwrap();
+            assert!(!disabled.enabled);
+            assert_eq!(
+                fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+                "directory"
+            );
+            assert_eq!(fs::read_to_string(root.join("demo.md")).unwrap(), "flat");
+            assert!(!disabled_skill_root(&root).exists());
+            let config = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+            let parsed = config.parse::<toml::Value>().unwrap();
+            assert_eq!(parsed["skills"]["config"].as_array().unwrap().len(), 2);
+        });
     }
 
     #[test]
     fn skill_enabled_private_save_new_then_edit_disabled_and_reenable() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let workspace = Some(tmp.path().to_string_lossy().into_owned());
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let saved = runtime
-            .block_on(acp_save_agent_skill(
-                AgentType::Codex,
-                AgentSkillScope::Project,
-                "demo".into(),
-                "original".into(),
-                workspace.clone(),
-                None,
-            ))
-            .unwrap();
-        assert!(saved.enabled);
-        assert_eq!(saved.layout, AgentSkillLayout::MarkdownFile);
-        runtime
-            .block_on(acp_set_agent_skill_enabled(
-                AgentType::Codex,
-                AgentSkillScope::Project,
-                "demo".into(),
-                workspace.clone(),
-                false,
-            ))
-            .unwrap();
-        let saved = runtime
-            .block_on(acp_save_agent_skill(
-                AgentType::Codex,
-                AgentSkillScope::Project,
-                "demo".into(),
-                "updated".into(),
-                workspace.clone(),
-                Some(AgentSkillLayout::SkillDirectory),
-            ))
-            .unwrap();
-        assert!(!saved.enabled);
-        assert_eq!(saved.layout, AgentSkillLayout::MarkdownFile);
-        let enabled = runtime
-            .block_on(acp_set_agent_skill_enabled(
-                AgentType::Codex,
-                AgentSkillScope::Project,
-                "demo".into(),
-                workspace,
-                true,
-            ))
-            .unwrap();
-        assert!(enabled.enabled);
-        assert_eq!(fs::read_to_string(enabled.path).unwrap(), "updated");
+        let codex_home = tmp.path().join("codex-home");
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            let workspace = Some(tmp.path().to_string_lossy().into_owned());
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let saved = runtime
+                .block_on(acp_save_agent_skill(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    "original".into(),
+                    workspace.clone(),
+                    None,
+                ))
+                .unwrap();
+            assert!(saved.enabled);
+            assert_eq!(saved.layout, AgentSkillLayout::MarkdownFile);
+            runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    workspace.clone(),
+                    false,
+                ))
+                .unwrap();
+            let saved = runtime
+                .block_on(acp_save_agent_skill(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    "updated".into(),
+                    workspace.clone(),
+                    Some(AgentSkillLayout::SkillDirectory),
+                ))
+                .unwrap();
+            assert!(!saved.enabled);
+            assert_eq!(saved.layout, AgentSkillLayout::MarkdownFile);
+            let enabled = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    workspace,
+                    true,
+                ))
+                .unwrap();
+            assert!(enabled.enabled);
+            assert_eq!(fs::read_to_string(enabled.path).unwrap(), "updated");
+        });
     }
 
     #[test]
@@ -18513,7 +19340,7 @@ wire_api = "chat"
     fn skill_enabled_private_safety_vault_alias_to_native_root_is_rejected() {
         for destination in [".agents/skills", "skills"] {
             let tmp = tempfile::tempdir().unwrap();
-            let root = tmp.path().join(".codex/skills");
+            let root = tmp.path().join(".gemini/skills");
             let other = tmp.path().join(destination);
             fs::create_dir_all(root.join("demo")).unwrap();
             fs::write(root.join("demo/SKILL.md"), "original").unwrap();
@@ -18523,7 +19350,7 @@ wire_api = "chat"
                 tokio::runtime::Runtime::new()
                     .unwrap()
                     .block_on(acp_set_agent_skill_enabled(
-                        AgentType::Codex,
+                        AgentType::Gemini,
                         AgentSkillScope::Project,
                         "demo".into(),
                         Some(tmp.path().to_string_lossy().into_owned()),
@@ -18638,7 +19465,7 @@ wire_api = "chat"
         };
         let _registry_guard = hydrate_test_guard();
         let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path().join(".codex/skills");
+        let root = tmp.path().join(".gemini/skills");
         fs::create_dir_all(root.join("demo")).unwrap();
         fs::write(root.join("demo/SKILL.md"), "shared").unwrap();
         let definition = CustomAgentDef {
@@ -18665,7 +19492,7 @@ wire_api = "chat"
         let result = tokio::runtime::Runtime::new()
             .unwrap()
             .block_on(acp_set_agent_skill_enabled(
-                AgentType::Codex,
+                AgentType::Gemini,
                 AgentSkillScope::Project,
                 "demo".into(),
                 Some(tmp.path().to_string_lossy().into_owned()),
@@ -18843,13 +19670,12 @@ wire_api = "chat"
     }
 
     #[test]
-    fn skill_enabled_private_read_only_skill_cannot_be_toggled() {
+    fn codex_native_toggle_disables_read_only_system_skill_without_editing_it() {
         let tmp = tempfile::tempdir().expect("tempdir");
         temp_env::with_var("CODEX_HOME", Some(tmp.path()), || {
             let system_skill = tmp.path().join("skills/.system/task1-system-demo");
             std::fs::create_dir_all(&system_skill).expect("create system skill");
-            std::fs::write(system_skill.join("SKILL.md"), "system\n")
-                .expect("write system skill");
+            std::fs::write(system_skill.join("SKILL.md"), "system\n").expect("write system skill");
             let runtime = tokio::runtime::Runtime::new().expect("runtime");
 
             let listed = runtime
@@ -18861,9 +19687,9 @@ wire_api = "chat"
                 .find(|item| item.id == "task1-system-demo")
                 .expect("listed system skill");
             assert!(item.read_only);
-            assert!(!item.can_toggle);
+            assert!(item.can_toggle);
 
-            let error = runtime
+            let disabled = runtime
                 .block_on(acp_set_agent_skill_enabled(
                     AgentType::Codex,
                     AgentSkillScope::Global,
@@ -18871,10 +19697,77 @@ wire_api = "chat"
                     None,
                     false,
                 ))
-                .expect_err("system skill toggle must fail");
-            assert!(error.to_string().contains("cannot be toggled"));
+                .expect("system skill availability should be configurable");
+            assert!(!disabled.enabled);
+            assert!(disabled.read_only);
+            assert!(disabled.can_toggle);
+            assert_eq!(disabled.path, item.path);
             assert!(system_skill.join("SKILL.md").is_file());
+
+            let listed = runtime
+                .block_on(acp_list_agent_skills(AgentType::Codex, None))
+                .expect("list disabled system skill");
+            let item = listed
+                .skills
+                .iter()
+                .find(|item| item.id == "task1-system-demo")
+                .expect("disabled system skill remains listed");
+            assert!(!item.enabled);
+            assert!(item.read_only);
+            assert!(item.can_toggle);
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_native_toggle_preserves_config_symlink() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        let real_dir = tmp.path().join("real-config");
+        fs::create_dir_all(&codex_home).unwrap();
+        fs::create_dir_all(&real_dir).unwrap();
+        let target = real_dir.join("config.toml");
+        fs::write(&target, "# linked config\nmodel = \"test-model\"\n").unwrap();
+        let relative_target = Path::new("../real-config/config.toml");
+        std::os::unix::fs::symlink(relative_target, codex_home.join("config.toml")).unwrap();
+
+        temp_env::with_var("CODEX_HOME", Some(&codex_home), || {
+            let system_skill = codex_home.join("skills/.system/task1-linked-config-demo");
+            fs::create_dir_all(&system_skill).unwrap();
+            fs::write(system_skill.join("SKILL.md"), "system\n").unwrap();
+
+            let disabled = tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::Codex,
+                    AgentSkillScope::Global,
+                    "task1-linked-config-demo".into(),
+                    None,
+                    false,
+                ))
+                .expect("toggle through linked config");
+            assert!(!disabled.enabled);
+        });
+
+        let link = codex_home.join("config.toml");
+        assert!(
+            fs::symlink_metadata(&link).unwrap().file_type().is_symlink(),
+            "atomic replacement must update the target without replacing the link",
+        );
+        assert_eq!(fs::read_link(&link).unwrap(), relative_target);
+        let written = fs::read_to_string(&target).unwrap();
+        assert!(written.contains("# linked config"));
+        let parsed = written.parse::<toml::Value>().unwrap();
+        assert_eq!(
+            parsed.get("model").and_then(toml::Value::as_str),
+            Some("test-model"),
+        );
+        assert_eq!(
+            parsed["skills"]["config"].as_array().unwrap()[0]
+                .get("enabled")
+                .and_then(toml::Value::as_bool),
+            Some(false),
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8900,6 +8900,485 @@ fn skill_roots_overlap(first: &Path, second: &Path) -> bool {
     first.starts_with(second) || second.starts_with(first)
 }
 
+#[derive(Clone)]
+struct SkillPeer {
+    agent: AgentType,
+    scope: AgentSkillScope,
+    kind: SkillStorageKind,
+    roots: Vec<PathBuf>,
+}
+
+fn skill_peers(workspace_path: Option<&str>) -> Vec<SkillPeer> {
+    let mut peers: Vec<SkillPeer> = Vec::new();
+    for (agent, scope, root) in native_skill_roots(workspace_path) {
+        if let Some(peer) = peers
+            .iter_mut()
+            .find(|p| p.agent == agent && p.scope == scope)
+        {
+            peer.roots.push(root);
+        } else if let Some(spec) = skill_storage_spec(agent) {
+            peers.push(SkillPeer {
+                agent,
+                scope,
+                kind: spec.kind,
+                roots: vec![root],
+            });
+        }
+    }
+    peers
+}
+
+fn preflight_skill_destination(root: &Path, id: &str) -> Result<(), AcpError> {
+    // Reserve both layouts, including dangling links and malformed bundles.
+    for path in [root.join(id), root.join(format!("{id}.md"))] {
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {
+                return Err(AcpError::protocol(format!(
+                    "skill destination collision: '{}' already exists",
+                    path.display()
+                )))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(AcpError::protocol(format!(
+                    "failed to inspect skill destination '{}': {e}",
+                    path.display()
+                )))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn skill_root_writable(root: &Path) -> bool {
+    let mut ancestor = root;
+    loop {
+        match fs::metadata(ancestor) {
+            Ok(metadata) => {
+                if !metadata.is_dir() || metadata.permissions().readonly() {
+                    return false;
+                }
+                #[cfg(unix)]
+                {
+                    use std::os::unix::ffi::OsStrExt;
+                    let Ok(path) = std::ffi::CString::new(ancestor.as_os_str().as_bytes()) else {
+                        return false;
+                    };
+                    // access checks search permission and ACLs without creating a probe file.
+                    unsafe {
+                        return libc::access(path.as_ptr(), libc::W_OK | libc::X_OK) == 0;
+                    }
+                }
+                #[cfg(not(unix))]
+                return true;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let Some(parent) = ancestor.parent() else {
+                    return false;
+                };
+                ancestor = parent;
+            }
+            Err(_) => return false,
+        }
+    }
+}
+
+fn unique_skill_root(peer: &SkillPeer, peers: &[SkillPeer]) -> Result<PathBuf, AcpError> {
+    for root in &peer.roots {
+        let resolved = resolved_skill_root(root)?;
+        if is_read_only_skill_path(peer.agent, root)
+            || is_read_only_skill_path(peer.agent, &resolved)
+            || !skill_root_writable(root)
+        {
+            continue;
+        }
+        let mut unique = true;
+        for other in peers {
+            if other.agent == peer.agent && other.scope == peer.scope {
+                continue;
+            }
+            for other_root in &other.roots {
+                if skill_roots_overlap(&resolved, &resolved_skill_root(other_root)?) {
+                    unique = false;
+                }
+            }
+        }
+        if unique {
+            return Ok(root.clone());
+        }
+    }
+    Err(AcpError::protocol(format!(
+        "shared skill root: {} has no unique writable root",
+        peer.agent
+    )))
+}
+
+fn create_skill_link(source: &Path, destination: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        super::experts::create_link_raw(source, destination).map(|_| ())
+    }
+    #[cfg(windows)]
+    {
+        if source.is_dir() {
+            // A copy fallback would stop following canonical edits.
+            junction::create(source, destination)
+        } else {
+            std::os::windows::fs::symlink_file(source, destination)
+        }
+    }
+}
+
+fn remove_skill_link(path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    if super::experts::path_is_reparse_point(path) && path.is_dir() {
+        return junction::delete(path);
+    }
+    fs::remove_file(path)
+}
+
+fn skill_link_targets(path: &Path, canonical: &Path) -> bool {
+    let Some(target) = super::experts::read_link_target(path) else {
+        return false;
+    };
+    let target = if target.is_absolute() {
+        target
+    } else {
+        path.parent().unwrap_or_else(|| Path::new("")).join(target)
+    };
+    // Compare the link's direct destination, preserving a canonical entry that
+    // is itself a symlink. An independent link to the same content is not ours.
+    let identity = |entry: &Path| -> Option<PathBuf> {
+        Some(
+            resolved_skill_root(entry.parent()?)
+                .ok()?
+                .join(entry.file_name()?),
+        )
+    };
+    identity(&target)
+        .zip(identity(canonical))
+        .is_some_and(|(left, right)| left == right)
+}
+
+fn delete_shared_skill(
+    canonical: &Path,
+    peers: &[SkillPeer],
+    id: &str,
+    mut rename: impl FnMut(&Path, &Path) -> std::io::Result<()>,
+) -> Result<(), AcpError> {
+    let mut entries = vec![canonical.to_path_buf()];
+    let mut seen = std::collections::HashSet::new();
+    for peer in peers {
+        for root in &peer.roots {
+            for scan in [root.clone(), disabled_skill_root(root)] {
+                for path in [scan.join(id), scan.join(format!("{id}.md"))] {
+                    if skill_link_targets(&path, canonical) {
+                        let identity = resolved_skill_root(path.parent().expect("link parent"))?
+                            .join(path.file_name().expect("link filename"));
+                        if seen.insert(identity) {
+                            entries.push(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let staging = canonical
+        .parent()
+        .ok_or_else(|| AcpError::protocol("canonical skill has no parent"))?
+        .join(format!(".codeg-delete-{}", uuid::Uuid::new_v4()));
+    fs::create_dir(&staging)
+        .map_err(|e| AcpError::protocol(format!("failed to stage skill deletion: {e}")))?;
+    let mut moved: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        let destination = staging.join(index.to_string());
+        if let Err(error) = rename(entry, &destination) {
+            let mut failures = Vec::new();
+            for (source, staged) in moved.iter().rev() {
+                match fs::symlink_metadata(source) {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        if let Err(e) = fs::rename(staged, source) {
+                            failures.push(e.to_string());
+                        }
+                    }
+                    _ => failures.push(format!(
+                        "rollback destination '{}' is occupied or inaccessible",
+                        source.display()
+                    )),
+                }
+            }
+            let _ = fs::remove_dir(&staging);
+            return Err(AcpError::protocol(format!(
+                "shared skill deletion failed: {error}; {}",
+                if failures.is_empty() {
+                    "rolled back".to_string()
+                } else {
+                    format!(
+                        "rollback failed: {}; recovery directory '{}'",
+                        failures.join("; "),
+                        staging.display()
+                    )
+                }
+            )));
+        }
+        moved.push((entry.clone(), destination));
+    }
+    // All visible entries are now gone: deletion is committed. Cleanup failure
+    // leaves only hidden recovery material, never dangling native scan entries.
+    for (_, staged) in &moved {
+        if let Err(error) = remove_skill_entry(staged) {
+            tracing::warn!(path = %staged.display(), %error, "shared skill deletion committed; recovery cleanup failed");
+        }
+    }
+    if let Err(error) = fs::remove_dir(&staging) {
+        tracing::warn!(path = %staging.display(), %error, "shared skill deletion recovery directory retained");
+    }
+    Ok(())
+}
+
+/// Preflight the complete peer plan before changing the canonical entry.
+/// The caller holds SKILL_MUTATION_LOCK; link creation is injectable for IO failure tests.
+fn set_shared_skill_enabled(
+    selected: &SkillPeer,
+    peers: &[SkillPeer],
+    root: &Path,
+    skill_id: &str,
+    enabled: bool,
+    mut create_link: impl FnMut(&Path, &Path) -> std::io::Result<()>,
+) -> Result<AgentSkillItem, AcpError> {
+    let id = validate_skill_id(skill_id)?;
+    let original =
+        locate_existing_skill_across_dirs(&selected.roots, selected.kind, &id, selected.scope)
+            .ok_or_else(|| AcpError::protocol(format!("skill not found: {id}")))?;
+    reject_multiple_active_skills(&selected.roots, selected.kind, &id)?;
+    if original.enabled == enabled {
+        return Ok(original);
+    }
+    let resolved_root = resolved_skill_root(root)?;
+    let vault = disabled_skill_root(root);
+    let resolved_vault = resolved_skill_root(&vault)?;
+    for peer in peers {
+        for native in &peer.roots {
+            let resolved_native = resolved_skill_root(native)?;
+            if skill_roots_overlap(&resolved_vault, &resolved_native) {
+                return Err(AcpError::protocol(
+                    "disabled skill vault overlaps native scan root",
+                ));
+            }
+            if resolved_native != resolved_root
+                && resolved_skill_root(&disabled_skill_root(native))? == resolved_vault
+            {
+                return Err(AcpError::protocol(
+                    "shared skill storage: disabled vault has multiple native owners",
+                ));
+            }
+        }
+    }
+    let first_disable = original.enabled
+        && resolved_skill_root(Path::new(&original.path).parent().expect("skill parent"))?
+            == resolved_root;
+    let canonical_item = if first_disable {
+        original.clone()
+    } else {
+        locate_existing_skill(&vault, selected.kind, &id, selected.scope, false)
+            .ok_or_else(|| AcpError::protocol("shared canonical skill not found"))?
+    };
+    let file_name = Path::new(&canonical_item.path)
+        .file_name()
+        .expect("skill filename");
+    let canonical = resolved_vault.join(file_name);
+    let mut destinations = Vec::new();
+    let mut affected = Vec::new();
+    let mut restore_shared = false;
+    let mut redundant_links = Vec::new();
+    if first_disable {
+        preflight_skill_destination(&vault, &id)?;
+        for scan in &selected.roots {
+            preflight_skill_destination(&disabled_skill_root(scan), &id)?;
+        }
+        preflight_skill_symlink_move(Path::new(&original.path), &vault)?;
+        for peer in peers {
+            let mut shares = false;
+            for scan in &peer.roots {
+                let resolved_scan = resolved_skill_root(scan)?;
+                if skill_roots_overlap(&resolved_root, &resolved_scan) {
+                    if resolved_root != resolved_scan {
+                        return Err(AcpError::protocol(
+                            "shared skill root has overlapping scan roots that cannot be isolated",
+                        ));
+                    }
+                    shares = true;
+                }
+            }
+            if !shares || (peer.agent == selected.agent && peer.scope == selected.scope) {
+                continue;
+            }
+            // A flat markdown file is invisible to directory-only consumers.
+            if canonical_item.layout == AgentSkillLayout::MarkdownFile
+                && peer.kind == SkillStorageKind::SkillDirectoryOnly
+            {
+                continue;
+            }
+            reject_multiple_active_skills(&peer.roots, peer.kind, &id)?;
+            for scan in &peer.roots {
+                preflight_skill_destination(&disabled_skill_root(scan), &id)?;
+            }
+            let destination_root = unique_skill_root(peer, peers)?;
+            preflight_skill_destination(&destination_root, &id)?;
+            destinations.push(destination_root.join(file_name));
+            affected.push(peer);
+        }
+    } else if enabled {
+        match unique_skill_root(selected, peers) {
+            Ok(destination_root) => {
+                preflight_skill_destination(&destination_root, &id)?;
+                destinations.push(destination_root.join(file_name));
+            }
+            Err(error) if error.to_string().contains("no unique writable root") => {
+                preflight_skill_destination(root, &id)?;
+                preflight_skill_symlink_move(&canonical, root)?;
+                for peer in peers {
+                    if peer.agent == selected.agent && peer.scope == selected.scope {
+                        continue;
+                    }
+                    let shares = peer
+                        .roots
+                        .iter()
+                        .map(|scan| resolved_skill_root(scan))
+                        .collect::<Result<Vec<_>, _>>()?
+                        .iter()
+                        .any(|scan| skill_roots_overlap(scan, &resolved_root));
+                    if !shares
+                        || (canonical_item.layout == AgentSkillLayout::MarkdownFile
+                            && peer.kind == SkillStorageKind::SkillDirectoryOnly)
+                    {
+                        continue;
+                    }
+                    reject_multiple_active_skills(&peer.roots, peer.kind, &id)?;
+                    let active =
+                        locate_existing_skill_across_dirs(&peer.roots, peer.kind, &id, peer.scope)
+                            .filter(|item| item.enabled)
+                            .ok_or_else(|| {
+                                AcpError::protocol(
+                                    "shared skill restore would reenable a disabled peer",
+                                )
+                            })?;
+                    if !skill_link_targets(Path::new(&active.path), &canonical) {
+                        return Err(AcpError::protocol(
+                            "shared skill restore would conflict with an independent peer skill",
+                        ));
+                    }
+                    redundant_links.push(PathBuf::from(active.path));
+                    affected.push(peer);
+                }
+                restore_shared = true;
+            }
+            Err(error) => return Err(error),
+        }
+    } else if !skill_link_targets(Path::new(&original.path), &canonical) {
+        return Err(AcpError::protocol(
+            "active skill is not a managed canonical link",
+        ));
+    }
+
+    let mut moved = false;
+    let mut created: Vec<PathBuf> = Vec::new();
+    let mut removed = false;
+    let mut removed_redundant = Vec::new();
+    let restored_path = root.join(file_name);
+    let result = (|| {
+        if first_disable {
+            fs::create_dir_all(&vault)?;
+            fs::rename(&original.path, &canonical)?;
+            moved = true;
+        }
+        if restore_shared {
+            for link in &redundant_links {
+                remove_skill_link(link)?;
+                removed_redundant.push(link.clone());
+            }
+            fs::rename(&canonical, &restored_path)?;
+            moved = true;
+        }
+        for destination in &destinations {
+            fs::create_dir_all(destination.parent().expect("destination parent"))?;
+            let linked = create_link(&canonical, destination);
+            if linked.is_ok() || skill_link_targets(destination, &canonical) {
+                created.push(destination.clone());
+            }
+            linked?;
+        }
+        if !first_disable && !enabled {
+            remove_skill_link(Path::new(&original.path))?;
+            removed = true;
+        }
+        let item = list_skills_from_roots(selected.scope, &selected.roots, selected.kind)
+            .map_err(|e| std::io::Error::other(e.to_string()))?
+            .into_iter()
+            .find(|item| item.id == id && item.enabled == enabled)
+            .ok_or_else(|| std::io::Error::other("requested skill state was not reached"))?;
+        for peer in affected {
+            if !list_skills_from_roots(peer.scope, &peer.roots, peer.kind)
+                .map_err(|e| std::io::Error::other(e.to_string()))?
+                .iter()
+                .any(|item| item.id == id && item.enabled)
+            {
+                return Err(std::io::Error::other("peer skill state was not preserved"));
+            }
+        }
+        Ok(item)
+    })();
+    match result {
+        Ok(mut item) => {
+            apply_skill_capabilities(selected.agent, &mut item);
+            Ok(item)
+        }
+        Err(error) => {
+            let mut failures = Vec::new();
+            for destination in created.iter().rev() {
+                if !skill_link_targets(destination, &canonical) {
+                    failures.push(format!(
+                        "rollback refused for changed link '{}'",
+                        destination.display()
+                    ));
+                } else if let Err(e) = remove_skill_link(destination) {
+                    failures.push(e.to_string());
+                }
+            }
+            if moved {
+                let (from, to) = if restore_shared {
+                    (restored_path.as_path(), canonical.as_path())
+                } else {
+                    (canonical.as_path(), Path::new(&original.path))
+                };
+                if fs::symlink_metadata(to).is_ok() {
+                    failures.push("rollback source is occupied".to_string());
+                } else if let Err(e) = fs::rename(from, to) {
+                    failures.push(e.to_string());
+                }
+            }
+            for link in removed_redundant {
+                if let Err(e) = create_skill_link(&canonical, &link) {
+                    failures.push(e.to_string());
+                }
+            }
+            if removed {
+                if let Err(e) = create_skill_link(&canonical, Path::new(&original.path)) {
+                    failures.push(e.to_string());
+                }
+            }
+            Err(AcpError::protocol(format!(
+                "shared skill toggle failed: {error}; {}",
+                if failures.is_empty() {
+                    "rolled back".to_string()
+                } else {
+                    format!("rollback failed: {}", failures.join("; "))
+                }
+            )))
+        }
+    }
+}
+
 fn skill_root_is_shared(
     agent_type: AgentType,
     scope: AgentSkillScope,
@@ -13105,14 +13584,40 @@ pub async fn acp_set_agent_skill_enabled(
             "skill '{id}' is a built-in system skill and cannot be toggled"
         )));
     }
-    if skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), root)? {
-        // Task 2 owns peer fan-out and per-agent isolation for shared roots.
-        return Err(AcpError::protocol(format!(
-            "shared skill root '{}' requires shared-root toggle support",
-            root.display()
-        )));
-    }
     reject_multiple_active_skills(&dirs, spec.kind, &id)?;
+    for candidate in &dirs {
+        if !skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), candidate)? {
+            continue;
+        }
+        let canonical = locate_existing_skill(
+            &disabled_skill_root(candidate),
+            spec.kind,
+            &id,
+            scope,
+            false,
+        );
+        if candidate == root
+            || canonical.is_some_and(|item| {
+                skill_link_targets(Path::new(&skill.path), Path::new(&item.path))
+            })
+        {
+            let peers = skill_peers(workspace_path.as_deref());
+            let selected = SkillPeer {
+                agent: agent_type,
+                scope,
+                kind: spec.kind,
+                roots: dirs.clone(),
+            };
+            return set_shared_skill_enabled(
+                &selected,
+                &peers,
+                candidate,
+                &id,
+                enabled,
+                create_skill_link,
+            );
+        }
+    }
     if skill.enabled != enabled {
         preflight_disabled_skill_root(root, workspace_path.as_deref())?;
     }
@@ -13242,6 +13747,23 @@ pub async fn acp_delete_agent_skill(
         )));
     }
     let skill_path = PathBuf::from(&skill.path);
+    for root in &dirs {
+        if !skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), root)? {
+            continue;
+        }
+        if let Some(canonical) =
+            locate_existing_skill(&disabled_skill_root(root), spec.kind, &id, scope, false)
+        {
+            let canonical_path = Path::new(&canonical.path);
+            if skill_path == canonical_path || skill_link_targets(&skill_path, canonical_path) {
+                let peers = skill_peers(workspace_path.as_deref());
+                preflight_disabled_skill_root(root, workspace_path.as_deref())?;
+                return delete_shared_skill(canonical_path, &peers, &id, |from, to| {
+                    fs::rename(from, to)
+                });
+            }
+        }
+    }
     remove_skill_entry(&skill_path)
         .map_err(|e| AcpError::protocol(format!("failed to delete skill entry: {e}")))?;
     Ok(())
@@ -16365,15 +16887,395 @@ wire_api = "chat"
         );
     }
 
+    fn shared_skill_fixture(base: &Path) -> (PathBuf, Vec<SkillPeer>) {
+        let shared = base.join("shared/skills");
+        fs::create_dir_all(shared.join("demo")).unwrap();
+        fs::write(shared.join("demo/SKILL.md"), "shared").unwrap();
+        let peers = [(AgentType::Codex, "a"), (AgentType::Pi, "b")]
+            .into_iter()
+            .map(|(agent, name)| SkillPeer {
+                agent,
+                scope: AgentSkillScope::Project,
+                kind: SkillStorageKind::SkillDirectoryOrMarkdownFile,
+                roots: vec![base.join(name).join("skills"), shared.clone()],
+            })
+            .collect();
+        (shared, peers)
+    }
+
     #[test]
-    fn skill_enabled_private_command_leaves_shared_roots_for_task_two() {
-        let tmp = tempfile::tempdir().expect("tempdir");
+    fn shared_skill_fanout_isolates_and_reenables_selected_peer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        for enabled in [false, true, false] {
+            let item = set_shared_skill_enabled(
+                &peers[1],
+                &peers,
+                &shared,
+                "demo",
+                enabled,
+                create_skill_link,
+            )
+            .unwrap();
+            assert_eq!(item.enabled, enabled);
+            assert!(peers[0].roots[0].join("demo/SKILL.md").is_file());
+            assert_eq!(peers[1].roots[0].join("demo").exists(), enabled);
+            assert!(disabled_skill_root(&shared).join("demo/SKILL.md").is_file());
+            assert!(!shared.join("demo").exists());
+            for (peer, expected) in [(&peers[0], true), (&peers[1], enabled)] {
+                let items = list_skills_from_roots(peer.scope, &peer.roots, peer.kind).unwrap();
+                assert_eq!(items[0].enabled, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn shared_skill_peer_without_unique_root_refuses_before_move() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        peers[0].roots = vec![shared.clone()];
+        let error =
+            set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", false, create_skill_link)
+                .unwrap_err();
+        assert!(error.to_string().contains("unique writable root"));
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[test]
+    fn shared_skill_selected_without_unique_root_can_restore_when_peers_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        peers[1].roots = vec![shared.clone()];
+        set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", false, create_skill_link)
+            .unwrap();
+        assert!(peers[0].roots[0].join("demo/SKILL.md").is_file());
+        let item =
+            set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", true, create_skill_link)
+                .unwrap();
+        assert!(item.enabled);
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).join("demo").exists());
+        assert!(fs::symlink_metadata(peers[0].roots[0].join("demo")).is_err());
+    }
+
+    #[test]
+    fn shared_skill_restore_refuses_to_reenable_a_disabled_peer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        peers[1].roots = vec![shared.clone()];
+        for peer in [&peers[1], &peers[0]] {
+            set_shared_skill_enabled(peer, &peers, &shared, "demo", false, create_skill_link)
+                .unwrap();
+        }
+        let error =
+            set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", true, create_skill_link)
+                .unwrap_err();
+        assert!(error.to_string().contains("disabled peer"));
+        assert!(!shared.join("demo").exists());
+        assert!(disabled_skill_root(&shared).join("demo/SKILL.md").is_file());
+        assert!(fs::symlink_metadata(peers[0].roots[0].join("demo")).is_err());
+    }
+
+    #[test]
+    fn shared_skill_command_claude_cline_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join(".claude/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "body").unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        for enabled in [false, true] {
+            let item = runtime
+                .block_on(acp_set_agent_skill_enabled(
+                    AgentType::ClaudeCode,
+                    AgentSkillScope::Project,
+                    "demo".into(),
+                    Some(tmp.path().to_string_lossy().into_owned()),
+                    enabled,
+                ))
+                .unwrap();
+            assert_eq!(item.enabled, enabled);
+            let cline = scoped_skill_dirs(
+                AgentType::Cline,
+                AgentSkillScope::Project,
+                tmp.path().to_str(),
+            )
+            .unwrap();
+            assert!(
+                list_skills_from_roots(
+                    AgentSkillScope::Project,
+                    &cline,
+                    SkillStorageKind::SkillDirectoryOnly
+                )
+                .unwrap()[0]
+                    .enabled
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_skill_unsearchable_root_is_rejected_before_move() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        fs::create_dir_all(&peers[0].roots[0]).unwrap();
+        fs::set_permissions(&peers[0].roots[0], fs::Permissions::from_mode(0o600)).unwrap();
+        let result =
+            set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", false, create_skill_link);
+        fs::set_permissions(&peers[0].roots[0], fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("unique writable root"));
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[test]
+    fn shared_skill_destination_collision_refuses_before_move() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        fs::create_dir_all(&peers[0].roots[0]).unwrap();
+        fs::write(peers[0].roots[0].join("demo"), "occupied").unwrap();
+        let error =
+            set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", false, create_skill_link)
+                .unwrap_err();
+        assert!(error.to_string().contains("collision"));
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[test]
+    fn shared_skill_disabled_copy_collision_refuses_before_move() {
+        for conflicting_peer in [0, 1] {
+            let tmp = tempfile::tempdir().unwrap();
+            let (shared, peers) = shared_skill_fixture(tmp.path());
+            let other_vault = disabled_skill_root(&peers[conflicting_peer].roots[0]);
+            fs::create_dir_all(other_vault.join("demo")).unwrap();
+            fs::write(
+                other_vault.join("demo/SKILL.md"),
+                "different disabled skill",
+            )
+            .unwrap();
+            let error = set_shared_skill_enabled(
+                &peers[1],
+                &peers,
+                &shared,
+                "demo",
+                false,
+                create_skill_link,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("collision"));
+            assert!(shared.join("demo/SKILL.md").is_file());
+            assert!(!disabled_skill_root(&shared).exists());
+        }
+    }
+
+    #[test]
+    fn shared_skill_partial_link_failure_rolls_back_link_and_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        let error = set_shared_skill_enabled(
+            &peers[1],
+            &peers,
+            &shared,
+            "demo",
+            false,
+            |source, target| {
+                create_skill_link(source, target)?;
+                Err(std::io::Error::other("failure after creating link"))
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("failure after creating link"));
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(fs::symlink_metadata(peers[0].roots[0].join("demo")).is_err());
+    }
+
+    #[test]
+    fn shared_skill_link_failure_rolls_back_source_and_created_links() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        peers.push(SkillPeer {
+            agent: AgentType::OpenCode,
+            roots: vec![tmp.path().join("c/skills"), shared.clone()],
+            ..peers[0].clone()
+        });
+        let mut calls = 0;
+        let error = set_shared_skill_enabled(
+            &peers[1],
+            &peers,
+            &shared,
+            "demo",
+            false,
+            |source, target| {
+                calls += 1;
+                if calls == 2 {
+                    return Err(std::io::Error::other("injected link failure"));
+                }
+                create_skill_link(source, target)
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("injected link failure"));
+        assert_eq!(calls, 2);
+        assert!(shared.join("demo/SKILL.md").is_file());
+        assert!(!disabled_skill_root(&shared).join("demo").exists());
+        for peer in peers {
+            assert!(fs::symlink_metadata(peer.roots[0].join("demo")).is_err());
+        }
+    }
+
+    #[test]
+    fn shared_skill_markdown_file_keeps_canonical_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        fs::write(shared.join("flat.md"), "flat content").unwrap();
+        for enabled in [false, true] {
+            set_shared_skill_enabled(
+                &peers[1],
+                &peers,
+                &shared,
+                "flat",
+                enabled,
+                create_skill_link,
+            )
+            .unwrap();
+            assert_eq!(
+                fs::read_to_string(peers[0].roots[0].join("flat.md")).unwrap(),
+                "flat content"
+            );
+            assert_eq!(peers[1].roots[0].join("flat.md").exists(), enabled);
+        }
+    }
+
+    #[test]
+    fn shared_skill_delete_canonical_removes_peer_links() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", false, create_skill_link)
+            .unwrap();
+        let canonical = disabled_skill_root(&shared).join("demo");
+        delete_shared_skill(&canonical, &peers, "demo", |from, to| fs::rename(from, to)).unwrap();
+        assert!(!canonical.exists());
+        assert!(fs::symlink_metadata(peers[0].roots[0].join("demo")).is_err());
+        for peer in &peers {
+            assert!(list_skills_from_roots(peer.scope, &peer.roots, peer.kind)
+                .unwrap()
+                .is_empty());
+        }
+    }
+
+    #[test]
+    fn shared_skill_delete_rename_failure_rolls_back_canonical_and_links() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        peers.push(SkillPeer {
+            agent: AgentType::OpenCode,
+            roots: vec![tmp.path().join("c/skills"), shared.clone()],
+            ..peers[0].clone()
+        });
+        set_shared_skill_enabled(&peers[1], &peers, &shared, "demo", false, create_skill_link)
+            .unwrap();
+        let canonical = disabled_skill_root(&shared).join("demo");
+        let mut calls = 0;
+        let result = delete_shared_skill(&canonical, &peers, "demo", |from, to| {
+            calls += 1;
+            if calls == 3 {
+                return Err(std::io::Error::other("injected delete failure"));
+            }
+            fs::rename(from, to)
+        });
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("injected delete failure"));
+        assert_eq!(calls, 3);
+        assert!(canonical.join("SKILL.md").is_file());
+        for peer in [&peers[0], &peers[2]] {
+            assert!(peer.roots[0].join("demo/SKILL.md").is_file());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_skill_delete_keeps_independent_links_to_external_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        let external = tmp.path().join("external");
+        fs::create_dir_all(&external).unwrap();
+        fs::write(external.join("SKILL.md"), "external").unwrap();
+        std::os::unix::fs::symlink(&external, shared.join("linked")).unwrap();
+        set_shared_skill_enabled(
+            &peers[1],
+            &peers,
+            &shared,
+            "linked",
+            false,
+            create_skill_link,
+        )
+        .unwrap();
+        let independent = tmp.path().join("independent/skills");
+        fs::create_dir_all(&independent).unwrap();
+        std::os::unix::fs::symlink(&external, independent.join("linked")).unwrap();
+        peers.push(SkillPeer {
+            agent: AgentType::OpenCode,
+            roots: vec![independent.clone()],
+            ..peers[0].clone()
+        });
+        delete_shared_skill(
+            &disabled_skill_root(&shared).join("linked"),
+            &peers,
+            "linked",
+            |from, to| fs::rename(from, to),
+        )
+        .unwrap();
+        assert!(independent.join("linked/SKILL.md").is_file());
+        assert!(external.join("SKILL.md").is_file());
+        assert!(fs::symlink_metadata(peers[0].roots[0].join("linked")).is_err());
+    }
+
+    #[test]
+    fn shared_skill_command_delete_canonical_removes_cline_link() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join(".claude/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "body").unwrap();
+        let workspace = Some(tmp.path().to_string_lossy().into_owned());
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::ClaudeCode,
+                AgentSkillScope::Project,
+                "demo".into(),
+                workspace.clone(),
+                false,
+            ))
+            .unwrap();
+        let link = tmp.path().join(".cline/skills/demo");
+        assert!(link.join("SKILL.md").is_file());
+        runtime
+            .block_on(acp_delete_agent_skill(
+                AgentType::ClaudeCode,
+                AgentSkillScope::Project,
+                "demo".into(),
+                workspace,
+            ))
+            .unwrap();
+        assert!(fs::symlink_metadata(link).is_err());
+        assert!(!disabled_skill_root(&root).join("demo").exists());
+    }
+
+    #[test]
+    fn skill_enabled_private_command_unisolatable_shared_roots_are_rejected() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         for (agent, relative) in [
             (AgentType::Codex, ".agents/skills"),
-            (AgentType::ClaudeCode, ".claude/skills"),
             (AgentType::Gemini, ".gemini/skills"),
         ] {
+            let tmp = tempfile::tempdir().expect("tempdir");
             let root = tmp.path().join(relative);
             fs::create_dir_all(root.join("demo")).unwrap();
             fs::write(root.join("demo/SKILL.md"), "shared").unwrap();

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8397,6 +8397,24 @@ fn skill_content_path(layout: AgentSkillLayout, skill_path: &Path) -> PathBuf {
     }
 }
 
+fn skill_entry_layout(path: &Path, kind: SkillStorageKind) -> Option<AgentSkillLayout> {
+    if matches!(
+        kind,
+        SkillStorageKind::SkillDirectoryOnly | SkillStorageKind::SkillDirectoryOrMarkdownFile
+    ) && path.is_dir()
+        && path.join("SKILL.md").is_file()
+    {
+        return Some(AgentSkillLayout::SkillDirectory);
+    }
+    if kind == SkillStorageKind::SkillDirectoryOrMarkdownFile
+        && path.is_file()
+        && is_markdown_file(path)
+    {
+        return Some(AgentSkillLayout::MarkdownFile);
+    }
+    None
+}
+
 /// Symlink-safe removal: if `path` is a symlink (to a file or directory),
 /// only the link itself is removed. Otherwise directories are removed
 /// recursively and files are unlinked. This prevents `remove_dir_all` from
@@ -8478,46 +8496,40 @@ fn list_skills_from_dir_with_state(
         let file_name = entry.file_name();
         let id = file_name.to_string_lossy().to_string();
 
-        if path.is_dir()
-            && matches!(
-                kind,
-                SkillStorageKind::SkillDirectoryOnly
-                    | SkillStorageKind::SkillDirectoryOrMarkdownFile
-            )
-        {
-            let skill_doc = path.join("SKILL.md");
-            if !skill_doc.is_file() {
-                continue;
+        match skill_entry_layout(&path, kind) {
+            Some(AgentSkillLayout::SkillDirectory) => {
+                by_id.insert(
+                    id.clone(),
+                    build_skill_item(
+                        id,
+                        scope,
+                        AgentSkillLayout::SkillDirectory,
+                        path,
+                        enabled,
+                    ),
+                );
             }
-            by_id.insert(
-                id.clone(),
-                build_skill_item(
-                    id,
-                    scope,
-                    AgentSkillLayout::SkillDirectory,
-                    path,
-                    enabled,
-                ),
-            );
-            continue;
-        }
-
-        if path.is_file()
-            && matches!(kind, SkillStorageKind::SkillDirectoryOrMarkdownFile)
-            && is_markdown_file(&path)
-        {
-            let stem = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .map(str::to_string)
-                .unwrap_or_else(|| id.clone());
-            if by_id.contains_key(&stem) {
-                continue;
+            Some(AgentSkillLayout::MarkdownFile) => {
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| id.clone());
+                if by_id.contains_key(&stem) {
+                    continue;
+                }
+                by_id.insert(
+                    stem.clone(),
+                    build_skill_item(
+                        stem,
+                        scope,
+                        AgentSkillLayout::MarkdownFile,
+                        path,
+                        enabled,
+                    ),
+                );
             }
-            by_id.insert(
-                stem.clone(),
-                build_skill_item(stem, scope, AgentSkillLayout::MarkdownFile, path, enabled),
-            );
+            None => {}
         }
     }
 
@@ -8525,10 +8537,17 @@ fn list_skills_from_dir_with_state(
 }
 
 pub(crate) fn disabled_skill_root(active_root: &Path) -> PathBuf {
+    let cursor_builtin_root = home_dir_or_default().join(".cursor").join("skills-cursor");
+    let vault_name = if active_root == cursor_builtin_root {
+        ".skills-cursor.codeg-disabled"
+    } else {
+        // Keep the original location for existing disabled entries.
+        ".skills.codeg-disabled"
+    };
     active_root
         .parent()
         .unwrap_or_else(|| Path::new(""))
-        .join(".skills.codeg-disabled")
+        .join(vault_name)
 }
 
 pub(crate) fn list_skills_from_roots(
@@ -9042,6 +9061,74 @@ fn shared_skill_affected_peers<'a>(
     Ok(affected)
 }
 
+fn preflight_unplanned_incoming_skill_links(
+    selected: &SkillPeer,
+    peers: &[SkillPeer],
+    root: &Path,
+    skill_id: &str,
+    layout: AgentSkillLayout,
+    canonical: &Path,
+) -> Result<(), AcpError> {
+    let resolved_root = resolved_skill_root(root)?;
+    let expected_name = match layout {
+        AgentSkillLayout::SkillDirectory => skill_id.to_string(),
+        AgentSkillLayout::MarkdownFile => format!("{skill_id}.md"),
+    };
+    for peer in peers {
+        let is_selected = peer.agent == selected.agent && peer.scope == selected.scope;
+        let shares_canonical_root =
+            peer.roots.iter().try_fold(false, |shares, peer_root| {
+                Ok::<_, AcpError>(
+                    shares || resolved_root == resolved_skill_root(peer_root)?,
+                )
+            })?;
+        for peer_root in &peer.roots {
+            let vault = disabled_skill_root(peer_root);
+            for (scan, active) in [(peer_root.as_path(), true), (vault.as_path(), false)] {
+                let entries = match fs::read_dir(scan) {
+                    Ok(entries) => entries,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => {
+                        return Err(AcpError::protocol(format!(
+                            "failed to inspect peer skill root '{}': {error}",
+                            scan.display()
+                        )))
+                    }
+                };
+                for entry in entries {
+                    let entry = entry
+                        .map_err(|error| {
+                            AcpError::protocol(format!(
+                                "failed to inspect peer skill entry in '{}': {error}",
+                                scan.display()
+                            ))
+                        })?
+                        .path();
+                    if !skill_link_targets(&entry, canonical)
+                        || skill_entry_layout(&entry, peer.kind).is_none()
+                    {
+                        continue;
+                    }
+                    let planned_restore_link = !is_selected
+                        && shares_canonical_root
+                        && active
+                        && entry.file_name().and_then(|name| name.to_str())
+                            == Some(expected_name.as_str());
+                    if planned_restore_link {
+                        continue;
+                    }
+                    return Err(AcpError::protocol(format!(
+                        "skill '{skill_id}' has an incoming peer link '{}' from {}; moving its canonical entry is unsupported",
+                        entry.display(),
+                        peer.agent
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn shared_skill_restore_links(
     affected: &[&SkillPeer],
     id: &str,
@@ -9077,6 +9164,14 @@ fn plan_shared_skill_fanout<'a>(
     root: &Path,
     skill: &AgentSkillItem,
 ) -> Result<Vec<(&'a SkillPeer, PathBuf)>, AcpError> {
+    preflight_unplanned_incoming_skill_links(
+        selected,
+        peers,
+        root,
+        &skill.id,
+        skill.layout,
+        Path::new(&skill.path),
+    )?;
     let vault = disabled_skill_root(root);
     preflight_skill_destination(&vault, &skill.id)?;
     for scan in &selected.roots {
@@ -9124,6 +9219,15 @@ fn listed_skill_can_toggle(
         })
         .ok_or_else(|| AcpError::protocol("listed skill has no owning native root"))?;
     if !skill_root_is_shared_with_peers(selected.agent, selected.scope, root, peers)? {
+        preflight_unplanned_incoming_skill_links(
+            selected,
+            peers,
+            root,
+            &skill.id,
+            skill.layout,
+            Path::new(&skill.path),
+        )?;
+        preflight_disabled_skill_root_with_peers(root, peers)?;
         return Ok(true);
     }
     preflight_shared_skill_owner(root, peers)?;
@@ -9144,6 +9248,14 @@ fn listed_skill_can_toggle(
     }
     preflight_skill_destination(root, &skill.id)?;
     preflight_skill_symlink_move(Path::new(&skill.path), root)?;
+    preflight_unplanned_incoming_skill_links(
+        selected,
+        peers,
+        root,
+        &skill.id,
+        skill.layout,
+        Path::new(&skill.path),
+    )?;
     let affected = shared_skill_affected_peers(selected, peers, root, skill.layout)?;
     shared_skill_restore_links(&affected, &skill.id, Path::new(&skill.path))?;
     Ok(true)
@@ -9347,6 +9459,14 @@ fn set_shared_skill_enabled(
             None => {
                 preflight_skill_destination(root, &id)?;
                 preflight_skill_symlink_move(&canonical, root)?;
+                preflight_unplanned_incoming_skill_links(
+                    selected,
+                    peers,
+                    root,
+                    &id,
+                    canonical_item.layout,
+                    &canonical,
+                )?;
                 affected =
                     shared_skill_affected_peers(selected, peers, root, canonical_item.layout)?;
                 redundant_links = shared_skill_restore_links(&affected, &id, &canonical)?;
@@ -13694,8 +13814,15 @@ pub async fn acp_set_agent_skill_enabled(
         )));
     }
     reject_multiple_active_skills(&dirs, spec.kind, &id)?;
+    let peers = skill_peers(workspace_path.as_deref());
+    let selected = SkillPeer {
+        agent: agent_type,
+        scope,
+        kind: spec.kind,
+        roots: dirs.clone(),
+    };
     for candidate in &dirs {
-        if !skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), candidate)? {
+        if !skill_root_is_shared_with_peers(agent_type, scope, candidate, &peers)? {
             continue;
         }
         let canonical = locate_existing_skill(
@@ -13710,13 +13837,6 @@ pub async fn acp_set_agent_skill_enabled(
                 skill_link_targets(Path::new(&skill.path), Path::new(&item.path))
             })
         {
-            let peers = skill_peers(workspace_path.as_deref());
-            let selected = SkillPeer {
-                agent: agent_type,
-                scope,
-                kind: spec.kind,
-                roots: dirs.clone(),
-            };
             return set_shared_skill_enabled(
                 &selected,
                 &peers,
@@ -13728,6 +13848,14 @@ pub async fn acp_set_agent_skill_enabled(
         }
     }
     if skill.enabled != enabled {
+        preflight_unplanned_incoming_skill_links(
+            &selected,
+            &peers,
+            root,
+            &id,
+            skill.layout,
+            Path::new(&skill.path),
+        )?;
         preflight_disabled_skill_root(root, workspace_path.as_deref())?;
     }
     let moved = set_private_skill_enabled(root, spec.kind, scope, &id, enabled)?;
@@ -17019,6 +17147,360 @@ wire_api = "chat"
             })
             .collect();
         (shared, peers)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_skill_incoming_peer_link_is_rejected_before_canonical_move() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        let incoming_root = tmp.path().join("incoming/skills");
+        fs::create_dir_all(&incoming_root).unwrap();
+        std::os::unix::fs::symlink(shared.join("demo"), incoming_root.join("demo")).unwrap();
+        peers.push(SkillPeer {
+            agent: AgentType::OpenCode,
+            scope: AgentSkillScope::Project,
+            kind: SkillStorageKind::SkillDirectoryOnly,
+            roots: vec![incoming_root.clone()],
+        });
+        let listed = locate_existing_skill_across_dirs(
+            &peers[1].roots,
+            peers[1].kind,
+            "demo",
+            peers[1].scope,
+        )
+        .unwrap();
+
+        let can_toggle = listed_skill_can_toggle(&peers[1], &peers, &listed).unwrap_or(false);
+        let result = set_shared_skill_enabled(
+            &peers[1],
+            &peers,
+            &shared,
+            "demo",
+            false,
+            create_skill_link,
+        );
+
+        assert!(!can_toggle, "capability must match the move preflight");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("incoming peer link"),
+            "the canonical move must be refused"
+        );
+        assert_eq!(
+            fs::read_to_string(shared.join("demo/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert_eq!(
+            fs::read_to_string(incoming_root.join("demo/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert!(!disabled_skill_root(&shared).exists());
+        assert!(fs::symlink_metadata(peers[0].roots[0].join("demo")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_skill_alias_incoming_peer_link_is_rejected_before_canonical_move() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, mut peers) = shared_skill_fixture(tmp.path());
+        let incoming_root = tmp.path().join("incoming/skills");
+        fs::create_dir_all(&incoming_root).unwrap();
+        std::os::unix::fs::symlink(shared.join("demo"), incoming_root.join("alias")).unwrap();
+        peers.push(SkillPeer {
+            agent: AgentType::OpenCode,
+            scope: AgentSkillScope::Project,
+            kind: SkillStorageKind::SkillDirectoryOnly,
+            roots: vec![incoming_root.clone()],
+        });
+        let listed = locate_existing_skill_across_dirs(
+            &peers[1].roots,
+            peers[1].kind,
+            "demo",
+            peers[1].scope,
+        )
+        .unwrap();
+
+        let can_toggle = listed_skill_can_toggle(&peers[1], &peers, &listed).unwrap_or(false);
+        let result = set_shared_skill_enabled(
+            &peers[1],
+            &peers,
+            &shared,
+            "demo",
+            false,
+            create_skill_link,
+        );
+
+        assert!(!can_toggle, "aliases must be included in the move preflight");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("incoming peer link"));
+        assert_eq!(
+            fs::read_to_string(shared.join("demo/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert_eq!(
+            fs::read_to_string(incoming_root.join("alias/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_markdown_skill_alias_case_variant_incoming_link_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared = tmp.path().join("shared/skills");
+        let incoming_root = tmp.path().join("incoming/skills");
+        fs::create_dir_all(&shared).unwrap();
+        fs::create_dir_all(&incoming_root).unwrap();
+        fs::write(shared.join("demo.md"), "shared markdown").unwrap();
+        std::os::unix::fs::symlink(shared.join("demo.md"), incoming_root.join("alias.MD"))
+            .unwrap();
+        let peers = vec![
+            SkillPeer {
+                agent: AgentType::Codex,
+                scope: AgentSkillScope::Project,
+                kind: SkillStorageKind::SkillDirectoryOrMarkdownFile,
+                roots: vec![tmp.path().join("owner/skills"), shared.clone()],
+            },
+            SkillPeer {
+                agent: AgentType::OpenCode,
+                scope: AgentSkillScope::Project,
+                kind: SkillStorageKind::SkillDirectoryOrMarkdownFile,
+                roots: vec![incoming_root.clone()],
+            },
+        ];
+        let listed = locate_existing_skill_across_dirs(
+            &peers[0].roots,
+            peers[0].kind,
+            "demo",
+            peers[0].scope,
+        )
+        .unwrap();
+
+        let can_toggle = listed_skill_can_toggle(&peers[0], &peers, &listed).unwrap_or(false);
+        let result = set_shared_skill_enabled(
+            &peers[0],
+            &peers,
+            &shared,
+            "demo",
+            false,
+            create_skill_link,
+        );
+
+        assert!(!can_toggle, "case variants must be included in the preflight");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("incoming peer link"));
+        assert_eq!(fs::read_to_string(shared.join("demo.md")).unwrap(), "shared markdown");
+        assert_eq!(
+            fs::read_to_string(incoming_root.join("alias.MD")).unwrap(),
+            "shared markdown"
+        );
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_peer_secondary_root_incoming_alias_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (shared, peers) = shared_skill_fixture(tmp.path());
+        fs::create_dir_all(&peers[0].roots[0]).unwrap();
+        std::os::unix::fs::symlink(
+            shared.join("demo"),
+            peers[0].roots[0].join("alias"),
+        )
+        .unwrap();
+        let listed = locate_existing_skill_across_dirs(
+            &peers[1].roots,
+            peers[1].kind,
+            "demo",
+            peers[1].scope,
+        )
+        .unwrap();
+
+        let can_toggle = listed_skill_can_toggle(&peers[1], &peers, &listed).unwrap_or(false);
+        let result = set_shared_skill_enabled(
+            &peers[1],
+            &peers,
+            &shared,
+            "demo",
+            false,
+            create_skill_link,
+        );
+
+        assert!(
+            !can_toggle,
+            "only the peer's shared root may be skipped by the preflight"
+        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("incoming peer link"));
+        assert_eq!(
+            fs::read_to_string(shared.join("demo/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert_eq!(
+            fs::read_to_string(peers[0].roots[0].join("alias/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert!(!disabled_skill_root(&shared).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_skill_incoming_peer_link_is_rejected_before_canonical_move() {
+        use crate::acp::custom_registry::{hydrate, hydrate_test_guard};
+        let _registry_guard = hydrate_test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let canonical_root = tmp.path().join("owner/skills");
+        let incoming_root = tmp.path().join("peer/skills");
+        fs::create_dir_all(canonical_root.join("demo")).unwrap();
+        fs::write(canonical_root.join("demo/SKILL.md"), "private").unwrap();
+        fs::create_dir_all(&incoming_root).unwrap();
+        std::os::unix::fs::symlink(
+            canonical_root.join("demo"),
+            incoming_root.join("demo"),
+        )
+        .unwrap();
+        assert!(hydrate(&[
+            shared_skill_custom_def("task6-private-owner", &canonical_root),
+            shared_skill_custom_def("task6-private-peer", &incoming_root),
+        ])
+        .is_empty());
+        let owner = AgentType::custom("task6-private-owner").unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let listed = runtime
+            .block_on(acp_list_agent_skills(owner, None))
+            .unwrap()
+            .skills
+            .into_iter()
+            .find(|item| item.id == "demo")
+            .unwrap();
+        let result = runtime.block_on(acp_set_agent_skill_enabled(
+            owner,
+            AgentSkillScope::Global,
+            "demo".into(),
+            None,
+            false,
+        ));
+        hydrate(&[]);
+
+        assert!(!listed.can_toggle, "capability must match command execution");
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("incoming peer link"));
+        assert_eq!(
+            fs::read_to_string(canonical_root.join("demo/SKILL.md")).unwrap(),
+            "private"
+        );
+        assert_eq!(
+            fs::read_to_string(incoming_root.join("demo/SKILL.md")).unwrap(),
+            "private"
+        );
+        assert!(!disabled_skill_root(&canonical_root).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cursor_global_skill_round_trip_keeps_legacy_vault_compatible() {
+        let tmp = tempfile::tempdir().unwrap();
+        temp_env::with_vars(
+            [
+                ("HOME", Some(tmp.path())),
+                ("CODEX_HOME", None::<&Path>),
+                ("GEMINI_HOME", None),
+                ("HERMES_HOME", None),
+                ("KIMI_CODE_HOME", None),
+                ("PI_CODING_AGENT_DIR", None),
+                ("DSH_HOME", None),
+                ("DSH_AGENTS_HOME", None),
+                ("QODER_CONFIG_DIR", None),
+                ("QODER_CLI_HOME", None),
+            ],
+            || {
+                let home = home_dir_or_default();
+                let writable_root = home.join(".cursor/skills");
+                let builtin_root = home.join(".cursor/skills-cursor");
+                let legacy_vault = home.join(".cursor/.skills.codeg-disabled");
+                fs::create_dir_all(writable_root.join("demo")).unwrap();
+                fs::write(writable_root.join("demo/SKILL.md"), "cursor").unwrap();
+                let runtime = tokio::runtime::Runtime::new().unwrap();
+                let listed = runtime
+                    .block_on(acp_list_agent_skills(AgentType::Cursor, None))
+                    .unwrap()
+                    .skills
+                    .into_iter()
+                    .find(|item| item.id == "demo")
+                    .unwrap();
+                let disabled = runtime.block_on(acp_set_agent_skill_enabled(
+                    AgentType::Cursor,
+                    AgentSkillScope::Global,
+                    "demo".into(),
+                    None,
+                    false,
+                ));
+
+                assert!(listed.can_toggle);
+                assert_eq!(disabled_skill_root(&writable_root), legacy_vault);
+                assert_ne!(
+                    disabled_skill_root(&writable_root),
+                    disabled_skill_root(&builtin_root)
+                );
+                let disabled = disabled.expect("Cursor global skill must disable");
+                assert!(!disabled.enabled);
+                assert!(legacy_vault.join("demo/SKILL.md").is_file());
+                let enabled = runtime
+                    .block_on(acp_set_agent_skill_enabled(
+                        AgentType::Cursor,
+                        AgentSkillScope::Global,
+                        "demo".into(),
+                        None,
+                        true,
+                    ))
+                    .expect("Cursor global skill must re-enable");
+                assert!(enabled.enabled);
+                assert!(writable_root.join("demo/SKILL.md").is_file());
+                assert!(!legacy_vault.join("demo").exists());
+            },
+        );
+    }
+
+    #[test]
+    fn custom_skill_root_named_skills_cursor_keeps_legacy_disabled_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("custom/skills-cursor");
+        let legacy_vault = root.parent().unwrap().join(".skills.codeg-disabled");
+        fs::create_dir_all(legacy_vault.join("demo")).unwrap();
+        fs::write(legacy_vault.join("demo/SKILL.md"), "legacy").unwrap();
+
+        let listed = list_skills_from_roots(
+            AgentSkillScope::Global,
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOnly,
+        )
+        .unwrap();
+
+        assert_eq!(disabled_skill_root(&root), legacy_vault);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, "demo");
+        assert!(!listed[0].enabled);
+    }
+
+    #[test]
+    fn cursor_builtin_skill_root_uses_distinct_vault() {
+        let root = home_dir_or_default().join(".cursor/skills-cursor");
+        assert_eq!(
+            disabled_skill_root(&root),
+            home_dir_or_default().join(".cursor/.skills-cursor.codeg-disabled")
+        );
     }
 
     fn skill_capability_project_fixture(base: &Path) -> PathBuf {

--- a/src-tauri/src/commands/acp.rs
+++ b/src-tauri/src/commands/acp.rs
@@ -8619,54 +8619,195 @@ pub(crate) fn locate_existing_skill_across_dirs(
 // observe one state. No guard is held across an await.
 static SKILL_MUTATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-fn preflight_skill_symlink_move(source: &Path, destination_root: &Path) -> Result<(), AcpError> {
-    let metadata = fs::symlink_metadata(source)
-        .map_err(|e| AcpError::protocol(format!("failed to inspect skill entry: {e}")))?;
-    if !metadata.file_type().is_symlink() {
-        return Ok(());
-    }
-    let target = fs::read_link(source)
-        .map_err(|e| AcpError::protocol(format!("failed to read skill symlink: {e}")))?;
-    if target.is_absolute() {
-        return Ok(());
-    }
-    let original_target = fs::canonicalize(source)
-        .map_err(|e| AcpError::protocol(format!("failed to resolve skill symlink: {e}")))?;
-    let moved_target = if destination_root.exists() {
-        fs::canonicalize(destination_root.join(&target))
+fn resolved_skill_root(root: &Path) -> Result<PathBuf, AcpError> {
+    let absolute = if root.is_absolute() {
+        root.to_path_buf()
     } else {
-        let parent = destination_root
-            .parent()
-            .ok_or_else(|| AcpError::protocol("skill destination has no parent"))?;
-        let name = destination_root
-            .file_name()
-            .ok_or_else(|| AcpError::protocol("skill destination has no directory name"))?;
-        let mut future_root = fs::canonicalize(parent)
-            .map_err(|e| AcpError::protocol(format!("failed to resolve skill destination: {e}")))?
-            .join(name);
-        // The future root is a new directory, so leading parent components
-        // can be evaluated without creating it. Keep subsequent components
-        // intact so canonicalize still follows any symlinks in the target.
-        let mut remaining = target.components();
-        loop {
-            match remaining.clone().next() {
-                Some(std::path::Component::CurDir) => {
-                    remaining.next();
+        std::env::current_dir()
+            .map_err(|e| AcpError::protocol(format!("failed to resolve current directory: {e}")))?
+            .join(root)
+    };
+    let mut ancestor = absolute.as_path();
+    let mut suffix = Vec::new();
+    loop {
+        match fs::canonicalize(ancestor) {
+            Ok(mut resolved) => {
+                for component in suffix.into_iter().rev() {
+                    resolved.push(component);
                 }
-                Some(std::path::Component::ParentDir) => {
-                    future_root.pop();
-                    remaining.next();
-                }
-                _ => break,
+                return Ok(resolved);
+            }
+            Err(error)
+                if error.kind() == std::io::ErrorKind::NotFound
+                    && fs::symlink_metadata(ancestor).is_err() =>
+            {
+                let Some(name) = ancestor.file_name() else {
+                    return Err(AcpError::protocol(format!(
+                        "failed to resolve skill root '{}': {error}",
+                        root.display()
+                    )));
+                };
+                suffix.push(name.to_os_string());
+                ancestor = ancestor
+                    .parent()
+                    .ok_or_else(|| AcpError::protocol("skill root has no parent"))?;
+            }
+            Err(error) => {
+                return Err(AcpError::protocol(format!(
+                    "failed to resolve skill root '{}': {error}",
+                    root.display()
+                )))
             }
         }
-        fs::canonicalize(future_root.join(remaining.as_path()))
-    };
-    if moved_target.ok().as_ref() != Some(&original_target) {
-        return Err(AcpError::protocol(format!(
-            "relative symlink '{}' would resolve to a different or missing target after moving",
-            source.display()
-        )));
+    }
+}
+
+/// Resolve a path against the filesystem as it would look after one rename.
+/// Destination entries are inspected at their source paths, while symlink
+/// targets are interpreted from their future parents. The old entry is absent.
+fn resolve_skill_path_after_move(
+    path: &Path,
+    source: &Path,
+    destination: &Path,
+    directory: bool,
+    followed_links: usize,
+) -> std::io::Result<PathBuf> {
+    if followed_links > 40 {
+        return Err(std::io::Error::other("too many skill symlinks"));
+    }
+    let mut resolved = PathBuf::new();
+    let mut components = path.components();
+    while let Some(component) = components.next() {
+        match component {
+            std::path::Component::CurDir => continue,
+            std::path::Component::ParentDir => {
+                resolved.pop();
+                continue;
+            }
+            _ => resolved.push(component.as_os_str()),
+        }
+        if matches!(
+            component,
+            std::path::Component::Prefix(_) | std::path::Component::RootDir
+        ) {
+            continue;
+        }
+        // The sibling root may be created by the move, but no other missing
+        // path is treated as present during preflight.
+        if Some(resolved.as_path()) == destination.parent() {
+            continue;
+        }
+        let physical = if resolved == destination {
+            source.to_path_buf()
+        } else if directory && resolved.starts_with(destination) {
+            source.join(
+                resolved
+                    .strip_prefix(destination)
+                    .expect("checked destination prefix"),
+            )
+        } else if resolved == source || (directory && resolved.starts_with(source)) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "target remains in old skill location",
+            ));
+        } else {
+            resolved.clone()
+        };
+        let metadata = fs::symlink_metadata(&physical)?;
+        if metadata.file_type().is_symlink() {
+            let target = fs::read_link(physical)?;
+            let next = if target.is_absolute() {
+                target
+            } else {
+                resolved
+                    .parent()
+                    .unwrap_or_else(|| Path::new(""))
+                    .join(target)
+            };
+            return resolve_skill_path_after_move(
+                &next.join(components.as_path()),
+                source,
+                destination,
+                directory,
+                followed_links + 1,
+            );
+        }
+        if components.clone().next().is_some() && !metadata.is_dir() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotADirectory,
+                "skill target component is not a directory",
+            ));
+        }
+    }
+    Ok(resolved)
+}
+
+fn preflight_skill_symlink_move(source: &Path, destination_root: &Path) -> Result<(), AcpError> {
+    let source = resolved_skill_root(
+        source
+            .parent()
+            .ok_or_else(|| AcpError::protocol("skill entry has no parent"))?,
+    )?
+    .join(
+        source
+            .file_name()
+            .ok_or_else(|| AcpError::protocol("skill entry has no filename"))?,
+    );
+    let destination =
+        resolved_skill_root(destination_root)?.join(source.file_name().expect("checked filename"));
+    let directory = fs::symlink_metadata(&source)
+        .map_err(|e| AcpError::protocol(format!("failed to inspect skill entry: {e}")))?
+        .is_dir();
+    let mut pending = vec![source.clone()];
+    while let Some(entry) = pending.pop() {
+        let metadata = fs::symlink_metadata(&entry)
+            .map_err(|e| AcpError::protocol(format!("failed to inspect skill entry: {e}")))?;
+        if metadata.file_type().is_symlink() {
+            let target = fs::read_link(&entry)
+                .map_err(|e| AcpError::protocol(format!("failed to read skill symlink: {e}")))?;
+            let original_target = fs::canonicalize(&entry).map_err(|e| {
+                AcpError::protocol(format!(
+                    "failed to resolve skill symlink '{}': {e}",
+                    entry.display()
+                ))
+            })?;
+            let expected_target = if directory && original_target.starts_with(&source) {
+                destination.join(
+                    original_target
+                        .strip_prefix(&source)
+                        .expect("checked source prefix"),
+                )
+            } else {
+                original_target
+            };
+            let future_entry =
+                destination.join(entry.strip_prefix(&source).expect("entry is in bundle"));
+            let moved_target =
+                resolve_skill_path_after_move(&future_entry, &source, &destination, directory, 0);
+            if moved_target.ok().as_ref() != Some(&expected_target) {
+                return Err(AcpError::protocol(format!(
+                    "{}symlink '{}' would resolve to a different or missing target after moving",
+                    if target.is_relative() {
+                        "relative "
+                    } else {
+                        ""
+                    },
+                    entry.display()
+                )));
+            }
+        } else if metadata.is_dir() {
+            for child in fs::read_dir(&entry)
+                .map_err(|e| AcpError::protocol(format!("failed to inspect skill bundle: {e}")))?
+            {
+                pending.push(
+                    child
+                        .map_err(|e| {
+                            AcpError::protocol(format!("failed to inspect skill bundle entry: {e}"))
+                        })?
+                        .path(),
+                );
+            }
+        }
     }
     Ok(())
 }
@@ -8732,25 +8873,66 @@ fn set_private_skill_enabled(
     ))
 }
 
+fn native_skill_roots(workspace_path: Option<&str>) -> Vec<(AgentType, AgentSkillScope, PathBuf)> {
+    let mut roots = Vec::new();
+    for agent in registry::all_acp_agents() {
+        for scope in [AgentSkillScope::Global, AgentSkillScope::Project] {
+            if scope == AgentSkillScope::Project
+                && workspace_path
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                    .is_none()
+            {
+                continue;
+            }
+            roots.extend(
+                scoped_skill_dirs(agent, scope, workspace_path)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|root| (agent, scope, root)),
+            );
+        }
+    }
+    roots
+}
+
+fn skill_roots_overlap(first: &Path, second: &Path) -> bool {
+    first.starts_with(second) || second.starts_with(first)
+}
+
 fn skill_root_is_shared(
     agent_type: AgentType,
     scope: AgentSkillScope,
     workspace_path: Option<&str>,
     root: &Path,
-) -> bool {
-    let resolved_root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    registry::all_acp_agents().into_iter().any(|peer| {
-        peer != agent_type
-            && scoped_skill_dirs(peer, scope, workspace_path)
-                .unwrap_or_default()
-                .iter()
-                .any(|peer_root| {
-                    *peer_root == root
-                        || fs::canonicalize(peer_root)
-                            .map(|path| path == resolved_root)
-                            .unwrap_or(false)
-                })
-    })
+) -> Result<bool, AcpError> {
+    let resolved_root = resolved_skill_root(root)?;
+    for (peer, peer_scope, peer_root) in native_skill_roots(workspace_path) {
+        if (peer != agent_type || peer_scope != scope)
+            && skill_roots_overlap(&resolved_root, &resolved_skill_root(&peer_root)?)
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn preflight_disabled_skill_root(
+    root: &Path,
+    workspace_path: Option<&str>,
+) -> Result<(), AcpError> {
+    let vault = disabled_skill_root(root);
+    let resolved_vault = resolved_skill_root(&vault)?;
+    for (_, _, native_root) in native_skill_roots(workspace_path) {
+        if skill_roots_overlap(&resolved_vault, &resolved_skill_root(&native_root)?) {
+            return Err(AcpError::protocol(format!(
+                "disabled skill vault '{}' overlaps native scan root '{}'",
+                vault.display(),
+                native_root.display()
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn reject_multiple_active_skills(
@@ -8794,6 +8976,42 @@ fn reject_multiple_active_skills(
         }
     }
     Ok(())
+}
+
+fn finish_private_skill_toggle(
+    agent_type: AgentType,
+    dirs: &[PathBuf],
+    kind: SkillStorageKind,
+    original: &AgentSkillItem,
+    moved: AgentSkillItem,
+    enabled: bool,
+) -> Result<AgentSkillItem, AcpError> {
+    let authoritative = list_skills_from_roots(original.scope, dirs, kind)
+        .map(|items| items.into_iter().find(|item| item.id == original.id));
+    if let Ok(Some(mut item)) = authoritative {
+        if item.enabled == enabled {
+            apply_skill_capabilities(agent_type, &mut item);
+            return Ok(item);
+        }
+    }
+    if moved.path != original.path {
+        match fs::symlink_metadata(&original.path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            _ => return Err(AcpError::protocol(format!(
+                "requested skill state was not reached; rollback refused because original path '{}' is occupied or inaccessible; moved entry remains at '{}'",
+                original.path, moved.path
+            ))),
+        }
+        fs::rename(&moved.path, &original.path).map_err(|error| {
+            AcpError::protocol(format!(
+                "requested skill state was not reached; rollback from '{}' to '{}' failed: {error}",
+                moved.path, original.path
+            ))
+        })?;
+    }
+    Err(AcpError::protocol(
+        "requested skill state was not reached; skill move rolled back",
+    ))
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -12877,7 +13095,7 @@ pub async fn acp_set_agent_skill_enabled(
             "skill '{id}' is a built-in system skill and cannot be toggled"
         )));
     }
-    if skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), root) {
+    if skill_root_is_shared(agent_type, scope, workspace_path.as_deref(), root)? {
         // Task 2 owns peer fan-out and per-agent isolation for shared roots.
         return Err(AcpError::protocol(format!(
             "shared skill root '{}' requires shared-root toggle support",
@@ -12885,11 +13103,11 @@ pub async fn acp_set_agent_skill_enabled(
         )));
     }
     reject_multiple_active_skills(&dirs, spec.kind, &id)?;
-    set_private_skill_enabled(root, spec.kind, scope, &id, enabled)?;
-    let mut authoritative = locate_existing_skill_across_dirs(&dirs, spec.kind, &id, scope)
-        .ok_or_else(|| AcpError::protocol(format!("skill not found after toggle: {id}")))?;
-    apply_skill_capabilities(agent_type, &mut authoritative);
-    Ok(authoritative)
+    if skill.enabled != enabled {
+        preflight_disabled_skill_root(root, workspace_path.as_deref())?;
+    }
+    let moved = set_private_skill_enabled(root, spec.kind, scope, &id, enabled)?;
+    finish_private_skill_toggle(agent_type, &dirs, spec.kind, &skill, moved, enabled)
 }
 
 #[cfg_attr(feature = "tauri-runtime", tauri::command)]
@@ -16309,6 +16527,276 @@ wire_api = "chat"
             .unwrap();
         assert!(enabled.enabled);
         assert_eq!(fs::read_to_string(enabled.path).unwrap(), "updated");
+    }
+
+    #[test]
+    fn skill_enabled_private_safety_postcondition_mismatch_rolls_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("private/skills");
+        let other = tmp.path().join("other/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "original").unwrap();
+        let original = locate_existing_skill(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            "demo",
+            AgentSkillScope::Project,
+            true,
+        )
+        .unwrap();
+        let moved = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Project,
+            "demo",
+            false,
+        )
+        .unwrap();
+        fs::create_dir_all(other.join("demo")).unwrap();
+        fs::write(other.join("demo/SKILL.md"), "concurrent copy").unwrap();
+        let result = finish_private_skill_toggle(
+            AgentType::Codex,
+            &[root.clone(), other.clone()],
+            SkillStorageKind::SkillDirectoryOnly,
+            &original,
+            moved,
+            false,
+        );
+        assert!(
+            result.is_err(),
+            "requested state must be a postcondition: {result:?}"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+            "original"
+        );
+        assert_eq!(
+            fs::read_to_string(other.join("demo/SKILL.md")).unwrap(),
+            "concurrent copy"
+        );
+        assert!(!disabled_skill_root(&root).join("demo").exists());
+    }
+
+    #[test]
+    fn skill_enabled_private_safety_missing_post_move_entry_rolls_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "original").unwrap();
+        let original = locate_existing_skill(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            "demo",
+            AgentSkillScope::Project,
+            true,
+        )
+        .unwrap();
+        let moved = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Project,
+            "demo",
+            false,
+        )
+        .unwrap();
+        fs::rename(
+            Path::new(&moved.path).join("SKILL.md"),
+            Path::new(&moved.path).join("body.saved"),
+        )
+        .unwrap();
+        let result = finish_private_skill_toggle(
+            AgentType::Codex,
+            std::slice::from_ref(&root),
+            SkillStorageKind::SkillDirectoryOnly,
+            &original,
+            moved,
+            false,
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            fs::read_to_string(root.join("demo/body.saved")).unwrap(),
+            "original"
+        );
+        assert!(!disabled_skill_root(&root).join("demo").exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skill_enabled_private_safety_vault_alias_to_native_root_is_rejected() {
+        for destination in [".agents/skills", "skills"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path().join(".codex/skills");
+            let other = tmp.path().join(destination);
+            fs::create_dir_all(root.join("demo")).unwrap();
+            fs::write(root.join("demo/SKILL.md"), "original").unwrap();
+            fs::create_dir_all(&other).unwrap();
+            std::os::unix::fs::symlink(&other, disabled_skill_root(&root)).unwrap();
+            let result =
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(acp_set_agent_skill_enabled(
+                        AgentType::Codex,
+                        AgentSkillScope::Project,
+                        "demo".into(),
+                        Some(tmp.path().to_string_lossy().into_owned()),
+                        false,
+                    ));
+            assert!(
+                result.is_err(),
+                "vault must not alias any native scan root: {result:?}"
+            );
+            assert_eq!(
+                fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+                "original"
+            );
+            assert!(!other.join("demo").exists());
+            assert_eq!(fs::read_link(disabled_skill_root(&root)).unwrap(), other);
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skill_enabled_private_safety_bundle_content_link_escape_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("body.txt"), "original content").unwrap();
+        std::os::unix::fs::symlink("../body.txt", root.join("demo/SKILL.md")).unwrap();
+        let result = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Global,
+            "demo",
+            false,
+        );
+        assert!(
+            result.is_err(),
+            "content link must retain its target: {result:?}"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+            "original content"
+        );
+        assert!(!disabled_skill_root(&root).exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skill_enabled_private_safety_bundle_nested_asset_escape_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        fs::create_dir_all(root.join("demo/assets")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "body").unwrap();
+        fs::write(root.join("asset.txt"), "original asset").unwrap();
+        std::os::unix::fs::symlink("../../asset.txt", root.join("demo/assets/link")).unwrap();
+        let result = set_private_skill_enabled(
+            &root,
+            SkillStorageKind::SkillDirectoryOnly,
+            AgentSkillScope::Global,
+            "demo",
+            false,
+        );
+        assert!(
+            result.is_err(),
+            "nested asset link must retain its target: {result:?}"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("demo/assets/link")).unwrap(),
+            "original asset"
+        );
+        assert!(!disabled_skill_root(&root).exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn skill_enabled_private_safety_internal_bundle_links_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        fs::create_dir_all(root.join("demo/docs")).unwrap();
+        fs::create_dir_all(root.join("demo/assets")).unwrap();
+        fs::write(root.join("demo/docs/body.md"), "internal content").unwrap();
+        std::os::unix::fs::symlink("docs/body.md", root.join("demo/SKILL.md")).unwrap();
+        std::os::unix::fs::symlink("../docs/body.md", root.join("demo/assets/link")).unwrap();
+        for enabled in [false, true] {
+            let item = set_private_skill_enabled(
+                &root,
+                SkillStorageKind::SkillDirectoryOnly,
+                AgentSkillScope::Global,
+                "demo",
+                enabled,
+            )
+            .unwrap();
+            let path = Path::new(&item.path);
+            assert_eq!(
+                fs::read_to_string(path.join("SKILL.md")).unwrap(),
+                "internal content"
+            );
+            assert_eq!(
+                fs::read_to_string(path.join("assets/link")).unwrap(),
+                "internal content"
+            );
+            assert_eq!(
+                fs::read_link(path.join("SKILL.md")).unwrap(),
+                Path::new("docs/body.md")
+            );
+        }
+    }
+
+    #[test]
+    fn skill_enabled_private_safety_project_root_shared_with_custom_global_is_rejected() {
+        use crate::acp::custom_registry::{
+            hydrate, hydrate_test_guard, CustomAgentDef, CustomAgentSpec, CustomDistributionKind,
+            NpxSpec,
+        };
+        let _registry_guard = hydrate_test_guard();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join(".codex/skills");
+        fs::create_dir_all(root.join("demo")).unwrap();
+        fs::write(root.join("demo/SKILL.md"), "shared").unwrap();
+        let definition = CustomAgentDef {
+            registry_id: "task1b-cross-scope".into(),
+            name: "Cross Scope".into(),
+            description: String::new(),
+            version: "1.0.0".into(),
+            distribution_kind: CustomDistributionKind::Npx,
+            spec: CustomAgentSpec {
+                npx: Some(NpxSpec {
+                    package: "test-agent@1.0.0".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            icon_url: None,
+            skills_shared_store: false,
+            skills_dir: Some(root.to_string_lossy().into_owned()),
+            source: Default::default(),
+            version_probe: None,
+            supports_mcp: true,
+        };
+        assert!(hydrate(&[definition]).is_empty());
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(acp_set_agent_skill_enabled(
+                AgentType::Codex,
+                AgentSkillScope::Project,
+                "demo".into(),
+                Some(tmp.path().to_string_lossy().into_owned()),
+                false,
+            ));
+        hydrate(&[]);
+        assert!(
+            result.is_err(),
+            "global peer root must count as shared: {result:?}"
+        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("shared skill root"));
+        assert_eq!(
+            fs::read_to_string(root.join("demo/SKILL.md")).unwrap(),
+            "shared"
+        );
+        assert!(!disabled_skill_root(&root).exists());
     }
 
     #[test]

--- a/src-tauri/src/commands/experts.rs
+++ b/src-tauri/src/commands/experts.rs
@@ -467,7 +467,7 @@ pub(crate) fn path_is_symlink(path: &Path) -> bool {
 /// point. `symlink_metadata` reports it as a directory. So we also need to
 /// ask the OS whether the directory is a reparse point.
 #[cfg(windows)]
-fn path_is_reparse_point(path: &Path) -> bool {
+pub(crate) fn path_is_reparse_point(path: &Path) -> bool {
     use std::os::windows::fs::MetadataExt;
     const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
     fs::symlink_metadata(path)
@@ -476,7 +476,7 @@ fn path_is_reparse_point(path: &Path) -> bool {
 }
 
 #[cfg(not(windows))]
-fn path_is_reparse_point(_path: &Path) -> bool {
+pub(crate) fn path_is_reparse_point(_path: &Path) -> bool {
     false
 }
 

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -7783,9 +7783,10 @@ mod tests {
         let refused = git_delete_branch(repo.clone(), "wt".into(), false)
             .await
             .expect_err("git refuses a branch held by a worktree");
+        let refused = format!("{refused:?}");
         assert!(
-            format!("{refused:?}").contains("used by worktree"),
-            "expected git's worktree refusal, got: {refused:?}"
+            refused.contains("used by worktree") || refused.contains("checked out at"),
+            "expected git's worktree refusal, got: {refused}"
         );
 
         // Resolve ours the way git resolves its own — while the directory is

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -7783,10 +7783,9 @@ mod tests {
         let refused = git_delete_branch(repo.clone(), "wt".into(), false)
             .await
             .expect_err("git refuses a branch held by a worktree");
-        let refused = format!("{refused:?}");
         assert!(
-            refused.contains("used by worktree") || refused.contains("checked out at"),
-            "expected git's worktree refusal, got: {refused}"
+            format!("{refused:?}").contains("used by worktree"),
+            "expected git's worktree refusal, got: {refused:?}"
         );
 
         // Resolve ours the way git resolves its own — while the directory is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1477,6 +1477,7 @@ mod tauri_app {
                 crate::commands::custom_agents::acp_add_registry_agent,
                 crate::commands::custom_agents::acp_current_platform,
                 acp_commands::acp_list_agent_skills,
+                acp_commands::acp_set_agent_skill_enabled,
                 acp_commands::acp_read_agent_skill,
                 acp_commands::acp_save_agent_skill,
                 acp_commands::acp_delete_agent_skill,

--- a/src-tauri/src/web/handlers/acp.rs
+++ b/src-tauri/src/web/handlers/acp.rs
@@ -8,8 +8,8 @@ use crate::acp::error::AcpError;
 use crate::acp::opencode_plugins::PluginCheckSummary;
 use crate::acp::preflight::PreflightResult;
 use crate::acp::types::{
-    AcpAgentInfo, AcpAgentStatus, AgentDiagnosticsReport, AgentSkillContent, AgentSkillLayout,
-    AgentSkillScope, AgentSkillsListResult, ConnectionInfo, ForkResultInfo,
+    AcpAgentInfo, AcpAgentStatus, AgentDiagnosticsReport, AgentSkillContent, AgentSkillItem,
+    AgentSkillLayout, AgentSkillScope, AgentSkillsListResult, ConnectionInfo, ForkResultInfo,
 };
 use crate::app_error::{AppCommandError, AppErrorCode};
 use crate::app_state::AppState;
@@ -229,6 +229,31 @@ pub async fn acp_list_agent_skills(
     let result = acp_commands::acp_list_agent_skills(params.agent_type, params.workspace_path)
         .await
         .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))?;
+    Ok(Json(result))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpSetAgentSkillEnabledParams {
+    pub agent_type: AgentType,
+    pub scope: AgentSkillScope,
+    pub skill_id: String,
+    pub workspace_path: Option<String>,
+    pub enabled: bool,
+}
+
+pub async fn acp_set_agent_skill_enabled(
+    Json(params): Json<AcpSetAgentSkillEnabledParams>,
+) -> Result<Json<AgentSkillItem>, AppCommandError> {
+    let result = acp_commands::acp_set_agent_skill_enabled(
+        params.agent_type,
+        params.scope,
+        params.skill_id,
+        params.workspace_path,
+        params.enabled,
+    )
+    .await
+    .map_err(|e| AppCommandError::task_execution_failed(e.to_string()))?;
     Ok(Json(result))
 }
 

--- a/src-tauri/src/web/router.rs
+++ b/src-tauri/src/web/router.rs
@@ -946,6 +946,10 @@ pub fn build_router(
             post(handlers::acp::acp_list_agent_skills),
         )
         .route(
+            "/acp_set_agent_skill_enabled",
+            post(handlers::acp::acp_set_agent_skill_enabled),
+        )
+        .route(
             "/acp_read_agent_skill",
             post(handlers::acp::acp_read_agent_skill),
         )

--- a/src-tauri/tests/api_integration.rs
+++ b/src-tauri/tests/api_integration.rs
@@ -202,6 +202,23 @@ async fn unknown_endpoint_returns_501_with_typed_error() {
     assert!(body["message"].is_string());
 }
 
+#[tokio::test]
+async fn agent_skill_toggle_route_rejects_snake_case_params() {
+    let (server, _data, _static) = build_test_server().await;
+    let resp = server
+        .post("/api/acp_set_agent_skill_enabled")
+        .add_header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&json!({
+            "agent_type": "codex",
+            "scope": "project",
+            "skill_id": "example",
+            "workspace_path": null,
+            "enabled": false
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 422);
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // Live feedback settings + submit gate
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/components/settings/skills-settings.test.tsx
+++ b/src/components/settings/skills-settings.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { NextIntlClientProvider } from "next-intl"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import enMessages from "@/i18n/messages/en.json"
+import type {
+  AcpAgentInfo,
+  AgentSkillItem,
+  AgentSkillsListResult,
+} from "@/lib/types"
+
+const api = vi.hoisted(() => ({
+  acpDeleteAgentSkill: vi.fn(),
+  acpListAgents: vi.fn(),
+  acpListAgentSkills: vi.fn(),
+  acpReadAgentSkill: vi.fn(),
+  acpSaveAgentSkill: vi.fn(),
+  acpSetAgentSkillEnabled: vi.fn(),
+  loadFolderHistory: vi.fn(),
+  openFolder: vi.fn(),
+}))
+
+const toast = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}))
+
+vi.mock("@/lib/api", () => api)
+vi.mock("sonner", () => ({ toast }))
+
+import { SkillsSettings } from "./skills-settings"
+
+const messages = {
+  ...enMessages,
+  SkillsSettings: {
+    ...enMessages.SkillsSettings,
+    availability: {
+      enabled: "Enabled",
+      disabled: "Disabled",
+      toggleAria: "Toggle {skill} for {agent}",
+      readOnly: "Built-in skills are always available.",
+      cannotIsolate: "This shared skill cannot be toggled independently.",
+    },
+    toasts: {
+      ...enMessages.SkillsSettings.toasts,
+      enabled: "Skill enabled",
+      disabled: "Skill disabled",
+      toggleFailed: "Failed to update skill availability",
+    },
+  },
+}
+
+const agent = {
+  agent_type: "codex",
+  name: "Codex",
+  sort_order: 0,
+} as AcpAgentInfo
+
+function skill(overrides: Partial<AgentSkillItem> = {}): AgentSkillItem {
+  return {
+    id: "demo",
+    name: "Demo Skill",
+    scope: "global",
+    layout: "skill_directory",
+    path: "/home/test/.codex/skills/demo/SKILL.md",
+    description: "Demo",
+    read_only: false,
+    enabled: true,
+    can_toggle: true,
+    ...overrides,
+  }
+}
+
+function listResult(item: AgentSkillItem): AgentSkillsListResult {
+  return {
+    supported: true,
+    message: null,
+    locations: [
+      {
+        scope: "global",
+        path: "/home/test/.codex/skills",
+        exists: true,
+      },
+    ],
+    skills: [item],
+  }
+}
+
+function renderSettings() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <SkillsSettings />
+    </NextIntlClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.acpListAgents.mockResolvedValue([agent])
+  api.acpListAgentSkills.mockResolvedValue(listResult(skill()))
+  api.acpReadAgentSkill.mockResolvedValue({
+    skill: skill(),
+    content: "# Demo",
+  })
+  api.acpSaveAgentSkill.mockResolvedValue(undefined)
+  api.acpDeleteAgentSkill.mockResolvedValue(undefined)
+  api.acpSetAgentSkillEnabled.mockResolvedValue(skill({ enabled: false }))
+  api.loadFolderHistory.mockResolvedValue([])
+  api.openFolder.mockResolvedValue(undefined)
+})
+
+describe("SkillsSettings availability", () => {
+  it("toggles a skill without opening its row and reloads the authoritative list", async () => {
+    api.acpListAgentSkills
+      .mockResolvedValueOnce(listResult(skill()))
+      .mockResolvedValueOnce(listResult(skill()))
+      .mockResolvedValueOnce(listResult(skill({ enabled: false })))
+
+    renderSettings()
+
+    const availability = await screen.findByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    expect(availability).toBeChecked()
+    await waitFor(() => expect(api.acpReadAgentSkill).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(availability)
+
+    await waitFor(() =>
+      expect(api.acpSetAgentSkillEnabled).toHaveBeenCalledWith({
+        agentType: "codex",
+        scope: "global",
+        skillId: "demo",
+        workspacePath: null,
+        enabled: false,
+      })
+    )
+    await waitFor(() => expect(api.acpListAgentSkills).toHaveBeenCalledTimes(3))
+    await waitFor(() => expect(availability).not.toBeChecked())
+    expect(api.acpReadAgentSkill).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith("Skill disabled")
+  })
+
+  it("disables non-toggleable skills and exposes an unavailable hint", async () => {
+    api.acpListAgentSkills.mockResolvedValue(
+      listResult(skill({ read_only: true, can_toggle: false }))
+    )
+
+    renderSettings()
+
+    const availability = await screen.findByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    expect(availability).toBeDisabled()
+    expect(availability).toHaveAttribute(
+      "title",
+      "Built-in skills are always available."
+    )
+  })
+
+  it("explains when a shared skill cannot be toggled independently", async () => {
+    api.acpListAgentSkills.mockResolvedValue(
+      listResult(skill({ read_only: false, can_toggle: false }))
+    )
+
+    renderSettings()
+
+    const availability = await screen.findByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    expect(availability).toBeDisabled()
+    expect(availability).toHaveAttribute(
+      "title",
+      "This shared skill cannot be toggled independently."
+    )
+  })
+
+  it("reloads authoritative state and reports a localized error after failure", async () => {
+    api.acpSetAgentSkillEnabled.mockRejectedValue(
+      new Error("permission denied")
+    )
+    api.acpListAgentSkills
+      .mockResolvedValueOnce(listResult(skill()))
+      .mockResolvedValueOnce(listResult(skill()))
+      .mockResolvedValueOnce(listResult(skill()))
+
+    renderSettings()
+
+    const availability = await screen.findByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    fireEvent.click(availability)
+
+    await waitFor(() => expect(api.acpListAgentSkills).toHaveBeenCalledTimes(3))
+    expect(availability).toBeChecked()
+    expect(toast.error).toHaveBeenCalledWith(
+      "Failed to update skill availability",
+      { description: "permission denied" }
+    )
+  })
+})

--- a/src/components/settings/skills-settings.test.tsx
+++ b/src/components/settings/skills-settings.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { NextIntlClientProvider } from "next-intl"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -56,6 +57,22 @@ const agent = {
   sort_order: 0,
 } as AcpAgentInfo
 
+const claudeAgent = {
+  agent_type: "claude_code",
+  name: "Claude Code",
+  sort_order: 1,
+} as AcpAgentInfo
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
 function skill(overrides: Partial<AgentSkillItem> = {}): AgentSkillItem {
   return {
     id: "demo",
@@ -77,8 +94,11 @@ function listResult(item: AgentSkillItem): AgentSkillsListResult {
     message: null,
     locations: [
       {
-        scope: "global",
-        path: "/home/test/.codex/skills",
+        scope: item.scope,
+        path:
+          item.scope === "project"
+            ? "/work/project/.codex/skills"
+            : "/home/test/.codex/skills",
         exists: true,
       },
     ],
@@ -176,26 +196,152 @@ describe("SkillsSettings availability", () => {
   })
 
   it("reloads authoritative state and reports a localized error after failure", async () => {
+    const reload = deferred<AgentSkillsListResult>()
     api.acpSetAgentSkillEnabled.mockRejectedValue(
       new Error("permission denied")
     )
     api.acpListAgentSkills
       .mockResolvedValueOnce(listResult(skill()))
       .mockResolvedValueOnce(listResult(skill()))
-      .mockResolvedValueOnce(listResult(skill()))
+      .mockReturnValueOnce(reload.promise)
 
     renderSettings()
 
     const availability = await screen.findByRole("switch", {
       name: "Toggle Demo Skill for Codex",
     })
+    availability.focus()
     fireEvent.click(availability)
 
     await waitFor(() => expect(api.acpListAgentSkills).toHaveBeenCalledTimes(3))
-    expect(availability).toBeChecked()
+    const switchDuringReload = screen.queryByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    const focusStayedOnSwitch = document.activeElement === switchDuringReload
+
+    await act(async () => {
+      reload.resolve(listResult(skill({ enabled: false })))
+      await reload.promise
+    })
+
+    const authoritativeSwitch = await screen.findByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    await waitFor(() => expect(authoritativeSwitch).not.toBeChecked())
+    expect(switchDuringReload).not.toBeNull()
+    expect(focusStayedOnSwitch).toBe(true)
     expect(toast.error).toHaveBeenCalledWith(
       "Failed to update skill availability",
       { description: "permission denied" }
+    )
+  })
+
+  it("ignores an old agent reload after the selected target changes", async () => {
+    const staleCodexReload = deferred<AgentSkillsListResult>()
+    let codexLoads = 0
+    const codexSkill = skill({ name: "Codex Skill" })
+    const claudeSkill = skill({
+      id: "claude-demo",
+      name: "Claude Skill",
+      path: "/home/test/.claude/skills/claude-demo/SKILL.md",
+    })
+
+    api.acpListAgents.mockResolvedValue([agent, claudeAgent])
+    api.acpListAgentSkills.mockImplementation(
+      (params: { agentType: string; workspacePath?: string | null }) => {
+        if (!("workspacePath" in params)) {
+          return Promise.resolve(
+            listResult(params.agentType === "codex" ? codexSkill : claudeSkill)
+          )
+        }
+        if (params.agentType === "codex") {
+          codexLoads += 1
+          return codexLoads === 1
+            ? Promise.resolve(listResult(codexSkill))
+            : staleCodexReload.promise
+        }
+        return Promise.resolve(listResult(claudeSkill))
+      }
+    )
+
+    renderSettings()
+
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Toggle Codex Skill for Codex",
+      })
+    )
+    await waitFor(() => expect(codexLoads).toBe(2))
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("combobox"))
+    await user.click(await screen.findByRole("option", { name: "Claude Code" }))
+    await screen.findByRole("switch", {
+      name: "Toggle Claude Skill for Claude Code",
+    })
+
+    await act(async () => {
+      staleCodexReload.resolve(
+        listResult(skill({ name: "Stale Codex Skill", enabled: false }))
+      )
+      await staleCodexReload.promise
+    })
+
+    expect(
+      screen.getByRole("switch", {
+        name: "Toggle Claude Skill for Claude Code",
+      })
+    ).toBeChecked()
+    expect(screen.queryByText("Stale Codex Skill")).not.toBeInTheDocument()
+  })
+
+  it("sends the selected project workspace when toggling a folder skill", async () => {
+    const projectSkill = skill({
+      id: "project-demo",
+      name: "Project Skill",
+      scope: "project",
+      path: "/work/project/.codex/skills/project-demo/SKILL.md",
+    })
+    api.loadFolderHistory.mockResolvedValue([
+      {
+        id: 1,
+        name: "Project",
+        path: "/work/project",
+        last_opened_at: "2026-09-07T00:00:00Z",
+      },
+    ])
+    api.acpListAgentSkills.mockImplementation(
+      (params: { workspacePath?: string | null }) =>
+        Promise.resolve(
+          params.workspacePath === "/work/project"
+            ? listResult(projectSkill)
+            : listResult(skill())
+        )
+    )
+
+    renderSettings()
+
+    const user = userEvent.setup()
+    await user.click(await screen.findByRole("button", { name: "Folder" }))
+    await waitFor(() => expect(api.loadFolderHistory).toHaveBeenCalledTimes(1))
+    await user.click(screen.getAllByRole("combobox")[1])
+    await user.click(
+      await screen.findByRole("option", { name: /Project.*\/work\/project/ })
+    )
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Toggle Project Skill for Codex",
+      })
+    )
+
+    await waitFor(() =>
+      expect(api.acpSetAgentSkillEnabled).toHaveBeenCalledWith({
+        agentType: "codex",
+        scope: "project",
+        skillId: "project-demo",
+        workspacePath: "/work/project",
+        enabled: false,
+      })
     )
   })
 })

--- a/src/components/settings/skills-settings.test.tsx
+++ b/src/components/settings/skills-settings.test.tsx
@@ -178,6 +178,20 @@ describe("SkillsSettings availability", () => {
     )
   })
 
+  it("keeps a read-only system skill toggleable when availability is configurable", async () => {
+    api.acpListAgentSkills.mockResolvedValue(
+      listResult(skill({ read_only: true, can_toggle: true }))
+    )
+
+    renderSettings()
+
+    const availability = await screen.findByRole("switch", {
+      name: "Toggle Demo Skill for Codex",
+    })
+    expect(availability).toBeEnabled()
+    expect(availability).toHaveAttribute("title", "Enabled")
+  })
+
   it("explains when a shared skill cannot be toggled independently", async () => {
     api.acpListAgentSkills.mockResolvedValue(
       listResult(skill({ read_only: false, can_toggle: false }))

--- a/src/components/settings/skills-settings.test.tsx
+++ b/src/components/settings/skills-settings.test.tsx
@@ -46,6 +46,8 @@ const messages = {
       ...enMessages.SkillsSettings.toasts,
       enabled: "Skill enabled",
       disabled: "Skill disabled",
+      codexNewSession:
+        "Applies to new Codex sessions. Existing sessions may retain skills they already loaded.",
       toggleFailed: "Failed to update skill availability",
     },
   },
@@ -158,6 +160,45 @@ describe("SkillsSettings availability", () => {
     await waitFor(() => expect(api.acpListAgentSkills).toHaveBeenCalledTimes(3))
     await waitFor(() => expect(availability).not.toBeChecked())
     expect(api.acpReadAgentSkill).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith("Skill disabled", {
+      description:
+        "Applies to new Codex sessions. Existing sessions may retain skills they already loaded.",
+    })
+  })
+
+  it("keeps the existing success toast for non-Codex agents", async () => {
+    const claudeSkill = skill({
+      path: "/home/test/.claude/skills/demo/SKILL.md",
+    })
+    api.acpListAgents.mockResolvedValue([claudeAgent])
+    api.acpListAgentSkills
+      .mockResolvedValueOnce(listResult(claudeSkill))
+      .mockResolvedValueOnce(listResult(claudeSkill))
+      .mockResolvedValueOnce(
+        listResult(skill({ ...claudeSkill, enabled: false }))
+      )
+    api.acpSetAgentSkillEnabled.mockResolvedValue(
+      skill({ ...claudeSkill, enabled: false })
+    )
+
+    renderSettings()
+
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Toggle Demo Skill for Claude Code",
+      })
+    )
+
+    await waitFor(() =>
+      expect(api.acpSetAgentSkillEnabled).toHaveBeenCalledWith({
+        agentType: "claude_code",
+        scope: "global",
+        skillId: "demo",
+        workspacePath: null,
+        enabled: false,
+      })
+    )
+    await waitFor(() => expect(api.acpListAgentSkills).toHaveBeenCalledTimes(3))
     expect(toast.success).toHaveBeenCalledWith("Skill disabled")
   })
 

--- a/src/components/settings/skills-settings.tsx
+++ b/src/components/settings/skills-settings.tsx
@@ -168,6 +168,7 @@ export function SkillsSettings() {
   const t = useTranslations("SkillsSettings")
   const skillsT = t as unknown as SkillsTranslator
   const panelContainerRef = useRef<HTMLDivElement | null>(null)
+  const skillsLoadGenerationRef = useRef(0)
   const [panelContainerWidth, setPanelContainerWidth] = useState(0)
   const [agents, setAgents] = useState<AcpAgentInfo[]>([])
   const [loadingAgents, setLoadingAgents] = useState(true)
@@ -200,6 +201,9 @@ export function SkillsSettings() {
     skillsScope === "folder" ? selectedFolderPath : null
   const backendScope: AgentSkillScope =
     skillsScope === "folder" ? "project" : "global"
+  const skillsTargetKey = `${selectedAgentType ?? ""}|${backendScope}|${workspacePathForRequest ?? ""}`
+  const currentSkillsTargetKeyRef = useRef(skillsTargetKey)
+  currentSkillsTargetKeyRef.current = skillsTargetKey
 
   const [skillDraftId, setSkillDraftId] = useState("")
   const [skillDraftContent, setSkillDraftContent] = useState("")
@@ -332,10 +336,19 @@ export function SkillsSettings() {
 
   const loadSkills = useCallback(
     async (agentType: AgentType) => {
+      const requestTargetKey = `${agentType}|${backendScope}|${workspacePathForRequest ?? ""}`
+      if (currentSkillsTargetKeyRef.current !== requestTargetKey) return null
+
+      const generation = ++skillsLoadGenerationRef.current
+      const isCurrentRequest = () =>
+        currentSkillsTargetKeyRef.current === requestTargetKey &&
+        skillsLoadGenerationRef.current === generation
+
       // Folder scope but no folder chosen → skip the fetch; UI prompts the
       // user to pick one. We still clear previous results so list doesn't
       // show stale items from another folder.
       if (skillsScope === "folder" && !workspacePathForRequest) {
+        setSkillsLoading(false)
         setSkillsError(null)
         setSkillsSupported(true)
         setSkillLocation(null)
@@ -351,6 +364,8 @@ export function SkillsSettings() {
           agentType,
           workspacePath: workspacePathForRequest,
         })
+        if (!isCurrentRequest()) return result
+
         setSkillsSupported(result.supported)
         setSkillLocation(
           result.locations.find(
@@ -362,6 +377,8 @@ export function SkillsSettings() {
         )
         return result
       } catch (err) {
+        if (!isCurrentRequest()) return null
+
         const message = toErrorMessage(err)
         setSkillsError(message)
         setSkillsSupported(true)
@@ -369,7 +386,7 @@ export function SkillsSettings() {
         setSkillItems([])
         return null
       } finally {
-        setSkillsLoading(false)
+        if (isCurrentRequest()) setSkillsLoading(false)
       }
     },
     [backendScope, skillsScope, workspacePathForRequest]
@@ -710,6 +727,10 @@ export function SkillsSettings() {
     // template here anymore — the right panel shows a placeholder until the
     // user picks a skill from the list or clicks "New Skill".
     setSelectedSkillId(null)
+    setSkillsError(null)
+    setSkillsSupported(true)
+    setSkillLocation(null)
+    setSkillItems([])
     setSkillDraftId("")
     setSkillDraftContent("")
     setIsContentEditing(false)
@@ -927,7 +948,7 @@ export function SkillsSettings() {
                 </div>
 
                 <div className="flex-1 min-h-0 overflow-y-auto p-2 space-y-1.5">
-                  {skillsLoading && (
+                  {skillsLoading && skillItems.length === 0 && (
                     <div className="text-xs text-muted-foreground flex items-center gap-1.5 p-1">
                       <Loader2 className="h-3.5 w-3.5 animate-spin" />
                       {t("loadingSkills")}
@@ -956,8 +977,7 @@ export function SkillsSettings() {
                       </div>
                     )}
 
-                  {!skillsLoading &&
-                    skillsSupported &&
+                  {skillsSupported &&
                     filteredSkills.map((skill) => {
                       const isActive = skill.id === selectedSkillId
                       const deleting = skillDeletingId === skill.id

--- a/src/components/settings/skills-settings.tsx
+++ b/src/components/settings/skills-settings.tsx
@@ -981,13 +981,13 @@ export function SkillsSettings() {
                     filteredSkills.map((skill) => {
                       const isActive = skill.id === selectedSkillId
                       const deleting = skillDeletingId === skill.id
-                      const availabilityHint = skill.read_only
-                        ? skillsT("availability.readOnly")
-                        : !skill.can_toggle
-                          ? skillsT("availability.cannotIsolate")
-                          : skill.enabled
-                            ? skillsT("availability.enabled")
-                            : skillsT("availability.disabled")
+                      const availabilityHint = !skill.can_toggle
+                        ? skill.read_only
+                          ? skillsT("availability.readOnly")
+                          : skillsT("availability.cannotIsolate")
+                        : skill.enabled
+                          ? skillsT("availability.enabled")
+                          : skillsT("availability.disabled")
 
                       return (
                         <ContextMenu key={skill.id}>

--- a/src/components/settings/skills-settings.tsx
+++ b/src/components/settings/skills-settings.tsx
@@ -448,7 +448,14 @@ export function SkillsSettings() {
             skill.scope === "project" ? workspacePathForRequest : null,
           enabled,
         })
-        toast.success(skillsT(enabled ? "toasts.enabled" : "toasts.disabled"))
+        const message = skillsT(enabled ? "toasts.enabled" : "toasts.disabled")
+        if (selectedAgent.agent_type === "codex") {
+          toast.success(message, {
+            description: skillsT("toasts.codexNewSession"),
+          })
+        } else {
+          toast.success(message)
+        }
       } catch (err) {
         toast.error(skillsT("toasts.toggleFailed"), {
           description: toErrorMessage(err),

--- a/src/components/settings/skills-settings.tsx
+++ b/src/components/settings/skills-settings.tsx
@@ -46,6 +46,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
 import { parseYamlFrontMatter } from "@/lib/skill-frontmatter"
@@ -53,6 +54,7 @@ import {
   acpDeleteAgentSkill,
   acpListAgents,
   acpListAgentSkills,
+  acpSetAgentSkillEnabled,
   loadFolderHistory,
   openFolder,
   acpReadAgentSkill,
@@ -206,6 +208,7 @@ export function SkillsSettings() {
   const [skillReading, setSkillReading] = useState(false)
   const [skillSaving, setSkillSaving] = useState(false)
   const [skillDeletingId, setSkillDeletingId] = useState<string | null>(null)
+  const [skillTogglingId, setSkillTogglingId] = useState<string | null>(null)
   const [deleteTargetSkill, setDeleteTargetSkill] =
     useState<AgentSkillItem | null>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
@@ -411,6 +414,42 @@ export function SkillsSettings() {
       setLoadingAgents(false)
     }
   }, [])
+
+  const handleToggleSkill = useCallback(
+    async (skill: AgentSkillItem) => {
+      if (!selectedAgent || !skill.can_toggle || skillTogglingId) return
+
+      const enabled = !skill.enabled
+      setSkillTogglingId(skill.id)
+
+      try {
+        await acpSetAgentSkillEnabled({
+          agentType: selectedAgent.agent_type,
+          scope: skill.scope,
+          skillId: skill.id,
+          workspacePath:
+            skill.scope === "project" ? workspacePathForRequest : null,
+          enabled,
+        })
+        toast.success(skillsT(enabled ? "toasts.enabled" : "toasts.disabled"))
+      } catch (err) {
+        toast.error(skillsT("toasts.toggleFailed"), {
+          description: toErrorMessage(err),
+        })
+      } finally {
+        invalidateAgentSkillsCache(selectedAgent.agent_type)
+        await loadSkills(selectedAgent.agent_type)
+        setSkillTogglingId(null)
+      }
+    },
+    [
+      loadSkills,
+      selectedAgent,
+      skillTogglingId,
+      skillsT,
+      workspacePathForRequest,
+    ]
+  )
 
   const handleCreateDraft = useCallback(() => {
     if (!selectedAgent) return
@@ -922,51 +961,95 @@ export function SkillsSettings() {
                     filteredSkills.map((skill) => {
                       const isActive = skill.id === selectedSkillId
                       const deleting = skillDeletingId === skill.id
+                      const availabilityHint = skill.read_only
+                        ? skillsT("availability.readOnly")
+                        : !skill.can_toggle
+                          ? skillsT("availability.cannotIsolate")
+                          : skill.enabled
+                            ? skillsT("availability.enabled")
+                            : skillsT("availability.disabled")
 
                       return (
                         <ContextMenu key={skill.id}>
                           <ContextMenuTrigger asChild>
-                            <button
-                              type="button"
+                            <div
                               className={cn(
-                                "w-full rounded-md border px-2 py-1.5 text-left transition-colors",
+                                "w-full rounded-md border flex items-center gap-2 transition-colors",
                                 isActive
                                   ? "border-primary/60 bg-primary/5"
                                   : "hover:bg-muted/30"
                               )}
-                              onClick={() => {
-                                handlePreviewSkill(skill).catch((err) => {
-                                  console.error(
-                                    "[SkillsSettings] preview skill failed:",
-                                    err
-                                  )
-                                })
-                              }}
                             >
-                              <div className="flex items-center gap-1.5 min-w-0">
-                                <span className="text-xs font-medium truncate">
-                                  {skill.name}
-                                </span>
-                                <Badge
-                                  variant="outline"
-                                  className="h-6 px-2 inline-flex items-center gap-1 text-xs leading-none shrink-0 border-blue-500/40 bg-blue-500/10 text-blue-600 dark:text-blue-400"
-                                >
-                                  {skill.scope}
-                                </Badge>
-                                {skill.read_only && (
+                              <button
+                                type="button"
+                                className="min-w-0 flex-1 px-2 py-1.5 text-left"
+                                onClick={() => {
+                                  handlePreviewSkill(skill).catch((err) => {
+                                    console.error(
+                                      "[SkillsSettings] preview skill failed:",
+                                      err
+                                    )
+                                  })
+                                }}
+                              >
+                                <div className="flex items-center gap-1.5 min-w-0">
+                                  <span className="text-xs font-medium truncate">
+                                    {skill.name}
+                                  </span>
                                   <Badge
                                     variant="outline"
-                                    title={t("systemHint")}
-                                    className="h-6 px-2 inline-flex items-center gap-1 text-xs leading-none shrink-0 border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                                    className="h-6 px-2 inline-flex items-center gap-1 text-xs leading-none shrink-0 border-blue-500/40 bg-blue-500/10 text-blue-600 dark:text-blue-400"
                                   >
-                                    {t("systemBadge")}
+                                    {skill.scope}
                                   </Badge>
-                                )}
+                                  {skill.read_only && (
+                                    <Badge
+                                      variant="outline"
+                                      title={t("systemHint")}
+                                      className="h-6 px-2 inline-flex items-center gap-1 text-xs leading-none shrink-0 border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                                    >
+                                      {t("systemBadge")}
+                                    </Badge>
+                                  )}
+                                </div>
+                                <div className="text-2xs text-muted-foreground truncate mt-1">
+                                  {skill.path}
+                                </div>
+                              </button>
+                              <div
+                                className="shrink-0 pr-2"
+                                onPointerDown={(event) => {
+                                  event.stopPropagation()
+                                }}
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                }}
+                              >
+                                <Switch
+                                  checked={skill.enabled}
+                                  onCheckedChange={() => {
+                                    handleToggleSkill(skill).catch((err) => {
+                                      console.error(
+                                        "[SkillsSettings] toggle skill failed:",
+                                        err
+                                      )
+                                    })
+                                  }}
+                                  disabled={
+                                    !skill.can_toggle ||
+                                    Boolean(skillTogglingId)
+                                  }
+                                  aria-label={skillsT(
+                                    "availability.toggleAria",
+                                    {
+                                      skill: skill.name,
+                                      agent: selectedAgent?.name ?? "",
+                                    }
+                                  )}
+                                  title={availabilityHint}
+                                />
                               </div>
-                              <div className="text-2xs text-muted-foreground truncate mt-1">
-                                {skill.path}
-                              </div>
-                            </button>
+                            </div>
                           </ContextMenuTrigger>
                           <ContextMenuContent>
                             <ContextMenuItem

--- a/src/components/tasks/task-message-composer.test.tsx
+++ b/src/components/tasks/task-message-composer.test.tsx
@@ -38,6 +38,8 @@ const SKILL: AgentSkillItem = {
   path: "/skills/deploy",
   description: "Ship it",
   read_only: false,
+  enabled: true,
+  can_toggle: true,
 }
 // The "+" menu's data sources all hit the transport; none of them is what
 // these tests exercise.

--- a/src/hooks/use-agent-skills.test.tsx
+++ b/src/hooks/use-agent-skills.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { AgentSkillItem } from "@/lib/types"
@@ -49,5 +49,35 @@ describe("useAgentSkills", () => {
     const cached = renderHook(() => useAgentSkills("codex", null))
     expect(cached.result.current.map((item) => item.id)).toEqual(["enabled"])
     expect(api.acpListAgentSkills).toHaveBeenCalledTimes(1)
+  })
+
+  it("replaces a warm cached result after a focus refresh", async () => {
+    api.acpListAgentSkills
+      .mockResolvedValueOnce({
+        supported: true,
+        message: null,
+        locations: [],
+        skills: [skill("demo", true)],
+      })
+      .mockResolvedValueOnce({
+        supported: true,
+        message: null,
+        locations: [],
+        skills: [skill("demo", false)],
+      })
+
+    const prime = renderHook(() => useAgentSkills("codex", null))
+    await waitFor(() => expect(prime.result.current).toHaveLength(1))
+    prime.unmount()
+
+    const warm = renderHook(() => useAgentSkills("codex", null))
+    expect(warm.result.current).toHaveLength(1)
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"))
+    })
+
+    await waitFor(() => expect(warm.result.current).toEqual([]))
+    expect(api.acpListAgentSkills).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/hooks/use-agent-skills.test.tsx
+++ b/src/hooks/use-agent-skills.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { AgentSkillItem } from "@/lib/types"
+
+const api = vi.hoisted(() => ({
+  acpListAgentSkills: vi.fn(),
+}))
+
+vi.mock("@/lib/api", () => api)
+
+import { invalidateAgentSkillsCache, useAgentSkills } from "./use-agent-skills"
+
+function skill(id: string, enabled: boolean): AgentSkillItem {
+  return {
+    id,
+    name: id,
+    scope: "global",
+    layout: "skill_directory",
+    path: `/home/test/.codex/skills/${id}/SKILL.md`,
+    description: null,
+    read_only: false,
+    enabled,
+    can_toggle: true,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  invalidateAgentSkillsCache()
+})
+
+describe("useAgentSkills", () => {
+  it("excludes disabled skills from autocomplete results and its cache", async () => {
+    api.acpListAgentSkills.mockResolvedValue({
+      supported: true,
+      message: null,
+      locations: [],
+      skills: [skill("enabled", true), skill("disabled", false)],
+    })
+
+    const first = renderHook(() => useAgentSkills("codex", null))
+
+    await waitFor(() =>
+      expect(first.result.current.map((item) => item.id)).toEqual(["enabled"])
+    )
+    first.unmount()
+
+    const cached = renderHook(() => useAgentSkills("codex", null))
+    expect(cached.result.current.map((item) => item.id)).toEqual(["enabled"])
+    expect(api.acpListAgentSkills).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/use-agent-skills.ts
+++ b/src/hooks/use-agent-skills.ts
@@ -26,7 +26,9 @@ function fetchSkills(
   if (!promise) {
     promise = acpListAgentSkills({ agentType, workspacePath })
       .then((result) => {
-        const skills = result.supported ? result.skills : EMPTY
+        const skills = result.supported
+          ? result.skills.filter((skill) => skill.enabled !== false)
+          : EMPTY
         cache.set(key, skills)
         inflight.delete(key)
         return skills

--- a/src/hooks/use-agent-skills.ts
+++ b/src/hooks/use-agent-skills.ts
@@ -52,10 +52,10 @@ export function useAgentSkills(
     () => (agentType ? makeKey(agentType, normalizedPath) : null),
     [agentType, normalizedPath]
   )
-  const cached = useMemo(
-    () => (cacheKey ? (cache.get(cacheKey) ?? null) : null),
-    [cacheKey]
-  )
+  // Read the mutable cache on every render. A focus refresh updates the Map
+  // before setFetched triggers a render, so a mount-time snapshot cannot mask
+  // the authoritative replacement.
+  const cached = cacheKey ? (cache.get(cacheKey) ?? null) : null
   // Track which (agentType, workspacePath) the fetched result belongs to so
   // stale data from a previous key is never returned after a switch.
   const [fetched, setFetched] = useState<{

--- a/src/i18n/messages.test.ts
+++ b/src/i18n/messages.test.ts
@@ -62,6 +62,44 @@ const ALL_LOCALES = [
   ["zh-TW", zhTW],
 ] as const
 
+const SKILL_AVAILABILITY_MESSAGES = [
+  ["SkillsSettings.availability.enabled", []],
+  ["SkillsSettings.availability.disabled", []],
+  ["SkillsSettings.availability.toggleAria", ["agent", "skill"]],
+  ["SkillsSettings.availability.readOnly", []],
+  ["SkillsSettings.availability.cannotIsolate", []],
+  ["SkillsSettings.toasts.enabled", []],
+  ["SkillsSettings.toasts.disabled", []],
+  ["SkillsSettings.toasts.toggleFailed", []],
+] as const
+
+function getMessage(node: MessageNode, path: string): string | undefined {
+  let current: MessageNode | undefined = node
+  for (const segment of path.split(".")) {
+    if (typeof current === "string") return undefined
+    current = current?.[segment]
+  }
+  return typeof current === "string" ? current : undefined
+}
+
+describe("skill availability message contract", () => {
+  it.each(ALL_LOCALES)(
+    "%s includes the required keys and placeholders",
+    (_locale, messages) => {
+      for (const [key, expectedPlaceholders] of SKILL_AVAILABILITY_MESSAGES) {
+        const message = getMessage(messages as MessageNode, key)
+        expect(message, key).toBeTypeOf("string")
+        const placeholders = [
+          ...(message?.matchAll(/\{([a-zA-Z][\w]*)\}/g) ?? []),
+        ]
+          .map((match) => match[1])
+          .sort()
+        expect(placeholders, key).toEqual(expectedPlaceholders)
+      }
+    }
+  )
+})
+
 // Every message goes through ICU MessageFormat, which reserves `<tag>`, `{`,
 // `}` and `#`. A string like `<QODER_CONFIG_DIR>/settings.json` parses as an
 // unclosed tag and falls back to rendering the KEY — visible in the UI as

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "اختر Skill من اليسار، أو انقر على \"Skill جديد\" لإنشاء واحد.",
     "systemBadge": "نظام",
     "systemHint": "Skill مدمج في CLI · للقراءة فقط",
+    "availability": {
+      "enabled": "مفعّلة",
+      "disabled": "معطّلة",
+      "toggleAria": "تبديل حالة {skill} للوكيل {agent}",
+      "readOnly": "المهارات المدمجة متاحة دائمًا.",
+      "cannotIsolate": "لا يمكن تبديل هذه المهارة المشتركة بشكل مستقل."
+    },
     "scope": {
       "global": "عام",
       "folder": "مجلد",
@@ -579,7 +586,10 @@
       "created": "تم إنشاء Skill",
       "saveFailed": "فشل حفظ Skill",
       "deleted": "تم حذف Skill",
-      "deleteFailed": "فشل حذف Skill"
+      "deleteFailed": "فشل حذف Skill",
+      "enabled": "تم تفعيل Skill",
+      "disabled": "تم تعطيل Skill",
+      "toggleFailed": "فشل تحديث حالة توفر Skill"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -589,6 +589,7 @@
       "deleteFailed": "فشل حذف Skill",
       "enabled": "تم تفعيل Skill",
       "disabled": "تم تعطيل Skill",
+      "codexNewSession": "ينطبق على جلسات Codex الجديدة. قد تحتفظ الجلسات الحالية بالـ Skills التي سبق تحميلها.",
       "toggleFailed": "فشل تحديث حالة توفر Skill"
     },
     "templates": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -589,6 +589,7 @@
       "deleteFailed": "Skill konnte nicht gelöscht werden",
       "enabled": "Skill aktiviert",
       "disabled": "Skill deaktiviert",
+      "codexNewSession": "Gilt für neue Codex-Sitzungen. Bereits geöffnete Sitzungen können zuvor geladene Skills behalten.",
       "toggleFailed": "Skill-Verfügbarkeit konnte nicht aktualisiert werden"
     },
     "templates": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "Wählen Sie links einen Skill oder klicken Sie auf „Neuer Skill“, um einen zu erstellen.",
     "systemBadge": "System",
     "systemHint": "Integrierter CLI-Skill · schreibgeschützt",
+    "availability": {
+      "enabled": "Aktiviert",
+      "disabled": "Deaktiviert",
+      "toggleAria": "{skill} für {agent} umschalten",
+      "readOnly": "Integrierte Skills sind immer verfügbar.",
+      "cannotIsolate": "Dieser gemeinsam genutzte Skill kann nicht separat umgeschaltet werden."
+    },
     "scope": {
       "global": "Global",
       "folder": "Ordner",
@@ -579,7 +586,10 @@
       "created": "Skill erstellt",
       "saveFailed": "Skill konnte nicht gespeichert werden",
       "deleted": "Skill gelöscht",
-      "deleteFailed": "Skill konnte nicht gelöscht werden"
+      "deleteFailed": "Skill konnte nicht gelöscht werden",
+      "enabled": "Skill aktiviert",
+      "disabled": "Skill deaktiviert",
+      "toggleFailed": "Skill-Verfügbarkeit konnte nicht aktualisiert werden"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -589,6 +589,7 @@
       "deleteFailed": "Failed to delete skill",
       "enabled": "Skill enabled",
       "disabled": "Skill disabled",
+      "codexNewSession": "Applies to new Codex sessions. Existing sessions may retain skills they already loaded.",
       "toggleFailed": "Failed to update skill availability"
     },
     "templates": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "Select a skill on the left, or click \"New Skill\" to create one.",
     "systemBadge": "System",
     "systemHint": "Built-in CLI skill · read-only",
+    "availability": {
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "toggleAria": "Toggle {skill} for {agent}",
+      "readOnly": "Built-in skills are always available.",
+      "cannotIsolate": "This shared skill cannot be toggled independently."
+    },
     "scope": {
       "global": "Global",
       "folder": "Folder",
@@ -579,7 +586,10 @@
       "created": "Skill created",
       "saveFailed": "Failed to save skill",
       "deleted": "Skill deleted",
-      "deleteFailed": "Failed to delete skill"
+      "deleteFailed": "Failed to delete skill",
+      "enabled": "Skill enabled",
+      "disabled": "Skill disabled",
+      "toggleFailed": "Failed to update skill availability"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "Selecciona un Skill a la izquierda o haz clic en \"Nuevo Skill\" para crear uno.",
     "systemBadge": "Sistema",
     "systemHint": "Skill integrado del CLI · solo lectura",
+    "availability": {
+      "enabled": "Activada",
+      "disabled": "Desactivada",
+      "toggleAria": "Cambiar el estado de {skill} para {agent}",
+      "readOnly": "Las Skills integradas siempre están disponibles.",
+      "cannotIsolate": "Esta Skill compartida no se puede activar o desactivar de forma independiente."
+    },
     "scope": {
       "global": "Global",
       "folder": "Carpeta",
@@ -579,7 +586,10 @@
       "created": "Skill creada",
       "saveFailed": "No se pudo guardar la Skill",
       "deleted": "Skill eliminada",
-      "deleteFailed": "No se pudo eliminar la Skill"
+      "deleteFailed": "No se pudo eliminar la Skill",
+      "enabled": "Skill activada",
+      "disabled": "Skill desactivada",
+      "toggleFailed": "No se pudo actualizar la disponibilidad de la Skill"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -589,6 +589,7 @@
       "deleteFailed": "No se pudo eliminar la Skill",
       "enabled": "Skill activada",
       "disabled": "Skill desactivada",
+      "codexNewSession": "Se aplica a las sesiones nuevas de Codex. Las sesiones existentes pueden conservar las Skills que ya cargaron.",
       "toggleFailed": "No se pudo actualizar la disponibilidad de la Skill"
     },
     "templates": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -589,6 +589,7 @@
       "deleteFailed": "Échec de la suppression de la Skill",
       "enabled": "Skill activée",
       "disabled": "Skill désactivée",
+      "codexNewSession": "S'applique aux nouvelles sessions Codex. Les sessions existantes peuvent conserver les Skills déjà chargées.",
       "toggleFailed": "Échec de la mise à jour de la disponibilité de la Skill"
     },
     "templates": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "Sélectionnez un Skill à gauche ou cliquez sur « Nouveau Skill » pour en créer un.",
     "systemBadge": "Système",
     "systemHint": "Skill intégré du CLI · lecture seule",
+    "availability": {
+      "enabled": "Activée",
+      "disabled": "Désactivée",
+      "toggleAria": "Activer ou désactiver {skill} pour {agent}",
+      "readOnly": "Les Skills intégrées sont toujours disponibles.",
+      "cannotIsolate": "Cette Skill partagée ne peut pas être activée ou désactivée indépendamment."
+    },
     "scope": {
       "global": "Global",
       "folder": "Dossier",
@@ -579,7 +586,10 @@
       "created": "Skill créée",
       "saveFailed": "Échec de l’enregistrement de la Skill",
       "deleted": "Skill supprimée",
-      "deleteFailed": "Échec de la suppression de la Skill"
+      "deleteFailed": "Échec de la suppression de la Skill",
+      "enabled": "Skill activée",
+      "disabled": "Skill désactivée",
+      "toggleFailed": "Échec de la mise à jour de la disponibilité de la Skill"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -589,6 +589,7 @@
       "deleteFailed": "Skillの削除に失敗しました",
       "enabled": "Skillを有効にしました",
       "disabled": "Skillを無効にしました",
+      "codexNewSession": "新しく作成した Codex セッションに適用されます。既存のセッションには、すでに読み込まれた Skill が残る場合があります。",
       "toggleFailed": "Skillの利用可否の更新に失敗しました"
     },
     "templates": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "左側から Skill を選択するか、「新規 Skill」をクリックして作成してください。",
     "systemBadge": "システム",
     "systemHint": "CLI 組み込み Skill・読み取り専用",
+    "availability": {
+      "enabled": "有効",
+      "disabled": "無効",
+      "toggleAria": "{agent} で {skill} の有効状態を切り替える",
+      "readOnly": "組み込みの Skill は常に利用できます。",
+      "cannotIsolate": "この共有 Skill は個別に切り替えできません。"
+    },
     "scope": {
       "global": "グローバル",
       "folder": "フォルダ",
@@ -579,7 +586,10 @@
       "created": "Skillを作成しました",
       "saveFailed": "Skillの保存に失敗しました",
       "deleted": "Skillを削除しました",
-      "deleteFailed": "Skillの削除に失敗しました"
+      "deleteFailed": "Skillの削除に失敗しました",
+      "enabled": "Skillを有効にしました",
+      "disabled": "Skillを無効にしました",
+      "toggleFailed": "Skillの利用可否の更新に失敗しました"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -589,6 +589,7 @@
       "deleteFailed": "Skill 삭제에 실패했습니다",
       "enabled": "Skill이 활성화되었습니다",
       "disabled": "Skill이 비활성화되었습니다",
+      "codexNewSession": "새로 만든 Codex 세션에 적용됩니다. 기존 세션에는 이미 불러온 Skill이 남아 있을 수 있습니다.",
       "toggleFailed": "Skill 사용 여부를 업데이트하지 못했습니다"
     },
     "templates": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "왼쪽에서 Skill을 선택하거나 \"새 Skill\"을 클릭하여 만드세요.",
     "systemBadge": "시스템",
     "systemHint": "CLI 내장 Skill · 읽기 전용",
+    "availability": {
+      "enabled": "사용",
+      "disabled": "사용 안 함",
+      "toggleAria": "{agent}에서 {skill} 사용 여부 전환",
+      "readOnly": "내장 Skill은 항상 사용할 수 있습니다.",
+      "cannotIsolate": "이 공유 Skill은 개별적으로 전환할 수 없습니다."
+    },
     "scope": {
       "global": "전역",
       "folder": "폴더",
@@ -579,7 +586,10 @@
       "created": "Skill이 생성되었습니다",
       "saveFailed": "Skill 저장에 실패했습니다",
       "deleted": "Skill이 삭제되었습니다",
-      "deleteFailed": "Skill 삭제에 실패했습니다"
+      "deleteFailed": "Skill 삭제에 실패했습니다",
+      "enabled": "Skill이 활성화되었습니다",
+      "disabled": "Skill이 비활성화되었습니다",
+      "toggleFailed": "Skill 사용 여부를 업데이트하지 못했습니다"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "Selecione um Skill à esquerda ou clique em \"Novo Skill\" para criar um.",
     "systemBadge": "Sistema",
     "systemHint": "Skill integrado do CLI · somente leitura",
+    "availability": {
+      "enabled": "Ativada",
+      "disabled": "Desativada",
+      "toggleAria": "Alternar {skill} para {agent}",
+      "readOnly": "As Skills integradas estão sempre disponíveis.",
+      "cannotIsolate": "Esta Skill compartilhada não pode ser alternada de forma independente."
+    },
     "scope": {
       "global": "Global",
       "folder": "Pasta",
@@ -579,7 +586,10 @@
       "created": "Skill criada",
       "saveFailed": "Falha ao salvar Skill",
       "deleted": "Skill excluída",
-      "deleteFailed": "Falha ao excluir Skill"
+      "deleteFailed": "Falha ao excluir Skill",
+      "enabled": "Skill ativada",
+      "disabled": "Skill desativada",
+      "toggleFailed": "Falha ao atualizar a disponibilidade da Skill"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -589,6 +589,7 @@
       "deleteFailed": "Falha ao excluir Skill",
       "enabled": "Skill ativada",
       "disabled": "Skill desativada",
+      "codexNewSession": "Aplica-se a novas sessões do Codex. Sessões existentes podem manter as Skills já carregadas.",
       "toggleFailed": "Falha ao atualizar a disponibilidade da Skill"
     },
     "templates": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "从左侧选择一个 Skill，或点击“新建 Skill”创建。",
     "systemBadge": "系统",
     "systemHint": "CLI 内置 Skill · 只读",
+    "availability": {
+      "enabled": "已启用",
+      "disabled": "已禁用",
+      "toggleAria": "为 {agent} 切换 {skill} 的启用状态",
+      "readOnly": "内置 Skill 始终可用。",
+      "cannotIsolate": "此共享 Skill 无法单独切换。"
+    },
     "scope": {
       "global": "全局",
       "folder": "文件夹",
@@ -579,7 +586,10 @@
       "created": "Skill 已创建",
       "saveFailed": "保存 Skill 失败",
       "deleted": "Skill 已删除",
-      "deleteFailed": "删除 Skill 失败"
+      "deleteFailed": "删除 Skill 失败",
+      "enabled": "Skill 已启用",
+      "disabled": "Skill 已禁用",
+      "toggleFailed": "更新 Skill 可用状态失败"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -589,6 +589,7 @@
       "deleteFailed": "删除 Skill 失败",
       "enabled": "Skill 已启用",
       "disabled": "Skill 已禁用",
+      "codexNewSession": "仅对新建的 Codex 会话生效；已打开的会话可能仍保留此前加载的 Skill。",
       "toggleFailed": "更新 Skill 可用状态失败"
     },
     "templates": {

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -589,6 +589,7 @@
       "deleteFailed": "刪除 Skill 失敗",
       "enabled": "Skill 已啟用",
       "disabled": "Skill 已停用",
+      "codexNewSession": "僅對新建的 Codex 工作階段生效；已開啟的工作階段可能仍保留先前載入的 Skill。",
       "toggleFailed": "更新 Skill 可用狀態失敗"
     },
     "templates": {

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -544,6 +544,13 @@
     "noSelectionHint": "從左側選擇一個 Skill，或點擊「新建 Skill」建立。",
     "systemBadge": "系統",
     "systemHint": "CLI 內建 Skill · 唯讀",
+    "availability": {
+      "enabled": "已啟用",
+      "disabled": "已停用",
+      "toggleAria": "切換 {agent} 的 {skill} 啟用狀態",
+      "readOnly": "內建 Skill 始終可用。",
+      "cannotIsolate": "此共享 Skill 無法單獨切換。"
+    },
     "scope": {
       "global": "全域",
       "folder": "資料夾",
@@ -579,7 +586,10 @@
       "created": "Skill 已建立",
       "saveFailed": "儲存 Skill 失敗",
       "deleted": "Skill 已刪除",
-      "deleteFailed": "刪除 Skill 失敗"
+      "deleteFailed": "刪除 Skill 失敗",
+      "enabled": "Skill 已啟用",
+      "disabled": "Skill 已停用",
+      "toggleFailed": "更新 Skill 可用狀態失敗"
     },
     "templates": {
       "gemini": "---\nname: example-skill\ndescription: Describe when this skill should be used.\n---\n\n# Skill Name\n\nInstructions for the agent when this skill is active.\n\n## Workflow\n\n1. Add actionable step one.\n2. Add actionable step two.\n",

--- a/src/lib/api-agent-skill-toggle.test.ts
+++ b/src/lib/api-agent-skill-toggle.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  call: vi.fn(),
+  invoke: vi.fn(),
+}))
+
+vi.mock("@/lib/transport", () => ({
+  getTransport: () => ({ call: mocks.call }),
+  getShellTransport: () => ({ call: vi.fn() }),
+  isDesktop: () => false,
+  isRemoteDesktopMode: () => false,
+  getActiveRemoteConnectionId: () => null,
+  notifyRemoteDesktopUnauthorized: vi.fn(),
+}))
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}))
+
+import { acpSetAgentSkillEnabled as callAgentSkillToggle } from "@/lib/api"
+import { acpSetAgentSkillEnabled as invokeAgentSkillToggle } from "@/lib/tauri"
+import type { AgentSkillItem } from "@/lib/types"
+
+const TOGGLE_RESULT: AgentSkillItem = {
+  id: "example",
+  name: "Example",
+  scope: "project",
+  layout: "skill_directory",
+  path: "/workspace/.agents/skills/example",
+  description: null,
+  read_only: false,
+  enabled: false,
+  can_toggle: true,
+}
+
+describe("acpSetAgentSkillEnabled", () => {
+  beforeEach(() => {
+    mocks.call.mockReset()
+    mocks.invoke.mockReset()
+  })
+
+  it("sends camelCase params through the shared transport", async () => {
+    mocks.call.mockResolvedValue(TOGGLE_RESULT)
+
+    await expect(
+      callAgentSkillToggle({
+        agentType: "codex",
+        scope: "project",
+        skillId: "example",
+        enabled: false,
+      })
+    ).resolves.toBe(TOGGLE_RESULT)
+
+    expect(mocks.call).toHaveBeenCalledWith("acp_set_agent_skill_enabled", {
+      agentType: "codex",
+      scope: "project",
+      skillId: "example",
+      workspacePath: null,
+      enabled: false,
+    })
+  })
+
+  it("uses the same command contract for desktop invoke", async () => {
+    mocks.invoke.mockResolvedValue(TOGGLE_RESULT)
+
+    await expect(
+      invokeAgentSkillToggle({
+        agentType: "claude",
+        scope: "global",
+        skillId: "example",
+        workspacePath: "/workspace",
+        enabled: true,
+      })
+    ).resolves.toBe(TOGGLE_RESULT)
+
+    expect(mocks.invoke).toHaveBeenCalledWith("acp_set_agent_skill_enabled", {
+      agentType: "claude",
+      scope: "global",
+      skillId: "example",
+      workspacePath: "/workspace",
+      enabled: true,
+    })
+  })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1363,6 +1363,22 @@ export async function acpListAgentSkills(params: {
   })
 }
 
+export async function acpSetAgentSkillEnabled(params: {
+  agentType: AgentType
+  scope: AgentSkillScope
+  skillId: string
+  workspacePath?: string | null
+  enabled: boolean
+}): Promise<AgentSkillItem> {
+  return getTransport().call("acp_set_agent_skill_enabled", {
+    agentType: params.agentType,
+    scope: params.scope,
+    skillId: params.skillId,
+    workspacePath: params.workspacePath ?? null,
+    enabled: params.enabled,
+  })
+}
+
 export async function acpReadAgentSkill(params: {
   agentType: AgentType
   scope: AgentSkillScope

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -281,6 +281,22 @@ export async function acpListAgentSkills(params: {
   })
 }
 
+export async function acpSetAgentSkillEnabled(params: {
+  agentType: AgentType
+  scope: AgentSkillScope
+  skillId: string
+  workspacePath?: string | null
+  enabled: boolean
+}): Promise<AgentSkillItem> {
+  return invoke("acp_set_agent_skill_enabled", {
+    agentType: params.agentType,
+    scope: params.scope,
+    skillId: params.skillId,
+    workspacePath: params.workspacePath ?? null,
+    enabled: params.enabled,
+  })
+}
+
 export async function acpReadAgentSkill(params: {
   agentType: AgentType
   scope: AgentSkillScope

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3486,6 +3486,8 @@ export interface AgentSkillItem {
   path: string
   description: string | null
   read_only: boolean
+  enabled: boolean
+  can_toggle: boolean
 }
 
 export interface AgentSkillsListResult {


### PR DESCRIPTION
## 背景

设置页的技能管理此前只能查看、编辑和删除技能，不能控制某个技能是否对指定 Agent 可用。本 PR 增加与 MCP 按 Agent 分配语义一致的技能开关，并确保关闭后会影响 Agent 自身的实际发现结果，而不只是隐藏 Codeg 的自动补全项。

## 主要改动

- 在“设置 > 技能”中为当前 Agent、当前全局/项目范围的每个技能增加可用性开关，包含提交中、失败回滚、权威列表刷新和本地化提示状态。
- 为 `AgentSkillItem` 增加 `enabled`、`canToggle` 状态，并打通 TypeScript API、Tauri command、Axum route 与 Rust 核心逻辑。
- 禁用技能仍保留在管理列表中，可以继续预览、编辑、删除或重新启用；聊天输入中的技能自动补全只返回已启用技能。
- 串行化并发修改，补充目标碰撞、符号链接别名、大小写变体、多个技能根目录、共享所有权、回滚和原子配置写入保护。
- 补齐简体中文、繁体中文、英语、日语、韩语、西班牙语、德语、法语、葡萄牙语和阿拉伯语文案。

## 不同 Agent 的实现方式

### Codex

- 使用 Codex 官方的 `CODEX_HOME/config.toml` 中 `skills.config` 配置，不移动任何技能文件。
- 按配置顺序计算 `path` / `name` 规则，最后一条匹配规则生效；如果后面的名称规则会覆盖当前路径规则，则在末尾追加路径级覆盖，后续切换复用该条目，不会持续膨胀配置。
- 因为只修改可用性配置，Codex 的系统只读技能也可以禁用，技能文件和设置页显示位置保持不变。
- 配置通过临时文件原子替换，并保留已有注释、无关配置和 `config.toml` 符号链接。

### 其他 Agent

- 私有技能通过相邻的禁用 vault 在扫描目录外保存，启用时原样恢复。
- 共享技能在隐藏共享源之前，为仍需使用它的其他 Agent 创建独立根目录链接；预检无法隔离、存在冲突或异常入站链接时会拒绝操作，执行中失败会回滚。
- CLI 自带且不可写的技能继续展示为不可切换，避免移动或破坏 Agent 管理的内容。

## 生效与兼容说明

- 开关按 Agent 和范围独立生效，不会用一个全局数据库布尔值替代各 CLI 的真实状态。
- Codex 已运行的会话可能缓存技能清单，切换后需要新建或重新连接会话；设置页会明确提示这一点。
- Codex 的规则顺序已在本机 `codex-cli 0.144.1` 和 Codeg 实际驱动的 `0.153.4` 上验证。Codex 官方尚未明确该配置的最低支持版本，过旧版本可能不识别 `skills.config`，建议使用当前版本。
- 当前分支相对最新 `origin/main` 落后 25 个提交；未合并或变基 `main`，但最终 `git merge-tree` 模拟合并通过且无冲突。

## 验证

- `pnpm eslint .`：0 error；1 个既有 warning，位于未涉及的 `status-bar-mcp.tsx`。
- `pnpm test`：428 个测试文件、6130 项测试全部通过。
- `pnpm build`：通过，生成 32 个静态页面。
- 桌面、服务器和 `codeg-mcp` 的 `cargo check` 全部通过。
- 桌面、服务器和 `codeg-mcp` 的严格 Clippy（`-D warnings`）全部通过。
- 技能专项：24 个文件系统隔离测试、7 个 Codex 原生开关测试、5 个 Codex 规则/写回测试全部通过。
- `api_integration`：17/17 通过。
- `git diff --check` 通过；与最新 `origin/main` 的模拟合并无冲突。

## 本机已知基线差异

移除本功能无关的 `folders.rs` 兼容改动后，完整 Rust 共享库测试在 Apple Git 2.39.3 下各有 1 个上游断言失败：`remove_worktree_deletes_a_branch_plain_delete_cannot` 只接受 `used by worktree`，而本机 Git 返回 `checked out at`。桌面结果为 3603 通过、1 忽略、1 个该断言失败；服务器结果为 3568 通过、1 忽略、1 个该断言失败。该文件相对 `origin/main` 的 PR 净差异为零，与技能功能无关。