### PR TITLE
fix(chat): render local Markdown images inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/mdast": "^4.0.4",
     "@types/node": "25.2.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.3(@testing-library/dom@10.4.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: 25.2.2
         version: 25.2.2

--- a/src/components/ai-elements/markdown-local-image.tsx
+++ b/src/components/ai-elements/markdown-local-image.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react"
+import type { Components } from "streamdown"
+import { ImageOff, Loader2 } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { readWorkspaceFileBase64 } from "@/lib/api"
+import {
+  createLocalImageLoader,
+  resolveLocalImage,
+} from "@/lib/markdown-local-image"
+import {
+  ImageActions,
+  useImageActions,
+} from "@/components/message/image-actions"
+import { ImagePreviewDialog } from "@/components/ui/image-preview-dialog"
+
+type ImageScope = {
+  root: string
+  load: ReturnType<typeof createLocalImageLoader>
+}
+const LocalImageContext = createContext<ImageScope | null>(null)
+
+/** Scope belongs to this transcript, never the globally active folder. */
+export function MarkdownImageProvider({
+  rootPath,
+  children,
+}: {
+  rootPath: string | null
+  children: ReactNode
+}) {
+  const scope = useMemo(
+    () =>
+      rootPath
+        ? {
+            root: rootPath,
+            load: createLocalImageLoader(rootPath, readWorkspaceFileBase64),
+          }
+        : null,
+    [rootPath]
+  )
+  return (
+    <LocalImageContext.Provider value={scope}>
+      {children}
+    </LocalImageContext.Provider>
+  )
+}
+
+function LocalMarkdownImage({
+  source,
+  alt,
+  linked,
+}: {
+  source: string
+  alt: string
+  linked: boolean
+}) {
+  const scope = useContext(LocalImageContext)
+  const t = useTranslations("Folder.chat.messageList")
+  const target = scope ? resolveLocalImage(source, scope.root) : null
+  const path = target?.path
+  const [result, setResult] = useState<{
+    scope: ImageScope
+    path: string
+    data: string | null
+  } | null>(null)
+  const [preview, setPreview] = useState<{
+    scope: ImageScope
+    path: string
+  } | null>(null)
+  const { canCopy, copy, download } = useImageActions()
+  useEffect(() => {
+    if (!scope || !path) return
+    let cancelled = false
+    void scope.load(path).then((data) => {
+      if (!cancelled) setResult({ scope, path, data })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [scope, path])
+
+  // A source or transcript change must never paint bytes from the previous
+  // scope while its replacement is loading (including out-of-order reads).
+  const current =
+    result?.scope === scope && result?.path === path ? result : null
+  const label = alt || target?.name || source
+  if (!scope || !target || current?.data === null) {
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        className="inline-flex max-w-full items-center gap-1.5 text-muted-foreground"
+      >
+        <ImageOff aria-hidden="true" className="size-4 shrink-0" />
+        <span className="wrap-anywhere">{label}</span>
+      </span>
+    )
+  }
+  if (!current) {
+    return (
+      <span
+        role="status"
+        className="inline-flex max-w-full items-center gap-1.5 text-muted-foreground"
+      >
+        <Loader2 aria-hidden="true" className="size-4 shrink-0 animate-spin" />
+        <span className="wrap-anywhere">{label}</span>
+      </span>
+    )
+  }
+  const image = {
+    name: target.name,
+    mime_type: target.mime,
+    data: current.data!,
+    uri: null,
+  }
+  const src = `data:${image.mime_type};base64,${image.data}`
+  const picture = (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={label}
+      className="h-auto max-h-96 max-w-full object-contain"
+      onError={() => setResult({ scope, path: target.path, data: null })}
+    />
+  )
+  return (
+    <>
+      <ImageActions
+        image={image}
+        as="span"
+        className="inline-block max-w-full align-middle"
+      >
+        {linked ? (
+          picture
+        ) : (
+          <button
+            type="button"
+            className="inline-block max-w-full cursor-zoom-in"
+            aria-label={label}
+            onClick={() => setPreview({ scope, path: target.path })}
+          >
+            {picture}
+          </button>
+        )}
+      </ImageActions>
+      <ImagePreviewDialog
+        src={src}
+        alt={label}
+        open={preview?.scope === scope && preview?.path === target.path}
+        onOpenChange={(open) =>
+          setPreview(open ? { scope, path: target.path } : null)
+        }
+        onDownload={() => void download(image)}
+        onCopy={canCopy ? () => void copy(image) : undefined}
+        copyLabel={t("copyImage")}
+        downloadLabel={t("downloadImage")}
+        renderImage={(preview) => (
+          <ImageActions image={image}>{preview}</ImageActions>
+        )}
+      />
+    </>
+  )
+}
+
+function MarkdownImageSpan({
+  // The parser node is not a DOM attribute.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  node: _node,
+  children,
+  ...props
+}: ComponentProps<"span"> & {
+  node?: unknown
+  "data-codeg-local-image"?: string
+  "data-codeg-image-linked"?: string
+}) {
+  const source = props["data-codeg-local-image"]
+  if (typeof source === "string") {
+    return (
+      <LocalMarkdownImage
+        source={source}
+        alt={typeof children === "string" ? children : ""}
+        linked={props["data-codeg-image-linked"] === "true"}
+      />
+    )
+  }
+  return <span {...props}>{children}</span>
+}
+
+export const markdownLocalImageComponents: Components = {
+  span: MarkdownImageSpan as Components["span"],
+}

--- a/src/components/ai-elements/markdown-local-image.tsx
+++ b/src/components/ai-elements/markdown-local-image.tsx
@@ -182,8 +182,12 @@ function MarkdownImageSpan({
   "data-codeg-local-image"?: string
   "data-codeg-image-linked"?: string
 }) {
+  // Non-empty, not merely present: `remarkLocalImages` only ever emits a
+  // destination it already parsed, so a valueless attribute can only come from
+  // author-written raw HTML — leave that span as the plain text it is instead
+  // of decorating it with a broken-image icon.
   const source = props["data-codeg-local-image"]
-  if (typeof source === "string") {
+  if (source) {
     return (
       <LocalMarkdownImage
         source={source}

--- a/src/components/ai-elements/message-local-image.test.tsx
+++ b/src/components/ai-elements/message-local-image.test.tsx
@@ -156,6 +156,63 @@ describe("inline local images in real chat Markdown", () => {
     }
   )
 
+  // CommonMark eats the `\` before a punctuation-initial Windows segment, so
+  // `…\shots\.preview.png` arrives as `…\shots.preview.png` — a DIFFERENT file
+  // that is still inside the root. Reading it would render the wrong picture
+  // under the right alt text, which `[Image blocked: …]` never did.
+  it.each([
+    "![shot](C:\\repo\\shots\\.preview.png)",
+    "![shot](<C:\\repo\\shots\\.preview.png>)",
+    "![shot](C:\\repo\\shots\\_preview.png)",
+    "![shot][s]\n\n[s]: C:\\repo\\shots\\.preview.png",
+    "![shot](.\\shots\\.preview.png)",
+    "![shot](a\\b\\.preview.png)",
+    // The parsed destination keeps NO backslash in these — the only one was
+    // the eaten separator — so the source, not the url, is what tells.
+    "![shot](C:/repo/shots\\.preview.png)",
+    "![shot](shots\\.preview.png)",
+    "![shot][s]\n\n[s]: C:/repo/shots\\.preview.png",
+  ])("refuses a Windows path the parser may have glued: %s", async (source) => {
+    const { container } = render(preview(source, "C:/repo"))
+    await waitFor(() => expect(container.textContent).toContain("shot"))
+    expect(mocks.read).not.toHaveBeenCalled()
+    expect(container.querySelector("img")).toBeNull()
+  })
+
+  it("still resolves a Windows path with no escape to lose", async () => {
+    // The escape check is scoped to backslash destinations, and to the node
+    // that carries one — an alt-text escape next to a forward-slash path is
+    // not the parser gluing a directory onto a file name.
+    render(
+      preview(
+        "![a \\* b](./preview.png)\n\n![shot](C:\\repo\\a\\b.png)",
+        "C:/repo"
+      )
+    )
+    await waitFor(() => expect(mocks.read).toHaveBeenCalledTimes(2))
+    expect(mocks.read).toHaveBeenCalledWith(
+      "C:/repo",
+      "preview.png",
+      LOCAL_IMAGE_MAX_BYTES
+    )
+    expect(mocks.read).toHaveBeenCalledWith(
+      "C:/repo",
+      "a/b.png",
+      LOCAL_IMAGE_MAX_BYTES
+    )
+  })
+
+  it("leaves an author-written span with no destination as plain text", async () => {
+    const { container } = render(
+      preview("<span data-codeg-local-image>important text</span>")
+    )
+    await waitFor(() =>
+      expect(container.textContent).toContain("important text")
+    )
+    expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    expect(mocks.read).not.toHaveBeenCalled()
+  })
+
   it("never falls back to the active workspace when its own root is unknown", async () => {
     render(preview("![Unavailable](./preview.png)", null))
     expect(

--- a/src/components/ai-elements/message-local-image.test.tsx
+++ b/src/components/ai-elements/message-local-image.test.tsx
@@ -1,0 +1,230 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  read: vi.fn(),
+  download: vi.fn(),
+  copy: vi.fn(),
+}))
+vi.mock("@/lib/api", () => ({ readWorkspaceFileBase64: mocks.read }))
+vi.mock("next-intl", () => ({ useTranslations: () => (key: string) => key }))
+vi.mock("@/components/ai-elements/link-safety", () => ({
+  useStreamdownLinkSafety: () => ({ enabled: false }),
+  parseLocalFileTarget: () => null,
+}))
+vi.mock("@/components/message/image-actions", () => ({
+  ImageActions: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+  useImageActions: () => ({
+    canCopy: true,
+    copy: mocks.copy,
+    download: mocks.download,
+  }),
+}))
+
+// Keep the real Streamdown parse/sanitize/harden pipeline. Mocking Streamdown
+// would miss the exact failure that used to replace this image with text.
+import { MessageResponse } from "./message"
+import { MarkdownImageProvider } from "./markdown-local-image"
+import { LOCAL_IMAGE_MAX_BYTES } from "@/lib/markdown-local-image"
+
+const PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl6TAAAAABJRU5ErkJggg=="
+
+function preview(markdown: string, rootPath: string | null = "/repo") {
+  return (
+    <MarkdownImageProvider rootPath={rootPath}>
+      <MessageResponse>{markdown}</MessageResponse>
+    </MarkdownImageProvider>
+  )
+}
+
+beforeEach(() => {
+  mocks.read.mockReset().mockResolvedValue(PNG)
+  mocks.copy.mockReset()
+  mocks.download.mockReset()
+})
+
+describe("inline local images in real chat Markdown", () => {
+  it.each([
+    [
+      "![Preview](</repo/My Images/preview.png>)",
+      "/repo",
+      "My Images/preview.png",
+    ],
+    ["![Preview](./images/preview.png)", "/repo", "images/preview.png"],
+    ["![Preview](images/preview.png)", "/repo", "images/preview.png"],
+    [
+      "![Preview](<C:/My Project/_tmp/preview.png>)",
+      "C:/My Project",
+      "_tmp/preview.png",
+    ],
+    [
+      "![Preview](file:///C:/My%20Project/_tmp/preview.png)",
+      "C:/My Project",
+      "_tmp/preview.png",
+    ],
+    [
+      "![Preview](C:\\repo\\images\\preview.png)",
+      "C:/repo",
+      "images/preview.png",
+    ],
+    [
+      "![Preview][shot]\n\n[shot]: ./images/preview.png",
+      "/repo",
+      "images/preview.png",
+    ],
+  ])(
+    "renders %s without an Image blocked placeholder",
+    async (markdown, root, path) => {
+      const { container } = render(preview(markdown, root))
+      await waitFor(() =>
+        expect(screen.getByRole("img", { name: "Preview" })).toHaveAttribute(
+          "src",
+          `data:image/png;base64,${PNG}`
+        )
+      )
+      expect(mocks.read).toHaveBeenCalledWith(root, path, LOCAL_IMAGE_MAX_BYTES)
+      expect(container.textContent).not.toContain("Image blocked")
+      expect(container.querySelector("img[src^='file:']")).toBeNull()
+    }
+  )
+
+  it("opens the existing image dialog with copy and download actions", async () => {
+    render(preview("![Preview](./preview.png)"))
+    await screen.findByRole("button", { name: "Preview" })
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }))
+    expect(screen.getByRole("dialog")).toBeVisible()
+    fireEvent.click(screen.getByRole("button", { name: "copyImage" }))
+    expect(mocks.copy).toHaveBeenCalledWith(
+      expect.objectContaining({ data: PNG, name: "preview.png" })
+    )
+    fireEvent.click(screen.getByRole("button", { name: "downloadImage" }))
+    expect(mocks.download).toHaveBeenCalledWith(
+      expect.objectContaining({ data: PNG })
+    )
+  })
+
+  it.each([
+    "[![Preview](./preview.png)](https://example.com/gallery)",
+    "[**![Preview](./preview.png)**](https://example.com/gallery)",
+    "[![Preview](./preview.png)][gallery]\n\n[gallery]: https://example.com/gallery",
+  ])("keeps a linked image in its original link: %s", async (markdown) => {
+    const { container } = render(preview(markdown))
+    await screen.findByRole("img", { name: "Preview" })
+    expect(container.querySelector("button button")).toBeNull()
+    expect(container.querySelector("[data-streamdown='link']")).toHaveAttribute(
+      "title",
+      "https://example.com/gallery"
+    )
+  })
+
+  it("leaves remote images alone and does not interpret examples in code", async () => {
+    const { container } = render(
+      preview(
+        "![Remote](https://example.com/preview.png)\n\n`![Inline](./inline.png)`\n\n```md\n![Code](./code.png)\n```"
+      )
+    )
+    await waitFor(() =>
+      expect(
+        container.querySelector('img[src="https://example.com/preview.png"]')
+      ).not.toBeNull()
+    )
+    expect(mocks.read).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(container.textContent).toContain("![Code](./code.png)")
+    )
+  })
+
+  it.each([
+    "../secret.png",
+    "/repo-other/secret.png",
+    "file:///private/secret.png",
+    "javascript:alert(1)",
+    "data:image/png;base64,AAAA",
+    "./secret.json",
+  ])(
+    "does not read an unsafe or unsupported destination: %s",
+    async (source) => {
+      const { container } = render(preview(`![Unavailable](<${source}>)`))
+      await waitFor(() =>
+        expect(container.textContent).toContain("Unavailable")
+      )
+      expect(mocks.read).not.toHaveBeenCalled()
+      expect(container.querySelector("img")).toBeNull()
+    }
+  )
+
+  it("never falls back to the active workspace when its own root is unknown", async () => {
+    render(preview("![Unavailable](./preview.png)", null))
+    expect(
+      screen.getByRole("img", { name: "Unavailable" })
+    ).not.toHaveAttribute("src")
+    expect(mocks.read).not.toHaveBeenCalled()
+  })
+
+  it("replaces a refused or undecodable image with its accessible alt text", async () => {
+    mocks.read.mockRejectedValueOnce(new Error("symlink outside workspace"))
+    const { rerender } = render(preview("![Missing](./missing.png)"))
+    await waitFor(() =>
+      expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    )
+    expect(screen.getByRole("img", { name: "Missing" }).tagName).toBe("SPAN")
+    rerender(preview("![Broken](./broken.png)"))
+    await screen.findByRole("button", { name: "Broken" })
+    fireEvent.error(screen.getByRole("img", { name: "Broken" }))
+    expect(screen.getByRole("img", { name: "Broken" }).tagName).toBe("SPAN")
+  })
+
+  it("does not show the previous workspace's bytes while a new one loads", async () => {
+    const { rerender } = render(preview("![Preview](./preview.png)", "/first"))
+    await screen.findByRole("button", { name: "Preview" })
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }))
+    expect(screen.getByRole("dialog")).toBeVisible()
+    let finish!: (data: string) => void
+    mocks.read.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finish = resolve
+        })
+    )
+    rerender(preview("![Preview](./preview.png)", "/second"))
+    expect(
+      screen.queryByRole("img", { name: "Preview" })
+    ).not.toBeInTheDocument()
+    expect(mocks.read).toHaveBeenLastCalledWith(
+      "/second",
+      "preview.png",
+      LOCAL_IMAGE_MAX_BYTES
+    )
+    await act(async () => {
+      finish(PNG)
+    })
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "Preview" })).toHaveAttribute(
+      "src",
+      `data:image/png;base64,${PNG}`
+    )
+  })
+
+  it("discards a read that completes after its source changed", async () => {
+    let finishOld!: (data: string) => void
+    mocks.read.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finishOld = resolve
+        })
+    )
+    const { rerender } = render(preview("![Old](./old.png)"))
+    rerender(preview("![New](./replacement.png)"))
+    await screen.findByRole("button", { name: "New" })
+    await act(async () => {
+      finishOld("b2xk")
+    })
+    expect(screen.getByRole("img", { name: "New" })).toHaveAttribute(
+      "src",
+      `data:image/png;base64,${PNG}`
+    )
+  })
+})

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -35,6 +35,8 @@ import { rehypePluginsAllowingCodeg } from "./rehype-allow-codeg"
 import { remarkTrimCjkAutolinkTail } from "./remark-cjk-autolink-tail"
 import { remarkRewriteFileUriLinks } from "./remark-file-uri-links"
 import { remarkRestoreWindowsPaths } from "./remark-windows-paths"
