### PR TITLE
fix: leave a record when the process panics, and harden the paths that can panic unattended

### DIFF
--- a/src-tauri/src/acp/session_state.rs
+++ b/src-tauri/src/acp/session_state.rs
@@ -1843,7 +1843,14 @@ pub(crate) fn background_keepalive_max_age() -> chrono::Duration {
         std::env::var("CODEG_ACP_BACKGROUND_KEEPALIVE_MAX_SECS")
             .ok()
             .and_then(|v| v.trim().parse::<i64>().ok())
-            .filter(|v| *v >= 0)
+            // `chrono::Duration::seconds` below is an `expect` over
+            // `try_seconds`, so it PANICS past `i64::MAX / 1000`. This value is
+            // read on the 60-second idle sweep and on every background-watch
+            // tick, so an out-of-range env value would abort the process from a
+            // timer with nobody at the keyboard, and a panic there leaves no
+            // trace of which setting caused it. Out of range is invalid input
+            // like any other, so it takes the documented default.
+            .filter(|v| *v >= 0 && chrono::Duration::try_seconds(*v).is_some())
             .unwrap_or(3600)
     });
     chrono::Duration::seconds(secs)

--- a/src-tauri/src/chat_channel/backends/telegram.rs
+++ b/src-tauri/src/chat_channel/backends/telegram.rs
@@ -632,6 +632,31 @@ fn redact_token(msg: String, token: &str) -> String {
     }
 }
 
+/// Byte offset of the first case-insensitive `at_bot` in `text`, or `None`.
+///
+/// Searches `text` itself, so the offset it returns is a real byte offset into
+/// `text`. Searching a `to_lowercase()` copy instead is what this used to do,
+/// and it is unsound: lowercasing is not length preserving, so one character
+/// before the mention silently shifts every later offset. `İ` (U+0130, two
+/// bytes) lowercases to two code points (three bytes), the Kelvin sign `K`
+/// (three bytes) lowercases to `k` (one byte), and `ẞ` (three bytes) lowercases
+/// to `ß` (two). Slicing `text` at an offset found that way then lands in the
+/// middle of a character, or past the end, and panics.
+///
+/// `eq_ignore_ascii_case` is the whole comparison because a Telegram bot
+/// username is ASCII by definition (letters, digits and underscores, ending in
+/// `bot`), so there is no non-ASCII folding to do on the needle.
+///
+/// `str::get` rather than indexing: it answers `None` for an end offset that is
+/// out of range or not on a character boundary, which is exactly the case that
+/// used to panic.
+fn find_bot_mention(text: &str, at_bot: &str) -> Option<usize> {
+    text.char_indices().map(|(i, _)| i).find(|&i| {
+        text.get(i..i + at_bot.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(at_bot))
+    })
+}
+
 /// Strip `@bot_username` from text (case-insensitive).
 /// Handles Telegram convention: `/command@botname args` → `/command args`
 fn strip_bot_mention(text: &str, bot_username: &str) -> String {
@@ -639,15 +664,16 @@ fn strip_bot_mention(text: &str, bot_username: &str) -> String {
         return text.to_string();
     }
     let at_bot = format!("@{}", bot_username);
-    let text_lower = text.to_lowercase();
-    let at_bot_lower = at_bot.to_lowercase();
-    if let Some(pos) = text_lower.find(&at_bot_lower) {
-        let mut result = String::with_capacity(text.len());
-        result.push_str(&text[..pos]);
-        result.push_str(&text[pos + at_bot.len()..]);
-        result.trim().to_string()
-    } else {
-        text.to_string()
+    match find_bot_mention(text, &at_bot) {
+        // `find_bot_mention` only reports an offset whose end is a character
+        // boundary, so both slices below are in range and aligned.
+        Some(pos) => {
+            let mut result = String::with_capacity(text.len());
+            result.push_str(&text[..pos]);
+            result.push_str(&text[pos + at_bot.len()..]);
+            result.trim().to_string()
+        }
+        None => text.to_string(),
     }
 }
 
@@ -728,7 +754,10 @@ fn telegram_should_process_text_message(
     }
 
     let at_bot = format!("@{}", bot_username);
-    text.to_lowercase().contains(&at_bot.to_lowercase())
+    // Same matcher `strip_bot_mention` uses, so a mention this accepts is one
+    // that will actually be stripped, and neither allocates a lowercased copy
+    // of every group message on the long-poll path.
+    find_bot_mention(text, &at_bot).is_some()
 }
 
 fn json_scalar_to_string(value: &serde_json::Value) -> Option<String> {
@@ -964,6 +993,60 @@ mod tests {
             "codeg_bot",
             false
         ));