+import { remarkLocalImages } from "./remark-local-images"
+import { markdownLocalImageComponents } from "./markdown-local-image"
 import { MATH_FENCE_PAD, useStreamdownPlugins } from "./streamdown-plugins"
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
@@ -467,6 +469,7 @@ const remarkPlugins = [
   ...Object.values(defaultRemarkPlugins),
   // Before remarkRewriteFileUriLinks, which reshapes a drive path's url.
   remarkRestoreWindowsPaths,
+  remarkLocalImages,
   remarkRewriteFileUriLinks,
   remarkTrimCjkAutolinkTail,
 ]
@@ -552,6 +555,7 @@ function MessageResponseImpl({
       components={{
         ...props.components,
         ...markdownLinkComponents,
+        ...markdownLocalImageComponents,
         ...mermaidComponents,
       }}
     >

--- a/src/components/ai-elements/rehype-allow-codeg.test.ts
+++ b/src/components/ai-elements/rehype-allow-codeg.test.ts
@@ -10,6 +10,13 @@ function hrefProtocols(plugin: unknown): string[] | undefined {
   return schema?.protocols?.href
 }
 
+/** Pull the `span` attribute allow-list out of the same tuple. */
+function spanAttributes(plugin: unknown): unknown[] | undefined {
+  if (!Array.isArray(plugin)) return undefined
+  const schema = plugin[1] as { attributes?: { span?: unknown[] } } | undefined
+  return schema?.attributes?.span
+}
+
 describe("rehypePluginsAllowingCodeg", () => {
   it("adds `codeg` to the sanitize schema's href protocol allow-list", () => {
     // Guards against an upstream rename of the `sanitize` key — the whole fix
@@ -25,6 +32,29 @@ describe("rehypePluginsAllowingCodeg", () => {
     expect(href?.filter((p) => p === "codeg")).toHaveLength(1)
     // Pre-existing protocols are preserved (https is always present).
     expect(href).toContain("https")
+  })
+
+  it("allows the local-image span attributes under both hast spellings", () => {
+    const sanitizeIndex = Object.keys(defaultRehypePlugins).indexOf("sanitize")
+    const span = spanAttributes(
+      rehypePluginsAllowingCodeg(defaultRehypePlugins)[sanitizeIndex]
+    )
+    // The camelCased names are what sanitize sees while `rehype-raw` runs
+    // ahead of it; the dashed ones are what it would see without that
+    // round-trip. Neither spelling alone is safe to rely on across upgrades.
+    expect(span).toEqual(
+      expect.arrayContaining([
+        "dataCodegLocalImage",
+        "dataCodegImageLinked",
+        "data-codeg-local-image",
+        "data-codeg-image-linked",
+      ])
+    )
+    // The shipped schema's own `span` entries (if any) are preserved.
+    for (const attribute of spanAttributes(defaultRehypePlugins.sanitize) ??
+      []) {
+      expect(span).toContainEqual(attribute)
+    }
   })
 
   it("preserves plugin count and order, passing raw/harden through by reference", () => {

--- a/src/components/ai-elements/rehype-allow-codeg.ts
+++ b/src/components/ai-elements/rehype-allow-codeg.ts
@@ -6,9 +6,10 @@ type RehypePlugins = NonNullable<
 >
 type RehypePlugin = RehypePlugins[number]
 
-/** Minimal view of rehype-sanitize's schema — only the protocol allow-list we widen. */
+/** Minimal view of the protocol and inert-attribute allow-lists we extend. */
 type SanitizeSchema = {
   protocols?: Record<string, string[]>
+  attributes?: Record<string, unknown[]>
   [key: string]: unknown
 }
 
@@ -34,6 +35,8 @@ type SanitizeSchema = {
  * Only the `sanitize` entry is rewritten; every other plugin is passed through
  * in its original position (mirroring how Streamdown builds the default list via
  * `Object.values`), so the pipeline stays correct if upstream adds plugins.
+ * The two span attributes carry local-image references to the confined reader;
+ * they never become browser image URLs or widen the src protocol allow-list.
  */
 export function rehypePluginsAllowingCodeg(
   defaults: Record<string, RehypePlugin>
@@ -46,6 +49,14 @@ export function rehypePluginsAllowingCodeg(
     const href = schema?.protocols?.href ?? []
     const next: SanitizeSchema = {
       ...schema,
+      attributes: {
+        ...schema?.attributes,
+        span: [
+          ...(schema?.attributes?.span ?? []),
+          "dataCodegLocalImage",
+          "dataCodegImageLinked",
+        ],
+      },
       protocols: {
         ...schema?.protocols,
         href: href.includes("codeg") ? href : [...href, "codeg"],

--- a/src/components/ai-elements/rehype-allow-codeg.ts
+++ b/src/components/ai-elements/rehype-allow-codeg.ts
@@ -37,6 +37,13 @@ type SanitizeSchema = {
  * `Object.values`), so the pipeline stays correct if upstream adds plugins.
  * The two span attributes carry local-image references to the confined reader;
  * they never become browser image URLs or widen the src protocol allow-list.
+ * Both spellings are listed on purpose: `remarkLocalImages` emits the dashed
+ * attribute names, but sanitize matches against the *hast property* name, and
+ * today that is the camelCased one only because Streamdown runs `rehype-raw`
+ * ahead of sanitize (hast-util-raw serializes to HTML and re-parses, which
+ * runs the names through property-information). Without `raw` in front the
+ * dashed key reaches sanitize verbatim; allowing both keeps local images
+ * working either way instead of silently degrading them to alt text.
  */
 export function rehypePluginsAllowingCodeg(
   defaults: Record<string, RehypePlugin>
@@ -55,6 +62,8 @@ export function rehypePluginsAllowingCodeg(
           ...(schema?.attributes?.span ?? []),
           "dataCodegLocalImage",
           "dataCodegImageLinked",
+          "data-codeg-local-image",
+          "data-codeg-image-linked",
         ],
       },
       protocols: {

--- a/src/components/ai-elements/remark-file-uri-links.ts
+++ b/src/components/ai-elements/remark-file-uri-links.ts
@@ -11,8 +11,8 @@
 //      blocks the now-hrefless `<a>`. Rewritten to `/C:/…` so `C:` is no longer
 //      in protocol position (see {@link windowsDrivePathToSafe}).
 //
-// Image syntax is intentionally left untouched: harden's "[Image blocked: …]"
-// placeholder is more useful than a broken <img src>.
+// Image destinations are handled by remarkLocalImages, which preserves their
+// original path until the workspace-confined image reader can resolve it.
 
 type MdastNodeLike = {
   type: string

--- a/src/components/ai-elements/remark-local-images.ts
+++ b/src/components/ai-elements/remark-local-images.ts
@@ -1,0 +1,40 @@
+import type { Definition, Image, ImageReference, Root } from "mdast"
+import { SKIP, visit } from "unist-util-visit"
+import { localImagePath } from "@/lib/markdown-local-image"
+
+/** Preserve local Markdown images as inert spans until React can load them
+ * through the workspace-confined reader. Remote images retain the default
+ * sanitize/harden pipeline; no file: or data: protocol is allowed through it. */
+export function remarkLocalImages() {
+  return (tree: Root) => {
+    const definitions = new Map<string, Definition>()
+    visit(tree, "definition", (node) => {
+      const id = node.identifier.toUpperCase()
+      if (!definitions.has(id)) definitions.set(id, node)
+    })
+    const linkedImages = new WeakSet<Image | ImageReference>()
+    visit(tree, ["link", "linkReference"], (node) => {
+      visit(node, ["image", "imageReference"], (image) => {
+        linkedImages.add(image as Image | ImageReference)
+      })
+      return SKIP
+    })
+    visit(tree, ["image", "imageReference"], (node) => {
+      const image = node as Image | ImageReference
+      const source =
+        image.type === "image"
+          ? image.url
+          : definitions.get(image.identifier.toUpperCase())?.url
+      if (!source || !localImagePath(source)) return
+      image.data = {
+        ...image.data,
+        hName: "span",
+        hProperties: {
+          "data-codeg-local-image": source,
+          "data-codeg-image-linked": linkedImages.has(image) ? "true" : "false",
+        },
+        hChildren: [{ type: "text", value: image.alt ?? "" }],
+      }
+    })
+  }
+}

--- a/src/components/ai-elements/remark-local-images.ts
+++ b/src/components/ai-elements/remark-local-images.ts
@@ -1,12 +1,66 @@
-import type { Definition, Image, ImageReference, Root } from "mdast"
+import type { Definition, Image, ImageReference, Node, Root } from "mdast"
 import { SKIP, visit } from "unist-util-visit"
 import { localImagePath } from "@/lib/markdown-local-image"
+
+/** `\` + ASCII punctuation — the escape CommonMark has already applied by the
+ *  time this plugin sees a destination. */
+const ESCAPED_PUNCTUATION = /\\[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/
+
+/**
+ * Where a destination can START inside a node's source: past the first `](`
+ * (an inline image) or `]:` (a reference definition). The FIRST match on
+ * purpose — a `](` inside the label, which only a code span can produce, makes
+ * this start too early, and starting early only widens the region checked
+ * below. Starting late is what would be unsound.
+ */
+function destinationStart(raw: string): number {
+  for (let i = 0; i + 1 < raw.length; i += 1) {
+    if (raw[i] === "]" && (raw[i + 1] === "(" || raw[i + 1] === ":")) {
+      return i + 2
+    }
+  }
+  return 0
+}
+
+/**
+ * True when the destination may have lost separators to that escape, and so
+ * must not be resolved.
+ *
+ * Every Windows segment starting with punctuation eats its own separator:
+ * `C:\repo\shots\.preview.png` parses as `C:\repo\shots.preview.png`. Usually
+ * that just points nowhere — but the glued form is still INSIDE the root, so
+ * if `shots.preview.png` happens to exist we would silently render a different
+ * file under the alt text of the one the agent named. `[Image blocked: …]` had
+ * no such failure mode, so refusing is the floor for replacing it. The parsed
+ * destination alone cannot reveal this: eating the only backslash
+ * (`shots\.preview.png`, or a mixed `C:/repo/shots\.preview.png`) leaves
+ * nothing behind to key on.
+ *
+ * `remarkRestoreWindowsPaths` repairs link destinations but deliberately not
+ * image ones (an mdast image keeps its label as the `alt` STRING and has no
+ * children, so nothing in the tree says where the label ends and the
+ * destination would have to be guessed). Refusing needs no such guess — an
+ * over-wide region only refuses more — so this asks the weaker question: does
+ * the escape occur anywhere from the earliest possible destination onward?
+ * Everything before that point, which is the label, is ignored, so the common
+ * `![a \* b](./shot.png)` still resolves. What it over-refuses is an escape in
+ * the TITLE, or a cosmetic one in the destination itself (`./my\_file.png`);
+ * both are rare and both degrade to the alt text this replaced.
+ */
+function separatorMayBeLost(node: Node, document: string): boolean {
+  const start = node.position?.start?.offset
+  const end = node.position?.end?.offset
+  if (typeof start !== "number" || typeof end !== "number") return true
+  const raw = document.slice(start, end)
+  return ESCAPED_PUNCTUATION.test(raw.slice(destinationStart(raw)))
+}
 
 /** Preserve local Markdown images as inert spans until React can load them
  * through the workspace-confined reader. Remote images retain the default
  * sanitize/harden pipeline; no file: or data: protocol is allowed through it. */
 export function remarkLocalImages() {
-  return (tree: Root) => {
+  return (tree: Root, file: unknown) => {
+    const document = String(file)
     const definitions = new Map<string, Definition>()
     visit(tree, "definition", (node) => {
       const id = node.identifier.toUpperCase()
@@ -21,11 +75,15 @@ export function remarkLocalImages() {
     })
     visit(tree, ["image", "imageReference"], (node) => {
       const image = node as Image | ImageReference
-      const source =
+      // A reference image's destination lives in its definition, so that is
+      // also the node whose source has to be free of the escape.
+      const origin: Image | Definition | undefined =
         image.type === "image"
-          ? image.url
-          : definitions.get(image.identifier.toUpperCase())?.url
-      if (!source || !localImagePath(source)) return
+          ? image
+          : definitions.get(image.identifier.toUpperCase())
+      if (!origin?.url || !localImagePath(origin.url)) return
+      const source = origin.url
+      if (separatorMayBeLost(origin, document)) return
       image.data = {
         ...image.data,
         hName: "span",

--- a/src/components/ai-elements/remark-windows-paths.ts
+++ b/src/components/ai-elements/remark-windows-paths.ts
@@ -237,10 +237,9 @@ function labelEndInRaw(node: MdastNode, nodeStart: number): number | null {
  * out of a code span in the alt; either can rewrite a perfectly good REMOTE url
  * and point the image at a different file.
  *
- * There is nothing to gain in exchange: rehype-harden blocks every local image
- * and renders `[Image blocked: …]`, so a repaired local destination is never
- * used, and a remote one has no Windows path in it to repair. This matches the
- * decision already recorded in remark-file-uri-links.
+ * Local images are handled by remarkLocalImages using the parsed destination.
+ * Forward-slash paths and percent-encoded file URIs avoid these ambiguous
+ * backslash escapes without guessing where the image label ends.
  */
 
 /**

--- a/src/components/canvas/canvas-conversation-surface.tsx
+++ b/src/components/canvas/canvas-conversation-surface.tsx
@@ -769,6 +769,12 @@ export function CanvasConversationSurface({
           )}
           <MessageListView
             conversationId={effectiveConversationId}
+            // The card's own cwd, which it already knows before any
+            // conversation row exists — a draft's first reply has no persisted
+            // detail to derive a folder from, so without this its screenshots
+            // stay unresolved until a later refetch. `undefined` (never a
+            // wrong guess) leaves MessageListView's folder fallback in place.
+            imageRoot={workingDir}
             agentType={agentType}
             connStatus={connStatus}
             isActive={isActive}

--- a/src/components/conversations/conversation-detail-panel.tsx
+++ b/src/components/conversations/conversation-detail-panel.tsx
@@ -1950,6 +1950,7 @@ const ConversationTabView = memo(function ConversationTabView({
     <GoalControlProvider value={goalControlValue}>
       <MessageListView
         conversationId={effectiveConversationId}
+        imageRoot={workingDirForConnection ?? null}
         agentType={selectedAgent}
         connStatus={connStatus}
         isActive={isActive}

--- a/src/components/message/image-actions.tsx
+++ b/src/components/message/image-actions.tsx
@@ -90,10 +90,12 @@ export function ImageActions({
   image,
   className,
   children,
+  as: Tag = "div",
 }: {
   image: UserImageDisplay
   className?: string
   children: ReactNode
+  as?: "div" | "span"
 }) {
   const t = useTranslations("Folder.chat.messageList")
   const { canCopy, copy, download } = useImageActions()
@@ -119,7 +121,7 @@ export function ImageActions({
   // without calling preventDefault is what lets it appear.
   if (!canCopy) {
     return (
-      <div
+      <Tag
         data-image-actions=""
         data-image-actions-native=""
         className={className}
@@ -127,21 +129,21 @@ export function ImageActions({
         onPointerDown={stopNonMousePointerDown}
       >
         {children}
-      </div>
+      </Tag>
     )
   }
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div
+        <Tag
           data-image-actions=""
           className={className}
           onContextMenu={stopContextMenu}
           onPointerDown={stopNonMousePointerDown}
         >
           {children}
-        </div>
+        </Tag>
       </ContextMenuTrigger>
       {/* The menu is portaled, but its click still bubbles through the React
           tree to whatever the trigger sits inside — in the preview dialog that

--- a/src/components/message/live-transcript-view.tsx
+++ b/src/components/message/live-transcript-view.tsx
@@ -340,6 +340,12 @@ export function LiveTranscriptView({
       <div className="min-h-0 flex-1">
         <MessageListView
           conversationId={conversationId}
+          // The viewed connection's own cwd. A delegation child runs in a
+          // scratch dir whose folder row this client may not have seen yet
+          // (it is created closed, without a folder-change broadcast), so the
+          // folder lookup would come up empty; `undefined` when there is no
+          // live connection keeps that lookup as the fallback.
+          imageRoot={conn?.workingDir ?? undefined}
           agentType={agentType ?? "claude_code"}
           connStatus={connStatus}
           isActive={false}

--- a/src/components/message/message-list-image-root.test.ts
+++ b/src/components/message/message-list-image-root.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), "utf8")
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(join(process.cwd(), dir), { withFileTypes: true }).flatMap(
+    (entry) => {
+      const path = `${dir}/${entry.name}`
+      if (entry.isDirectory()) return sourceFiles(path)
+      return entry.name.endsWith(".tsx") && !entry.name.includes(".test.")
+        ? [path]
+        : []
+    }
+  )
+}
+
+/**
+ * Every transcript surface must hand `MessageListView` the cwd it renders
+ * Markdown images against.
+ *
+ * `MessageListView` falls back to the path of the folder its persisted detail
+ * names, but that fallback is strictly weaker than what each host already
+ * knows: a canvas draft's first reply has no persisted detail at all, and a
+ * delegation child runs in a scratch dir whose folder row is created closed
+ * and without a `folder://changed` broadcast, so it is missing from this
+ * client's `allFolders`. In both cases the fallback yields null and the
+ * transcript's local screenshots never load.
+ *
+ * Passing `undefined` is how a host opts back INTO the fallback — this asks
+ * only that the decision was made, not which way it went.
+ */
+const SURFACES = [
+  "src/components/conversations/conversation-detail-panel.tsx",
+  "src/components/canvas/canvas-conversation-surface.tsx",
+  "src/components/message/live-transcript-view.tsx",
+]
+
+describe("MessageListView image root", () => {
+  it("is decided by every surface that mounts a transcript", () => {
+    // The list is derived, not maintained by hand: a new mount fails here
+    // until it is added — and adding it forces the `imageRoot` decision below.
+    const mounts = sourceFiles("src/components").filter((path) =>
+      read(path).includes("<MessageListView")
+    )
+    expect(mounts.sort()).toEqual([...SURFACES].sort())
+  })
+
+  it.each(SURFACES)("%s passes an imageRoot", (path) => {
+    const source = read(path)
+    const start = source.indexOf("<MessageListView")
+    expect(start).toBeGreaterThan(-1)
+    // One mount per surface today; a second would need its own decision, so
+    // assert that rather than silently checking only the first.
+    expect(source.indexOf("<MessageListView", start + 1)).toBe(-1)
+    const openingTag = source.slice(start, source.indexOf("/>", start))
+    expect(openingTag).toMatch(/\bimageRoot=/)
+  })
+})

--- a/src/components/message/message-list-view.tsx
+++ b/src/components/message/message-list-view.tsx
@@ -80,9 +80,13 @@ import type { MessageScrollContextValue } from "@/components/message/message-scr
 import { extractSessionFilesGrouped } from "@/lib/session-files"
 import { unescapeComposerText } from "@/lib/composer-copy-text"
 import { useStickToBottomContext } from "use-stick-to-bottom"
+import { useAppWorkspaceStore } from "@/stores/app-workspace-store"
+import { MarkdownImageProvider } from "@/components/ai-elements/markdown-local-image"
 
 interface MessageListViewProps {
   conversationId: number
+  /** This transcript's working directory, including new-chat drafts. */
+  imageRoot?: string | null
   agentType: AgentType
   connStatus?: ConnectionStatus | null
   isActive?: boolean
@@ -1022,6 +1026,7 @@ const AutoScrollOnSend = memo(function AutoScrollOnSend({
 
 export function MessageListView({
   conversationId,
+  imageRoot,
   agentType,
   connStatus,
   isActive = true,
@@ -1057,6 +1062,11 @@ export function MessageListView({
   // (windowed detail with a non-zero offset). Legacy full responses never
   // report an offset, so the loader row and near-top trigger stay off.
   const detail = session?.detail ?? null
+  const imageFolderId = detail?.summary.folder_id
+  const storedImageRoot = useAppWorkspaceStore(
+    (s) =>
+      s.allFolders.find((folder) => folder.id === imageFolderId)?.path ?? null
+  )
   const hasOlderTurns = isWindowedDetail(detail) && detail.turns_offset > 0
   const loadingOlderTurns = session?.loadingOlderTurns ?? false
   const { loadOlderTurns } = useConversationRuntimeActions()
@@ -1560,7 +1570,7 @@ export function MessageListView({
     )
   }
 
-  return (
+  const thread = (
     // The "查看会话" drawers are hosted HERE, not in the cards that offer them:
     // those live in virtua's rows and take their drawer down with them when
     // they scroll out of the buffer. This is the nearest ancestor that owns
@@ -1600,14 +1610,14 @@ export function MessageListView({
           />
         )}
         {/* Shared overlay stack pinned to the inline-start edge (top-left in LTR,
-          top-right in RTL). A flex column keeps the order stable regardless of
-          each panel's expand/collapse height: the message navigator first, then
-          the plan panel, then the sub-agent panel. Empty panels render null and
-          collapse out. Positioning lives here (not in the child overlays); the
-          chips are "bullets" — flat on the start side (flush to the pinned
-          edge), rounded on the end side — that expand toward the inline-end on
-          hover. Logical `start-0` + `items-start` keep the anchor and the bullet
-          on the same side, so the whole stack mirrors cleanly in RTL. */}
+        top-right in RTL). A flex column keeps the order stable regardless of
+        each panel's expand/collapse height: the message navigator first, then
+        the plan panel, then the sub-agent panel. Empty panels render null and
+        collapse out. Positioning lives here (not in the child overlays); the
+        chips are "bullets" — flat on the start side (flush to the pinned
+        edge), rounded on the end side — that expand toward the inline-end on
+        hover. Logical `start-0` + `items-start` keep the anchor and the bullet
+        on the same side, so the whole stack mirrors cleanly in RTL. */}
         <div className="pointer-events-none absolute start-0 top-4 z-20 flex max-w-[min(22rem,calc(100%-2rem))] flex-col items-start gap-2">
           {showMessageNav && userMessageCount > 0 && (
             <ConversationMessageNav
@@ -1640,5 +1650,13 @@ export function MessageListView({
         />
       </div>
     </SessionViewerHost>
+  )
+
+  return (
+    <MarkdownImageProvider
+      rootPath={imageRoot === undefined ? storedImageRoot : imageRoot}
+    >
+      {thread}
+    </MarkdownImageProvider>
   )
 }

--- a/src/lib/markdown-local-image.test.ts
+++ b/src/lib/markdown-local-image.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  createLocalImageLoader,
+  LOCAL_IMAGE_MAX_BYTES,
+  localImagePath,
+  resolveLocalImage,
+} from "./markdown-local-image"
+
+describe("local Markdown image paths", () => {
+  it.each([
+    ["/repo/images/plot.png", "/repo", "images/plot.png"],
+    ["./images/plot.png", "/repo", "images/plot.png"],
+    ["images/plot.png", "/repo", "images/plot.png"],
+    ["file:///repo/images/plot.png", "/repo", "images/plot.png"],
+    ["C:/My Project/_tmp/plot.png", "C:/My Project", "_tmp/plot.png"],
+    ["/C:/My%20Project/_tmp/plot.png", "C:/My Project", "_tmp/plot.png"],
+    ["c:\\MY PROJECT\\images\\plot.png", "C:/My Project", "images/plot.png"],
+    [
+      "file:///C:/My%20Project/images/plot.png",
+      "C:/My Project",
+      "images/plot.png",
+    ],
+    [
+      "file://server/share/project/plot.png",
+      "//server/share/project",
+      "plot.png",
+    ],
+    ["/repo/%E5%9B%BE%23%3F.png?v=2#preview", "/repo", "图#?.png"],
+    ["./images/../plot.svg", "/repo", "plot.svg"],
+    ["/plot.avif", "/", "plot.avif"],
+    ["C:/plot.png", "C:/", "plot.png"],
+  ])("resolves %s under %s", (source, root, path) => {
+    expect(resolveLocalImage(source, root)?.path).toBe(path)
+  })
+
+  it.each([
+    "https://example.com/image.png",
+    "//example.com/image.png",
+    "data:image/svg+xml;base64,AAAA",
+    "javascript:alert(1).png",
+    "blob:https://example.com/image.png",
+    "http%3A%2F%2Fexample.com/image.png",
+    "C:relative.png",
+    "file:///repo/plot.png:secret.png",
+    "/repo/%00.png",
+    "/repo/%zz.png",
+    "\\\\?\\C:\\repo\\plot.png",
+  ])("does not turn %s into a local image", (source) => {
+    expect(localImagePath(source)).toBeNull()
+  })
+
+  it.each([
+    ["../secret.png", "/repo"],
+    ["..\\secret.png", "C:/repo"],
+    ["images/%2e%2e/%2e%2e/secret.png", "/repo"],
+    ["/repo-other/secret.png", "/repo"],
+    ["/Repo/secret.png", "/repo"],
+    ["file:///private/secret.png", "/repo"],
+    ["D:/repo/secret.png", "C:/repo"],
+    ["file://other/share/secret.png", "//server/share"],
+    ["plot.png", ""],
+    ["plot.png", "relative/root"],
+    ["config.json", "/repo"],
+  ])("refuses an image outside its transcript: %s", (source, root) => {
+    expect(resolveLocalImage(source, root)).toBeNull()
+  })
+})
+
+describe("local image reads", () => {
+  it("deduplicates in-flight reads, but re-reads a later screenshot at the same path", async () => {
+    let finish!: (data: string) => void
+    const read = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          finish = resolve
+        })
+    )
+    const load = createLocalImageLoader("/repo", read)
+    const first = load("preview.png")
+    expect(load("preview.png")).toBe(first)
+    expect(read).toHaveBeenCalledWith(
+      "/repo",
+      "preview.png",
+      LOCAL_IMAGE_MAX_BYTES
+    )
+    finish("Zmlyc3Q=")
+    expect(await first).toBe("Zmlyc3Q=")
+    const second = load("preview.png")
+    expect(read).toHaveBeenCalledTimes(2)
+    finish("c2Vjb25k")
+    expect(await second).toBe("c2Vjb25k")
+  })
+
+  it("limits concurrent reads and releases slots after a failed read", async () => {
+    const finishes: Array<(data: string) => void> = []
+    let rejectFirst!: (reason: Error) => void
+    const read = vi.fn(
+      () =>
+        new Promise<string>((resolve, reject) => {
+          finishes.push(resolve)
+          rejectFirst ||= reject
+        })
+    )
+    const load = createLocalImageLoader("/repo", read)
+    const pending = Array.from({ length: 7 }, (_, i) => load(`${i}.png`))
+    expect(read).toHaveBeenCalledTimes(4)
+    rejectFirst(new Error("missing"))
+    expect(await pending[0]).toBeNull()
+    expect(read).toHaveBeenCalledTimes(5)
+    for (let i = 1; i < pending.length; i += 1) {
+      finishes[i]("cGljdHVyZQ==")
+      await pending[i]
+    }
+    expect(read).toHaveBeenCalledTimes(7)
+  })
+
+  it("bounds returned data and handles empty or refused reads without throwing", async () => {
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce(
+        "A".repeat(Math.ceil(LOCAL_IMAGE_MAX_BYTES / 3) * 4 + 1)
+      )
+      .mockResolvedValueOnce("")
+      .mockRejectedValueOnce(new Error("outside workspace root"))
+    const load = createLocalImageLoader("/repo", read)
+    expect(await load("large.png")).toBeNull()
+    expect(await load("empty.png")).toBeNull()
+    expect(await load("symlink.png")).toBeNull()
+  })
+})

--- a/src/lib/markdown-local-image.ts
+++ b/src/lib/markdown-local-image.ts
@@ -1,0 +1,110 @@
+import { isAbsoluteFilePath } from "@/lib/file-path-display"
+import { isPathUnderRoot, normalizeAbsPath } from "@/lib/file-open-target"
+
+const IMAGE_MIMES: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  gif: "image/gif",
+  svg: "image/svg+xml",
+  avif: "image/avif",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+}
+
+export const LOCAL_IMAGE_MAX_BYTES = 8 * 1024 * 1024
+
+/** Recognize file references before rehype-harden changes their destinations. */
+export function localImagePath(source: string): string | null {
+  let path = source.trim()
+  if (!path || path.startsWith("//") || path.startsWith("#")) return null
+  if (/^[\\/]{2}[?.][\\/]/.test(path)) return null
+  if (/^file:/i.test(path)) {
+    try {
+      const url = new URL(path)
+      path = url.host ? `//${url.host}${url.pathname}` : url.pathname
+    } catch {
+      return null
+    }
+  } else {
+    // A drive letter is a path, not a URI scheme. Drive-relative C:foo is
+    // deliberately excluded because it depends on process-global state.
+    if (/^[a-z][a-z\d+.-]*:/i.test(path) && !/^[a-z]:[\\/]/i.test(path)) {
+      return null
+    }
+    path = path.split(/[?#]/, 1)[0]
+  }
+  try {
+    path = decodeURIComponent(path)
+  } catch {
+    return null
+  }
+  if (/[\u0000-\u001f\u007f]/.test(path)) return null
+  path = path.replace(/\\/g, "/")
+  // Reject device paths and NTFS alternate data streams as well as schemes
+  // hidden behind percent encoding. Only the drive-designator colon is valid.
+  if (/^\/\/[?.]\//.test(path) || /:/.test(path.replace(/^\/?[a-z]:\//i, ""))) {
+    return null
+  }
+  return path
+}
+
+export function resolveLocalImage(source: string, rootPath: string) {
+  const path = localImagePath(source)
+  const root = normalizeAbsPath(rootPath)
+  if (!path || !isAbsoluteFilePath(root)) return null
+  const extension = path.split(".").pop()?.toLowerCase() ?? ""
+  if (!Object.prototype.hasOwnProperty.call(IMAGE_MIMES, extension)) return null
+  const absolute = normalizeAbsPath(
+    isAbsoluteFilePath(path) ? path : `${root}/${path}`
+  )
+  if (!isPathUnderRoot(absolute, root)) return null
+  const prefix = root.endsWith("/") ? root : `${root}/`
+  return {
+    path: absolute.slice(prefix.length),
+    name: absolute.slice(absolute.lastIndexOf("/") + 1),
+    mime: IMAGE_MIMES[absolute.split(".").pop()!.toLowerCase()],
+  }
+}
+
+export type LocalImageReader = (
+  root: string,
+  relativePath: string,
+  maxBytes: number
+) => Promise<string>
+
+/** Per-transcript queue: bound IO and deduplicate in-flight reads, without
+ * retaining historical image bytes or serving stale screenshots after edits. */
+export function createLocalImageLoader(root: string, read: LocalImageReader) {
+  const pending = new Map<string, Promise<string | null>>()
+  const waiting: Array<() => void> = []
+  let active = 0
+
+  return (path: string): Promise<string | null> => {
+    const existing = pending.get(path)
+    if (existing) return existing
+    const load = async () => {
+      if (active >= 4)
+        await new Promise<void>((resolve) => waiting.push(resolve))
+      else active += 1
+      try {
+        // The backend canonicalizes the path and checks symlink confinement.
+        const data = await read(root, path, LOCAL_IMAGE_MAX_BYTES)
+        return data && data.length <= Math.ceil(LOCAL_IMAGE_MAX_BYTES / 3) * 4
+          ? data
+          : null
+      } catch {
+        return null
+      } finally {
+        pending.delete(path)
+        const next = waiting.shift()
+        if (next) next()
+        else active -= 1
+      }
+    }
+    const result = load()
+    pending.set(path, result)
+    return result
+  }
+}

--- a/src/lib/markdown-local-image.ts
+++ b/src/lib/markdown-local-image.ts
@@ -64,7 +64,9 @@ export function resolveLocalImage(source: string, rootPath: string) {
   return {
     path: absolute.slice(prefix.length),
     name: absolute.slice(absolute.lastIndexOf("/") + 1),
-    mime: IMAGE_MIMES[absolute.split(".").pop()!.toLowerCase()],
+    // The extension already checked above, not a second derivation from
+    // `absolute` — those agree today, but only one of them was validated.
+    mime: IMAGE_MIMES[extension],
   }
 }
 


### PR DESCRIPTION
Local screenshot paths in assistant Markdown currently render as `Image blocked` placeholders. This displays workspace images inline and opens them in the existing image viewer with copy and download actions.

Relative paths, absolute Windows/POSIX paths, file URIs, and reference images use the existing workspace-confined reader. Each transcript owns its image root, including inactive tabs and embedded sessions. Reads are limited to 8 MiB and four concurrent requests; Markdown's URL sanitization stays in place.

Frontend CI passes: 6,283 tests, lint, and the static export build. Browser checks cover inline display, the image viewer, light/dark themes, and a 360px layout.