+    }
+
+    #[test]
+    fn strip_bot_mention_removes_the_mention_in_either_case() {
+        assert_eq!(
+            strip_bot_mention("/task@codeg_bot build", "codeg_bot"),
+            "/task build"
+        );
+        assert_eq!(
+            strip_bot_mention("/task@CodeG_Bot build", "codeg_bot"),
+            "/task build"
+        );
+        assert_eq!(strip_bot_mention("/task build", "codeg_bot"), "/task build");
+        assert_eq!(strip_bot_mention("/task@codeg_bot", ""), "/task@codeg_bot");
+    }
+
+    /// The long-poll loop runs unattended, and any member of a bound group
+    /// chooses the text it parses. Finding the mention in a `to_lowercase()`
+    /// copy and then slicing the original panicked on every case below, because
+    /// lowercasing is not length preserving: `İ` grows by a byte, `K` shrinks
+    /// by two, `ẞ` shrinks by one. The offsets then land mid character or past
+    /// the end of the string.
+    #[test]
+    fn strip_bot_mention_survives_text_whose_lowercase_is_a_different_length() {
+        // capital I with dot above, 2 bytes -> 3
+        assert_eq!(
+            strip_bot_mention("\u{130}@codeg_bot hi", "codeg_bot"),
+            "\u{130} hi"
+        );
+        // Kelvin sign, 3 bytes -> 1
+        assert_eq!(
+            strip_bot_mention("\u{212A}@codeg_bot hi", "codeg_bot"),
+            "\u{212A} hi"
+        );
+        // capital sharp s, 3 bytes -> 2
+        assert_eq!(
+            strip_bot_mention("\u{1E9E}@codeg_bot hi", "codeg_bot"),
+            "\u{1E9E} hi"
+        );
+        // Enough drift to run the old offset off the end of the string.
+        assert_eq!(
+            strip_bot_mention("\u{130}\u{130}@codeg_bot", "codeg_bot"),
+            "\u{130}\u{130}"
+        );
+        assert_eq!(
+            strip_bot_mention("\u{212A}\u{212A}@codeg_bot x", "codeg_bot"),
+            "\u{212A}\u{212A} x"
+        );
+        // A mention whose tail is a wide character is not a mention, and
+        // deciding that must not slice through the character.
+        assert_eq!(
+            strip_bot_mention("@codeg_bo\u{65E5}", "codeg_bot"),
+            "@codeg_bo\u{65E5}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/chat_channel/command_dispatcher.rs
+++ b/src-tauri/src/chat_channel/command_dispatcher.rs
@@ -25,7 +25,17 @@ const CONFIG_CACHE_TTL_SECS: u64 = 30;
 struct CommandConfigCache {
     prefix: String,
     lang: Lang,
-    last_refresh: Instant,
+    /// `None` until the first refresh, which is what forces one.
+    ///
+    /// This used to be a plain `Instant` seeded with
+    /// `Instant::now() - Duration::from_secs(TTL + 1)`, which is a panic, not a
+    /// saturating subtraction: `Sub<Duration> for Instant` is a `checked_sub`
+    /// plus `expect`. On Windows an `Instant` is the QPC reading, i.e. time
+    /// since boot, so starting codeg inside the first 31 seconds of a boot
+    /// aborted the process here. codeg ships an autostart plugin, so launching
+    /// at login is an ordinary case, and this runs inside a long-lived spawned
+    /// task with nobody at the keyboard.
+    last_refresh: Option<Instant>,
 }
 
 impl CommandConfigCache {
@@ -34,12 +44,15 @@ impl CommandConfigCache {
             prefix: DEFAULT_COMMAND_PREFIX.to_string(),
             lang: Lang::default(),
             // Force refresh on first use
-            last_refresh: Instant::now() - Duration::from_secs(CONFIG_CACHE_TTL_SECS + 1),
+            last_refresh: None,
         }
     }
 
     async fn refresh_if_needed(&mut self, db: &DatabaseConnection) {
-        if self.last_refresh.elapsed() < Duration::from_secs(CONFIG_CACHE_TTL_SECS) {
+        if self
+            .last_refresh
+            .is_some_and(|at| at.elapsed() < Duration::from_secs(CONFIG_CACHE_TTL_SECS))
+        {
             return;
         }
 
@@ -50,7 +63,7 @@ impl CommandConfigCache {
             self.lang = Lang::from_str_lossy(&val);
         }
 
-        self.last_refresh = Instant::now();
+        self.last_refresh = Some(Instant::now());
     }
 }
 

--- a/src-tauri/src/chat_channel/event_subscriber.rs
+++ b/src-tauri/src/chat_channel/event_subscriber.rs
@@ -76,7 +76,17 @@ struct EventConfigCache {
     /// feed as IM channels, but are not debounced and ignore the per-channel
     /// filter (an automation consumer wants the complete stream).
     webhooks: Vec<String>,
-    last_refresh: Instant,
+    /// `None` until the first clean refresh, which is what forces one.
+    ///
+    /// This used to be a plain `Instant` seeded with
+    /// `Instant::now() - Duration::from_secs(TTL + 1)`, which is a panic, not a
+    /// saturating subtraction: `Sub<Duration> for Instant` is a `checked_sub`
+    /// plus `expect`. On Windows an `Instant` is the QPC reading, i.e. time
+    /// since boot, so starting codeg inside the first 31 seconds of a boot
+    /// aborted the process here. codeg ships an autostart plugin, so launching
+    /// at login is an ordinary case, and this runs inside a long-lived spawned
+    /// task with nobody at the keyboard.
+    last_refresh: Option<Instant>,
     /// Value of `EVENT_CONFIG_EPOCH` at the last refresh; a mismatch forces an
     /// immediate refresh even within the TTL window.
     last_epoch: u64,
@@ -92,7 +102,7 @@ impl EventConfigCache {
             enabled_channels: Vec::new(),
             webhooks: Vec::new(),
             // Force refresh on first use
-            last_refresh: Instant::now() - Duration::from_secs(CONFIG_CACHE_TTL_SECS + 1),
+            last_refresh: None,
             last_epoch: 0,
         }
     }
@@ -113,7 +123,9 @@ impl EventConfigCache {
         // pending and the cached global_filter may already be out of date.
         let config_changed = epoch != self.last_epoch;
         if !config_changed
-            && self.last_refresh.elapsed() < Duration::from_secs(CONFIG_CACHE_TTL_SECS)
+            && self
+                .last_refresh
+                .is_some_and(|at| at.elapsed() < Duration::from_secs(CONFIG_CACHE_TTL_SECS))
         {
             return;
         }
@@ -191,7 +203,7 @@ impl EventConfigCache {
         // TTL elapses. The other reads above already keep-prior / fail-closed on
         // their own errors, so re-reading them while retrying is harmless.
         if filter_ok {
-            self.last_refresh = Instant::now();
+            self.last_refresh = Some(Instant::now());
             self.last_epoch = epoch;
         }
     }
@@ -526,7 +538,7 @@ mod permission_push_tests {
                 event_filter_json: None,
             }],
             webhooks: Vec::new(),
-            last_refresh: Instant::now(),
+            last_refresh: Some(Instant::now()),
             last_epoch: 0,
         }
     }
@@ -1409,7 +1421,7 @@ mod permission_push_tests {
         app_metadata_service::upsert_value(&db.conn, EVENT_FILTER_KEY, "{corrupt")
             .await
             .unwrap();
-        config.last_refresh = Instant::now() - Duration::from_secs(CONFIG_CACHE_TTL_SECS + 1);
+        config.last_refresh = None;
         config.refresh_with_epoch(&db.conn, EPOCH).await;
 
         assert!(

--- a/src-tauri/src/logging/budget.rs
+++ b/src-tauri/src/logging/budget.rs
@@ -85,20 +85,29 @@ fn unix_day() -> i32 {
     unix_day_from_secs(secs)
 }
 
+/// The name `tracing_appender` gives the `Rotation::DAILY` file covering `now`:
+/// `{prefix}.{%Y-%m-%d}.{suffix}`.
+///
+/// Shared, because two things other than the appender need to name that exact
+/// file and neither may drift from it: [`resume_point`] measures it, and
+/// [`crate::logging::panic_hook`] appends a crash record to it synchronously.
+pub fn daily_file_name(prefix: &str, suffix: &str, now: chrono::DateTime<chrono::Utc>) -> String {
+    format!("{prefix}.{}.{suffix}", now.format("%Y-%m-%d"))
+}
+
 /// What a fresh [`BudgetedWriter`] must resume from: the current UTC day, and
 /// how many bytes that day's file already holds.
 ///
 /// The filename is reconstructed the way `tracing_appender` builds it for
-/// `Rotation::DAILY` — `{prefix}.{%Y-%m-%d}.{suffix}` — from the *same* instant
-/// as the day number, so the two can't disagree across a midnight boundary. A
-/// missing or unreadable file reads as `0`: a restart that can't measure the file
-/// gets a full ceiling, which is the pre-existing behavior and strictly safer
-/// than refusing to log.
+/// `Rotation::DAILY` (see [`daily_file_name`]) from the *same* instant as the
+/// day number, so the two can't disagree across a midnight boundary. A missing
+/// or unreadable file reads as `0`: a restart that can't measure the file gets
+/// a full ceiling, which is the pre-existing behavior and strictly safer than
+/// refusing to log.
 pub fn resume_point(dir: &Path, prefix: &str, suffix: &str) -> (i32, u64) {
     let now = chrono::Utc::now();
     let day = unix_day_from_secs(now.timestamp());
-    let name = format!("{prefix}.{}.{suffix}", now.format("%Y-%m-%d"));
-    let existing = std::fs::metadata(dir.join(name))
+    let existing = std::fs::metadata(dir.join(daily_file_name(prefix, suffix, now)))
         .map(|m| m.len())
         .unwrap_or(0);
     (day, existing)
@@ -727,6 +736,21 @@ mod tests {
         assert_eq!(
             unix_day_from_secs(midnight.timestamp()),
             unix_day_from_secs(before.timestamp()) + 1
+        );
+    }
+
+    /// Two readers now reconstruct this name (the budget's resume measurement
+    /// and the panic hook's synchronous append), so the scheme is pinned rather
+    /// than left implicit in each of them.
+    #[test]
+    fn daily_file_name_matches_the_appenders_scheme() {
+        let day = chrono::DateTime::parse_from_rfc3339("2026-09-09T19:26:25Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert_eq!(daily_file_name("codeg", "log", day), "codeg.2026-09-09.log");
+        assert_eq!(
+            daily_file_name("codeg-server", "log", day),
+            "codeg-server.2026-09-09.log"
         );
     }
 

--- a/src-tauri/src/logging/init.rs
+++ b/src-tauri/src/logging/init.rs
@@ -474,6 +474,10 @@ fn init_file_writer(dir: &Path, prefix: &str) -> Option<(NonBlocking, WorkerGuar
         day,
         already_written,
     );
+    // Tell the panic hook which file to append its record to. Recorded only now
+    // that the appender exists, so the name it reconstructs is the file being
+    // written and the directory is known to have been created above.
+    crate::logging::panic_hook::set_log_file(dir, prefix, LOG_FILE_SUFFIX);
     Some(tracing_appender::non_blocking(budgeted))
 }
 
@@ -535,6 +539,13 @@ fn build_subscriber(
             None
         }
     };
+
+    // Last here, because the hook logs through the subscriber that was just
+    // installed. Early everywhere else: every binary builds its subscriber
+    // through this one function, so this single call covers the desktop app,
+    // the server, `codeg-mcp`, the supervisor and the credential helper, and it
+    // runs before any of them does real work.
+    crate::logging::panic_hook::install();
 
     (reload_handle, guard)
 }

--- a/src-tauri/src/logging/mod.rs
+++ b/src-tauri/src/logging/mod.rs
@@ -14,11 +14,15 @@
 //! - [`budget`] caps how much the file sink may write per day, so no log
 //!   firehose can fill the user's disk before the next rotation.
 //! - [`throttle`] collapses bursts of a near-duplicate line to one per window.
+//! - [`panic_hook`] makes a panic leave a record behind instead of a silent
+//!   abort, writing it to the file sink synchronously so it survives the death
+//!   of the process.
 
 pub mod budget;
 pub mod hub;
 pub mod init;
 pub mod layer;
+pub mod panic_hook;
 pub mod throttle;
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/logging/panic_hook.rs
+++ b/src-tauri/src/logging/panic_hook.rs
@@ -1,0 +1,435 @@
+//! The last thing a dying process gets to say.
+//!
+//! Without a hook, a Rust panic leaves **nothing** behind. On Windows the
+//! runtime's `abort()` raises `STATUS_STACK_BUFFER_OVERRUN` (`0xc0000409`), so
+//! all the user has is a Windows Error Reporting `BEX64` bucket naming
+//! `codeg.exe`, and the rolling log simply stops mid-file: no message, no
+//! location, no backtrace, nothing that names the code that failed. A report of
+//! exactly that shape (0.30.6, faulting module `codeg.exe`, exception
+//! `0xc0000409`, and a log whose last line predates the crash by days) is why
+//! this module exists.
+//!
+//! The hook writes **twice**, in this order, because the two writes fail in
+//! different ways:
+//!
+//! 1. **A synchronous append to today's rolling log file.** This is the write
+//!    that has to survive, and it is the reason this module is more than a
+//!    `tracing::error!`. The file sink is a `tracing_appender::non_blocking`
+//!    writer: an event only pushes its formatted bytes onto a crossbeam channel
+//!    and a *separate worker thread* does the writing. That writer's
+//!    `io::Write::flush` is a documented no-op (`non_blocking.rs` in
+//!    tracing-appender 0.2.5 returns `Ok(())` and nothing else), the sender is
+//!    lossy by default (`try_send`, silently dropped when the queue is full),
+//!    and the only real flush is `WorkerGuard::drop`, which this hook must not
+//!    do: tokio catches panics in spawned tasks, so most panics do not end the
+//!    process and tearing down the log writer would blind everything after.
+//!    A process that aborts before that worker thread is next scheduled loses
+//!    the line. Writing the record here removes the race.
+//! 2. **A `tracing::error!`**, so the same record also reaches stderr, the
+//!    in-app Logs viewer's ring buffer, and its live tail.
+//!
+//! Then the previously installed hook runs, so the standard
+//! `thread '...' panicked at ...` line still prints and anything the runtime
+//! installed still fires.
+//!
+//! Nothing in here may panic: a panic inside a panic hook aborts the process
+//! immediately and takes the record with it. Every fallible step is best
+//! effort, and there is no `unwrap` on this path.
+
+use std::backtrace::Backtrace;
+use std::io::Write;
+use std::panic::PanicHookInfo;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Tracing target for the panic record.
+///
+/// Deliberately **not** the module path, even though `tracing` would default to
+/// it. The `TARGET_BACKSTOPS` table in [`crate::logging::init`] pins
+/// `codeg_lib::logging` to `Off` so the logging stack cannot log about itself,
+/// and a record emitted from `codeg_lib::logging::panic_hook` would inherit
+/// that and be filtered out before it reached any sink. It is also the string a
+/// user greps their log for, so it should name the event and not the plumbing.
+pub const PANIC_TARGET: &str = "codeg_lib::panic";
+
+/// Ceiling on the payload text carried in the record.
+///
+/// A panic message is normally one line; a formatted `assert_eq!` over two
+/// large values is not. Bounded so one record cannot itself become the log
+/// storm that [`crate::logging::budget`] exists to prevent.
+const MAX_PAYLOAD_BYTES: usize = 4 * 1024;
+
+/// Ceiling on the captured backtrace.
+///
+/// Deep enough for every frame that matters (the panicking function and its
+/// callers sit at the top) and small enough that the whole record stays a
+/// single modest write, which is what keeps the append atomic in practice
+/// against the appender thread writing to the same file.
+const MAX_BACKTRACE_BYTES: usize = 16 * 1024;
+
+/// One captured panic.
+///
+/// Split out from the hook itself so the formatting is testable without
+/// killing a test process: everything below takes a `PanicReport` rather than
+/// a `PanicHookInfo`, which can only exist inside a real panic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PanicReport {
+    /// Thread name and id, e.g. `tokio-runtime-worker (ThreadId(7))`. The name
+    /// is what says whether this was the UI thread, a tokio worker, or one of
+    /// the detached OS threads.
+    pub thread: String,
+    /// `file:line:column` of the panic, or a placeholder when the runtime did
+    /// not record one.
+    pub location: String,
+    /// The panic message.
+    pub payload: String,
+    /// A backtrace captured at the panic site.
+    pub backtrace: String,
+}
+
+impl PanicReport {
+    /// The one-line human summary: the tracing event's message, and the
+    /// `message` field of the JSON line.
+    pub fn summary(&self) -> String {
+        format!(
+            "panic in thread '{}' at {}: {}",
+            self.thread, self.location, self.payload
+        )
+    }
+
+    /// The record as **one** JSON line, in the same shape the file sink's
+    /// `fmt::layer().json()` writes (`timestamp` / `level` / `fields` /
+    /// `target`), so a reader of the file sees one uniform stream. One line,
+    /// not several, so the worst case if the appender thread writes
+    /// concurrently is two interleaved records rather than a mangled report.
+    ///
+    /// Ends with the newline that makes it a line.
+    pub fn json_line(&self, timestamp: &str) -> String {
+        let value = serde_json::json!({
+            "timestamp": timestamp,
+            "level": "ERROR",
+            "fields": {
+                "message": self.summary(),
+                "thread": self.thread,
+                "location": self.location,
+                "payload": self.payload,
+                "version": env!("CARGO_PKG_VERSION"),
+                "backtrace": self.backtrace,
+            },
+            "target": PANIC_TARGET,
+        });
+        format!("{value}\n")
+    }
+}
+
+/// Where the rolling file sink writes, so the hook can append to the same file.
+///
+/// Recorded by [`set_log_file`] once the appender it describes has been built.
+/// Absent in the stderr-only modes (`codeg-mcp`, the `--supervise` supervisor,
+/// the credential helper), which have no file to append to; there the hook
+/// still emits its `tracing::error!` and stderr carries the record.
+static FILE_SINK: OnceLock<FileSink> = OnceLock::new();
+
+struct FileSink {
+    dir: PathBuf,
+    prefix: String,
+    suffix: &'static str,
+}
+
+/// Record where the daily log file lives.
+///
+/// Called by [`crate::logging::init`] only after the appender was built
+/// successfully, so the directory is known to exist and the name reconstructed
+/// from these parts is the file actually being written.
+pub(crate) fn set_log_file(dir: &Path, prefix: &str, suffix: &'static str) {
+    let _ = FILE_SINK.set(FileSink {
+        dir: dir.to_path_buf(),
+        prefix: prefix.to_string(),
+        suffix,
+    });
+}
+
+/// Install the hook, chaining to whatever was installed before.
+///
+/// Idempotent: the first call wins, so the repeated subscriber init in
+/// subprocess modes cannot stack hooks on top of each other.
+///
+/// Called from [`crate::logging::init`] as the last step of building the
+/// subscriber, which makes it the earliest point at which a panic record has
+/// somewhere to go. Every binary reaches it, since all five entry points build
+/// their subscriber through that one function.
+pub fn install() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    if INSTALLED.set(()).is_err() {
+        return;
+    }
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        write_report(&capture(info));
+        // Chain, so the standard `thread '...' panicked at ...` line still
+        // prints and anything the runtime installed still runs.
+        previous(info);
+    }));
+}
+
+/// Build the report for a panic in flight.
+fn capture(info: &PanicHookInfo<'_>) -> PanicReport {
+    let thread = std::thread::current();
+    PanicReport {
+        thread: format!(
+            "{} ({:?})",
+            thread.name().unwrap_or("<unnamed>"),
+            thread.id()
+        ),
+        location: match info.location() {
+            Some(l) => format!("{}:{}:{}", l.file(), l.line(), l.column()),
+            None => "<unknown location>".to_string(),
+        },
+        payload: truncate(&payload_text(info), MAX_PAYLOAD_BYTES),
+        // Forced, rather than left to `RUST_BACKTRACE`. A user who is about to
+        // file a crash report has not set that variable, and a panic record
+        // without a backtrace does not name the code that panicked, which is
+        // the entire question being asked. Cost is paid once, at death.
+        backtrace: truncate(&Backtrace::force_capture().to_string(), MAX_BACKTRACE_BYTES),
+    }
+}
+
+/// Write the report to both sinks.
+fn write_report(report: &PanicReport) {
+    // Durable first. See the module docs for why the tracing sink alone can
+    // lose this line when the process is seconds from aborting.
+    append_to_log_file(report);
+    tracing::error!(
+        target: PANIC_TARGET,
+        thread = %report.thread,
+        location = %report.location,
+        version = env!("CARGO_PKG_VERSION"),
+        backtrace = %report.backtrace,
+        "{}",
+        report.summary()
+    );
+}
+
+/// The panic payload as text.
+///
+/// `panic!`, `assert!` and friends produce a `&str` or a `String`. A
+/// `panic_any` with some other type has no textual form, so it is named rather
+/// than guessed at.
+fn payload_text(info: &PanicHookInfo<'_>) -> String {
+    let payload = info.payload();
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+/// `s` capped at `max` bytes, cut on a character boundary, with a marker
+/// naming the full length so a truncated record never reads as a complete one.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}... [truncated, {} bytes total]", &s[..end], s.len())
+}
+
+/// Append the record to today's rolling log file, if there is one.
+fn append_to_log_file(report: &PanicReport) {
+    let Some(sink) = FILE_SINK.get() else {
+        return;
+    };
+    let now = chrono::Utc::now();
+    append_line(
+        &sink.dir,
+        &sink.prefix,
+        sink.suffix,
+        now,
+        &report.json_line(&now.to_rfc3339_opts(chrono::SecondsFormat::Micros, true)),
+    );
+}
+
+/// Append `line` to the daily file covering `now`, best effort.
+///
+/// Takes the location explicitly rather than reading the global, so the write
+/// is testable against a temporary directory.
+///
+/// Every step is deliberately swallowed: this runs inside a panic hook, where
+/// a second panic aborts immediately and loses the very record being written.
+fn append_line(
+    dir: &Path,
+    prefix: &str,
+    suffix: &str,
+    now: chrono::DateTime<chrono::Utc>,
+    line: &str,
+) {
+    let path = dir.join(crate::logging::budget::daily_file_name(prefix, suffix, now));
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let _ = file.write_all(line.as_bytes());
+        let _ = file.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The record's target must escape the `codeg_lib::logging=off` backstop
+    /// that every constructed filter carries. Emitting from the module path
+    /// would land inside it and silently drop the one line the hook exists to
+    /// write, with no symptom other than the original silence.
+    #[test]
+    fn the_panic_target_escapes_the_logging_backstop() {
+        assert!(
+            !PANIC_TARGET.starts_with("codeg_lib::logging"),
+            "{PANIC_TARGET} would be filtered out by the logging backstop"
+        );
+        // And it is still a well-formed target, so the Settings UI and
+        // CODEG_LOG can name it.
+        assert!(PANIC_TARGET
+            .split("::")
+            .all(|seg| !seg.is_empty()
+                && seg.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')));
+    }
+
+    fn sample() -> PanicReport {
+        PanicReport {
+            thread: "tokio-runtime-worker (ThreadId(7))".into(),
+            location: "src/acp/idle_sweep.rs:42:9".into(),
+            payload: "called `Option::unwrap()` on a `None` value".into(),
+            backtrace: "0: codeg_lib::acp::idle_sweep::sweep".into(),
+        }
+    }
+
+    #[test]
+    fn summary_names_the_thread_the_location_and_the_payload() {
+        let summary = sample().summary();
+        assert!(summary.contains("tokio-runtime-worker"), "{summary}");
+        assert!(summary.contains("src/acp/idle_sweep.rs:42:9"), "{summary}");
+        assert!(summary.contains("Option::unwrap()"), "{summary}");
+    }
+
+    #[test]
+    fn json_line_is_one_parseable_line_carrying_the_backtrace() {
+        let line = sample().json_line("2026-09-09T19:26:25.000000Z");
+        assert!(line.ends_with('\n'), "the record must be a whole line");
+        assert_eq!(
+            line.matches('\n').count(),
+            1,
+            "one line, so a concurrent appender write can at worst interleave \
+             two records instead of mangling this one: {line}"
+        );
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(line.trim_end()).expect("valid JSON line");
+        assert_eq!(parsed["level"], "ERROR");
+        assert_eq!(parsed["target"], PANIC_TARGET);
+        assert_eq!(parsed["timestamp"], "2026-09-09T19:26:25.000000Z");
+        assert_eq!(parsed["fields"]["backtrace"], sample().backtrace);
+        assert_eq!(parsed["fields"]["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["fields"]["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("idle_sweep.rs:42:9")));
+    }
+
+    #[test]
+    fn truncate_keeps_short_input_and_marks_what_it_dropped() {
+        assert_eq!(truncate("short", 64), "short");
+        let long = "x".repeat(200);
+        let cut = truncate(&long, 32);
+        assert!(cut.starts_with(&"x".repeat(32)), "{cut}");
+        assert!(cut.contains("truncated"), "{cut}");
+        assert!(
+            cut.contains("200"),
+            "the marker names the full length: {cut}"
+        );
+    }
+
+    #[test]
+    fn truncate_never_splits_a_character() {
+        // A 3-byte character straddling the cap must be dropped whole, not
+        // sliced into invalid UTF-8 (which would panic inside the panic hook).
+        let s = "aa\u{4f60}\u{597d}";
+        for max in 0..s.len() {
+            let cut = truncate(s, max);
+            assert!(cut.is_char_boundary(0), "{cut}");
+        }
+        assert!(truncate(s, 3).starts_with("aa"));
+    }
+
+    #[test]
+    fn append_line_creates_todays_file_and_appends_to_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = chrono::Utc::now();
+        append_line(dir.path(), "codeg", "log", now, "first\n");
+        append_line(dir.path(), "codeg", "log", now, "second\n");
+
+        let name = crate::logging::budget::daily_file_name("codeg", "log", now);
+        let body = std::fs::read_to_string(dir.path().join(name)).expect("record written");
+        assert_eq!(body, "first\nsecond\n");
+    }
+
+    #[test]
+    fn append_line_swallows_a_bad_destination_instead_of_panicking() {
+        // A panic here would abort the process outright, so an unwritable
+        // location has to be a no-op.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no").join("such").join("dir");
+        append_line(&missing, "codeg", "log", chrono::Utc::now(), "dropped\n");
+    }
+
+    /// The capture path, exercised against a real panic. `PanicHookInfo` cannot
+    /// be constructed outside one, so this installs a hook of its own (not
+    /// [`install`], which is process-global and permanent) and unwinds into it.
+    #[test]
+    fn a_real_panic_yields_payload_location_and_backtrace() {
+        use std::sync::{Arc, Mutex};
+
+        let captured: Arc<Mutex<Option<PanicReport>>> = Arc::new(Mutex::new(None));
+        let sink = captured.clone();
+        // Only record this thread's panic: `cargo test` runs tests in parallel,
+        // and a `should_panic` test elsewhere would otherwise land here.
+        let want = std::thread::current().id();
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if std::thread::current().id() == want {
+                if let Ok(mut slot) = sink.lock() {
+                    *slot = Some(capture(info));
+                }
+            }
+        }));
+        let unwound = std::panic::catch_unwind(|| panic!("boom {}", 7));
+        std::panic::set_hook(previous);
+
+        assert!(unwound.is_err(), "the closure must have panicked");
+        let report = captured
+            .lock()
+            .ok()
+            .and_then(|mut slot| slot.take())
+            .expect("the hook ran");
+        assert_eq!(report.payload, "boom 7");
+        assert!(
+            report.location.contains("panic_hook.rs"),
+            "location must name the panic site: {}",
+            report.location
+        );
+        assert!(
+            !report.backtrace.is_empty(),
+            "the backtrace is forced, so it must be present without RUST_BACKTRACE"
+        );
+        assert!(
+            report.thread.contains("ThreadId"),
+            "the thread id identifies which task died: {}",
+            report.thread
+        );
+    }
+}

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -492,9 +492,18 @@ impl TerminalManager {
         infos
     }
 
+    /// Poison-tolerant, unlike the command-driven accessors above: this one and
+    /// [`Self::kill_all`] are called from inside Tauri's `on_window_event` and
+    /// `RunEvent::ExitRequested` handlers, which run on the main thread inside
+    /// the platform event loop. A panic there unwinds across an `extern
+    /// "system"` boundary, which Rust turns into an immediate `abort` (Windows
+    /// reports that as `0xc0000409`), so an unrelated earlier panic that merely
+    /// poisoned this mutex would take the whole process down at the next window
+    /// close. The map is a plain `HashMap` that cannot be left half-updated, so
+    /// there is nothing for the poison flag to protect.
     pub fn kill_by_owner_window(&self, owner_window_label: &str) -> usize {
         let mut instances = {
-            let mut terminals = self.terminals.lock().unwrap();
+            let mut terminals = self.terminals.lock().unwrap_or_else(|p| p.into_inner());
             let ids: Vec<String> = terminals
                 .iter()
                 .filter_map(|(id, instance)| {
@@ -522,9 +531,11 @@ impl TerminalManager {
         killed
     }
 
+    /// Poison-tolerant for the reason given on [`Self::kill_by_owner_window`]:
+    /// the quit path runs inside `RunEvent::ExitRequested` on the main thread.
     pub fn kill_all(&self) -> usize {
         let mut instances: Vec<TerminalInstance> = {
-            let mut terminals = self.terminals.lock().unwrap();
+            let mut terminals = self.terminals.lock().unwrap_or_else(|p| p.into_inner());
             terminals.drain().map(|(_, inst)| inst).collect()
         };
         let killed = instances.len();
@@ -602,8 +613,15 @@ fn read_loop(
         }
     }
 
-    // Terminal exited — remove from map and clean up temp files
-    if let Some(mut instance) = terminals.lock().unwrap().remove(&terminal_id) {
+    // Terminal exited — remove from map and clean up temp files. Poison-tolerant
+    // like the scrollback lock above: this runs on the long-lived `pty-reader-*`
+    // thread, and refusing the removal would leak the entry and its temp files
+    // for the rest of the process.
+    if let Some(mut instance) = terminals
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .remove(&terminal_id)
+    {
         cleanup_temp_files(&mut instance.temp_files);
     }
 

--- a/src-tauri/src/work_task/engine.rs
+++ b/src-tauri/src/work_task/engine.rs
@@ -6780,12 +6780,18 @@ async fn outstanding_instruction(
 struct LaunchSeq(std::sync::Mutex<Option<i32>>);
 
 impl LaunchSeq {
+    // Poison-tolerant, matching the locks in `office_watch` and
+    // `background_watch`. The guarded value is a plain `Option<i32>` that
+    // cannot be left half-written, so a panic elsewhere in the launch has
+    // nothing to corrupt here, while `expect` would turn that unrelated panic
+    // into a permanent failure of every later launch. The schedule tick reaches
+    // this with nobody at the keyboard.
     fn set(&self, run_seq: i32) {
-        *self.0.lock().expect("launch seq mutex") = Some(run_seq);
+        *self.0.lock().unwrap_or_else(|p| p.into_inner()) = Some(run_seq);
     }
 
     fn get(&self) -> Option<i32> {
-        *self.0.lock().expect("launch seq mutex")
+        *self.0.lock().unwrap_or_else(|p| p.into_inner())
     }
 }
 
@@ -6808,7 +6814,11 @@ impl DispatchSignal {
     }
 
     fn fire(&self, result: Result<(), String>) {
-        let sender = self.0.lock().expect("dispatch signal mutex").take();
+        // Poison-tolerant for the same reason as `LaunchSeq`: the fire-once
+        // guarantee is the `take()`, not the lock's poison flag, and refusing
+        // to fire after an unrelated panic would leave the caller waiting on a
+        // oneshot that is never sent.
+        let sender = self.0.lock().unwrap_or_else(|p| p.into_inner()).take();
         if let Some(sender) = sender {
             let _ = sender.send(result);
         }


### PR DESCRIPTION
A codeg 0.30.6 desktop process died on Windows with exception `0xc0000409`
(STATUS_STACK_BUFFER_OVERRUN), faulting module `codeg.exe`, and a matching
Windows Error Reporting `BEX64` bucket. It had logged nothing: `~/.codeg/logs/`
held a `codeg.2026-09-05.log` with content, a zero-byte `codeg.2026-09-06.log`,
no file at all for 09-07 or 09-08, and a `codeg.2026-09-09.log` that begins at
19:26:25 UTC with "Applying all pending migrations", which is the relaunch a
few seconds after the crash. So the process ran for days, sat idle, and
vanished without a message.

`0xc0000409` on Windows is what Rust's `abort()` raises, and `panic = "abort"`
is not set here, so the likely shapes are a panic unwinding across an
`extern "system"` boundary (the tao/wry event loop, a WndProc, a WebView2
callback) or a stack overflow. I have not proven which, and this PR does not
claim to have found the panic site. It makes the next one leave evidence, and
fixes the unattended paths I could show were reachable.

## The hook

`logging::panic_hook` installs a `std::panic::set_hook` from `build_subscriber`,
so all five entry points get it (desktop, `codeg-server`, `codeg-mcp`, the
`--supervise` supervisor, the credential helper) before any of them does real
work. It records the payload, the thread name and id, `file:line:column`, the
app version, and a backtrace from `Backtrace::force_capture()` rather than
`RUST_BACKTRACE`, which nobody filing a crash report has set. It then chains to
the previous hook, so the standard `thread '...' panicked at ...` line still
prints.

Getting that to disk needed more than `tracing::error!`. The file sink is a
`tracing_appender::non_blocking` writer, so an event is only pushed onto a
crossbeam channel for a separate worker thread. That writer's
`io::Write::flush` is a no-op, the sender is lossy by default (`try_send`,
dropped when the queue is full), and the only real flush is
`WorkerGuard::drop`, which the hook must not do, because tokio catches panics
in spawned tasks and tearing the log writer down would blind everything after.
A process that aborts before the worker is next scheduled loses the line. So
the hook appends the record to today's rolling file itself, synchronously, as
one JSON line in the same shape the file sink writes, and only then emits the
tracing event for stderr, the ring buffer and the Logs viewer.

Two details worth a review eye. The event uses an explicit target of
`codeg_lib::panic`, because `TARGET_BACKSTOPS` pins `codeg_lib::logging` to
`off` and a record inheriting the module path would be filtered out before any
sink saw it; there is a test for that. And the daily filename now comes from
one shared `budget::daily_file_name`, so the budget's resume measurement and
the hook's append cannot drift apart.

Note this catches a panic, including one that later aborts at an FFI boundary,
and a panic tokio swallows in a spawned task. It does not catch a stack
overflow, where Windows raises the same exception code with no panic involved.

## The idle-path fixes

`strip_bot_mention` found `@botname` in `text.to_lowercase()` and then sliced
the original `text` at that offset. Lowercasing is not length preserving, so a
single character before the mention desynchronises the two: U+0130 grows from
two bytes to three, the Kelvin sign U+212A shrinks from three to one. The slice
lands mid character or past the end and panics, and this text comes from any
member of a bound group chat, parsed by the unattended `getUpdates` long-poll
loop. Of the five cases in the new test, four panicked and the fifth silently
stripped the wrong bytes.

Both chat-channel config caches forced their first refresh with
`Instant::now() - Duration::from_secs(TTL + 1)`. That is a `checked_sub` plus
`expect`, not a saturating subtraction, and on Windows an `Instant` is the QPC
reading measured from system boot, so starting inside the first 31 seconds of a
boot panicked there. codeg ships an autostart plugin, so login start is an
ordinary case. `last_refresh` is now `Option<Instant>`.

`background_keepalive_max_age` built its `chrono::Duration` with
`Duration::seconds`, an `expect` over `try_seconds` that panics past
`i64::MAX / 1000`. It is read on the 60-second ACP idle sweep and on every
background-watch tick, so an out-of-range
`CODEG_ACP_BACKGROUND_KEEPALIVE_MAX_SECS` aborted from a timer. Out of range
now takes the documented default.

`LaunchSeq` and `DispatchSignal` in the work-task engine, and
`TerminalManager::kill_by_owner_window` / `kill_all` / the PTY read loop's final
removal, used panicking locks. None guards a value that can be left
half-written. The terminal ones matter most: they are called from inside
`on_window_event` and `RunEvent::ExitRequested`, on the main thread inside the
platform event loop, where a panic is an abort rather than a failed operation.
They now use the poison-tolerant form already used in `office_watch` and
`background_watch`.

## Not changed, but worth knowing

`spawn_pet_hover_watcher` polls `outer_position()`, `outer_size()` and
`cursor_position()` every 80 ms for as long as the pet window is open. Each of
those is a round trip to the main thread, where `tauri-runtime-wry`'s
`handle_user_message` answers with `tx.send(..).unwrap()`. If the requesting
task is gone by the time the main thread gets there, that unwrap panics on the
main thread inside the message pump, which is an abort. That is roughly a
million round trips a day with nobody present, and it is the only thing in the
process polling the windowing layer on a timer. Its own doc comment says the
polling exists because macOS does not deliver mouse events to non-key windows,
yet it runs everywhere. I did not touch it because I cannot test the hover
behaviour on each platform, but if the hook comes back pointing at
`handle_user_message`, that loop is where to look. It may also be relevant to
#393.

Main has not shipped anything in this area: 0.30.6 is still the latest release,
there is no `set_hook` anywhere in the tree, and I found no existing crash
reporting design to fit into. Happy to reshape any of this if you have one in
mind.

## Verification

Rust tests are new unit tests in the existing style: the hook's target,
summary, JSON line, truncation and file append, a real panic driven through
`catch_unwind` to check payload, location and backtrace capture, the shared
daily filename, and the Telegram mention cases. Extracted pure-logic versions
of the hook's formatting and the mention matcher were compiled and run locally
against stable 1.98; the full suite and clippy are left to CI. No frontend
changes.
