### PR TITLE
fix(import): group an imported worktree session under its repo

### DIFF
--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -988,8 +988,8 @@ pub(crate) async fn import_selected_from_summaries(
                 // off — the sort above put every plain folder ahead of every
                 // worktree precisely so this lands in time. Only plain folders
                 // are recorded: a linked worktree is never anyone's main working
-                // tree. `add_folder` left an existing row's `parent_id` alone, so
-                // the flattening rule is the seed's, applied to the row as read.
+                // tree. The candidate is flattened by the seed's rule, off the
+                // parent this row actually ended up with.
                 if root_key.is_none() {
                     let root = persisted_parent_id.unwrap_or(folder_id);
                     worktree_parents.insert(norm_key, root);

--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -532,6 +532,30 @@ fn index_folder_rows(rows: &[ScanFolderRow]) -> HashMap<String, &ScanFolderRow> 
     index
 }
 
+/// The folder id an imported session's cwd should hang off, or `None` to leave
+/// the folder top-level.
+///
+/// `Some` only when the cwd is a linked git worktree AND its main working tree
+/// is a folder codeg already knows: grouping under a repo the user never opened
+/// would invent a workspace row, and a non-worktree cwd is top-level by
+/// definition.
+fn worktree_parent_folder_id(
+    path: &str,
+    folder_index: &HashMap<String, &ScanFolderRow>,
+) -> Option<i32> {
+    let root = crate::git_repo::main_worktree_root(std::path::Path::new(path))?;
+    let row = folder_index.get(&normalize_path_for_matching(&root.to_string_lossy()))?;
+    // A soft-deleted repo renders nowhere, and a child of it would render
+    // nowhere either, which is worse than the top-level folder the user gets
+    // today.
+    if row.deleted {
+        return None;
+    }
+    // A main working tree is never itself a linked worktree, so there is no
+    // parent chain to flatten here the way `open_worktree_folder_core` does.
+    Some(row.id)
+}
+
 /// Pure grouping/reconciliation for the import-picker scan.
 /// `imported_index` maps `(agent_type_db_str, external_id)` → "a live row
 /// exists" (false = only soft-deleted rows).
@@ -822,10 +846,23 @@ pub(crate) async fn import_selected_from_summaries(
         // resilient (per-row failures are counted, never aborting the group), so
         // a partial failure still commits and reports its good rows and still
         // broadcasts the folder it created.
-        match folder_service::add_folder(conn, &target_path)
-            .await
-            .map_err(AppCommandError::from)
-        {
+        //
+        // A cwd that is a linked worktree of an already-open repo goes in as a
+        // CHILD of that repo, the way `open_worktree_folder_core` records one.
+        // Plain `add_folder` leaves `parent_id` NULL, which is exactly the
+        // sidebar's test for "top-level folder", so the same worktree lands
+        // beside its repo instead of under it (and the branch-label backfill,
+        // which selects on `parent_id IS NOT NULL`, never reaches it). Falling
+        // back to `add_folder` when nothing resolves keeps `ParentWrite::Preserve`
+        // for every other case, so a reopen can never demote a folder that a
+        // worktree open already parented. See issue #552.
+        let add = match worktree_parent_folder_id(&target_path, &folder_index) {
+            Some(parent_id) => {
+                folder_service::add_folder_with_parent(conn, &target_path, Some(parent_id)).await
+            }
+            None => folder_service::add_folder(conn, &target_path).await,
+        };
+        match add.map_err(AppCommandError::from) {
             Ok(entry) => {
                 let folder_id = entry.id;
                 // `DeletedPolicy::Restore`: every item here is a session the
@@ -5297,6 +5334,168 @@ mod tests {
         let convs = conversation::Entity::find().all(&db.conn).await.unwrap();
         assert_eq!(convs.len(), 2);
         assert!(convs.iter().all(|c| c.folder_id == folder_rows[0].id));
+    }
+
+    // A session whose cwd is a linked git worktree of an open repo belongs
+    // UNDER that repo. `parent_id` is exactly the sidebar's test for "worktree
+    // of" versus "one more top-level folder", and the branch-label backfill
+    // selects on it too, so leaving it NULL strands the folder twice. #552.
+    #[tokio::test]
+    async fn batch_import_nests_a_worktree_cwd_under_its_repo() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+        let repo_id = seed_folder(&db, &repo.to_string_lossy()).await;
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        let result = import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        assert_eq!(result.imported, 1);
+        let rows = crate::db::entities::folder::Entity::find()
+            .all(&db.conn)
+            .await
+            .unwrap();
+        let worktree_row = rows
+            .iter()
+            .find(|r| r.id != repo_id)
+            .expect("worktree folder row");
+        assert_eq!(
+            worktree_row.parent_id,
+            Some(repo_id),
+            "imported worktree must group under the repo it belongs to"
+        );
+    }
+
+    // Grouping under a repo codeg has never opened would invent a workspace row
+    // the user did not ask for, so an unknown repo leaves the folder top-level.
+    #[tokio::test]
+    async fn batch_import_leaves_a_worktree_top_level_when_its_repo_is_unopened() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (_repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        let rows = crate::db::entities::folder::Entity::find()
+            .all(&db.conn)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].parent_id, None);
+    }
+
+    // A soft-deleted repo renders nowhere, so a child of it would render
+    // nowhere either. Top-level is the better of the two.
+    #[tokio::test]
+    async fn batch_import_leaves_a_worktree_top_level_when_its_repo_is_deleted() {
+        use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, Set};
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+        let repo_id = seed_folder(&db, &repo.to_string_lossy()).await;
+
+        let row = crate::db::entities::folder::Entity::find_by_id(repo_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut active = row.into_active_model();
+        active.deleted_at = Set(Some(chrono::Utc::now()));
+        active.is_open = Set(false);
+        active.update(&db.conn).await.unwrap();
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        let rows = crate::db::entities::folder::Entity::find()
+            .all(&db.conn)
+            .await
+            .unwrap();
+        let worktree_row = rows
+            .iter()
+            .find(|r| r.id != repo_id)
+            .expect("worktree folder row");
+        assert_eq!(worktree_row.parent_id, None);
+    }
+
+    // The fallback stays on `add_folder`'s Preserve semantics, so re-importing
+    // into a folder a worktree open already parented cannot demote it, not even
+    // when the directory is gone from disk and resolves to nothing.
+    #[tokio::test]
+    async fn batch_import_preserves_a_recorded_worktree_parent() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let repo_id = seed_folder(&db, "/tmp/proj-repo").await;
+        folder_service::add_folder_with_parent(&db.conn, "/tmp/proj-wt", Some(repo_id))
+            .await
+            .expect("seed worktree folder");
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some("/tmp/proj-wt"),
+            at(0),
+        )];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        let rows = crate::db::entities::folder::Entity::find()
+            .all(&db.conn)
+            .await
+            .unwrap();
+        let worktree_row = rows
+            .iter()
+            .find(|r| r.path == "/tmp/proj-wt")
+            .expect("worktree folder row");
+        assert_eq!(worktree_row.parent_id, Some(repo_id));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -496,6 +496,10 @@ struct ScanFolderRow {
     path: String,
     name: String,
     deleted: bool,
+    /// The root folder this row was registered under, when it is a worktree
+    /// child. Only [`worktree_parent_folder_ids`] reads it — to flatten the
+    /// same way `open_worktree_folder_core` does.
+    parent_id: Option<i32>,
 }
 
 async fn load_folder_rows(
@@ -514,6 +518,7 @@ async fn load_folder_rows(
             path: f.path,
             name: f.name,
             deleted: f.deleted_at.is_some(),
+            parent_id: f.parent_id,
         })
         .collect())
 }
@@ -532,28 +537,44 @@ fn index_folder_rows(rows: &[ScanFolderRow]) -> HashMap<String, &ScanFolderRow> 
     index
 }
 
-/// The folder id an imported session's cwd should hang off, or `None` to leave
-/// the folder top-level.
+/// The main working tree an imported session's cwd belongs to, as a
+/// [`normalize_path_for_matching`] key — `None` when the cwd is not a linked git
+/// worktree (a plain repo, a submodule, a directory that is gone), which is
+/// top-level by definition.
 ///
-/// `Some` only when the cwd is a linked git worktree AND its main working tree
-/// is a folder codeg already knows: grouping under a repo the user never opened
-/// would invent a workspace row, and a non-worktree cwd is top-level by
-/// definition.
-fn worktree_parent_folder_id(
-    path: &str,
-    folder_index: &HashMap<String, &ScanFolderRow>,
-) -> Option<i32> {
+/// Resolving the ROOT rather than a folder id keeps the "is this a worktree"
+/// question separate from "is that repo a folder codeg has", which the importer
+/// answers later and against folders it may not have created yet.
+fn worktree_root_key(path: &str) -> Option<String> {
     let root = crate::git_repo::main_worktree_root(std::path::Path::new(path))?;
-    let row = folder_index.get(&normalize_path_for_matching(&root.to_string_lossy()))?;
-    // A soft-deleted repo renders nowhere, and a child of it would render
-    // nowhere either, which is worse than the top-level folder the user gets
-    // today.
-    if row.deleted {
-        return None;
-    }
-    // A main working tree is never itself a linked worktree, so there is no
-    // parent chain to flatten here the way `open_worktree_folder_core` does.
-    Some(row.id)
+    let key = normalize_path_for_matching(&root.to_string_lossy());
+    // Nothing may be its own parent: the sidebar drops a self-parented folder
+    // from the top level and then renders it under itself, i.e. nowhere. Only a
+    // corrupt `commondir` can land here, and the guard costs one compare.
+    (key != normalize_path_for_matching(path)).then_some(key)
+}
+
+/// Normalized path → the folder id a linked worktree of that path should hang
+/// off. Seeded from the folder rows on disk; the importer adds the folders it
+/// creates as it goes.
+///
+/// The id is FLATTENED the way `open_worktree_folder_core` flattens: a repo
+/// folder that is itself recorded as somebody's worktree child hands down its
+/// own root. A two-level chain would be worse than no grouping at all — the
+/// sidebar's worktree merge is single-level, so a grandchild's conversations
+/// bucket under a folder that is itself merged away and stop rendering.
+///
+/// Soft-deleted rows are left out: a deleted repo renders nowhere, and a child
+/// of it would render nowhere either, which is worse than the top-level folder
+/// the user gets today.
+fn worktree_parent_folder_ids(
+    folder_index: &HashMap<String, &ScanFolderRow>,
+) -> HashMap<String, i32> {
+    folder_index
+        .iter()
+        .filter(|(_, row)| !row.deleted)
+        .map(|(key, row)| (key.clone(), row.parent_id.unwrap_or(row.id)))
+        .collect()
 }
 
 /// Pure grouping/reconciliation for the import-picker scan.
@@ -821,42 +842,85 @@ pub(crate) async fn import_selected_from_summaries(
     };
     let mut touched_folder_ids: Vec<i32> = Vec::new();
 
-    // Deterministic folder order (normalized path) so results and tests are
-    // stable regardless of HashMap iteration.
-    let mut ordered: Vec<(String, Vec<(AgentType, ConversationSummary)>)> =
-        groups.into_iter().collect();
-    ordered.sort_by(|a, b| a.0.cmp(&b.0));
+    // Resolve every group's target path and worktree root BEFORE importing any
+    // of them, so the order they are imported in can depend on it.
+    struct PendingImport {
+        norm_key: String,
+        target_path: String,
+        created: bool,
+        /// The main working tree of this cwd, when it is a linked worktree —
+        /// a normalized path, not yet a folder id (see [`worktree_root_key`]).
+        root_key: Option<String>,
+        items: Vec<(AgentType, ConversationSummary)>,
+    }
 
-    for (norm_key, items) in ordered {
-        let row = folder_index.get(&norm_key).copied();
-        // Import into the stored row's exact path when one normalize-matches
-        // (see build_scan_result); otherwise the parser cwd creates the folder.
-        let target_path = row.map(|r| r.path.clone()).unwrap_or_else(|| {
-            items[0]
-                .1
-                .folder_path
-                .as_deref()
-                .map(str::trim)
-                .unwrap_or_default()
-                .to_string()
-        });
-        let created = row.map(|r| r.deleted).unwrap_or(true);
+    let mut ordered: Vec<PendingImport> = groups
+        .into_iter()
+        .map(|(norm_key, items)| {
+            let row = folder_index.get(&norm_key).copied();
+            // Import into the stored row's exact path when one normalize-matches
+            // (see build_scan_result); otherwise the parser cwd creates the folder.
+            let target_path = row.map(|r| r.path.clone()).unwrap_or_else(|| {
+                items[0]
+                    .1
+                    .folder_path
+                    .as_deref()
+                    .map(str::trim)
+                    .unwrap_or_default()
+                    .to_string()
+            });
+            PendingImport {
+                created: row.map(|r| r.deleted).unwrap_or(true),
+                root_key: worktree_root_key(&target_path),
+                norm_key,
+                target_path,
+                items,
+            }
+        })
+        .collect();
+
+    // Deterministic folder order (normalized path) so results and tests are
+    // stable regardless of HashMap iteration — but every plain folder is
+    // imported BEFORE any linked worktree, so a repo and a worktree of it
+    // selected in the same run still group. One pass suffices, no topological
+    // sort: a main working tree is never itself a linked worktree, so a repo can
+    // never be waiting on another group. Without the split, whether the two end
+    // up grouped would come down to which of their paths sorts first.
+    ordered.sort_by(|a, b| {
+        a.root_key
+            .is_some()
+            .cmp(&b.root_key.is_some())
+            .then_with(|| a.norm_key.cmp(&b.norm_key))
+    });
+    let mut worktree_parents = worktree_parent_folder_ids(&folder_index);
+
+    for pending in ordered {
+        let PendingImport {
+            norm_key,
+            target_path,
+            created,
+            root_key,
+            items,
+        } = pending;
 
         // `add_folder` is the only fallible step here — `import_summaries` is
         // resilient (per-row failures are counted, never aborting the group), so
         // a partial failure still commits and reports its good rows and still
         // broadcasts the folder it created.
         //
-        // A cwd that is a linked worktree of an already-open repo goes in as a
-        // CHILD of that repo, the way `open_worktree_folder_core` records one.
-        // Plain `add_folder` leaves `parent_id` NULL, which is exactly the
-        // sidebar's test for "top-level folder", so the same worktree lands
-        // beside its repo instead of under it (and the branch-label backfill,
-        // which selects on `parent_id IS NOT NULL`, never reaches it). Falling
-        // back to `add_folder` when nothing resolves keeps `ParentWrite::Preserve`
-        // for every other case, so a reopen can never demote a folder that a
+        // A cwd that is a linked worktree of a repo codeg has goes in as a CHILD
+        // of that repo, the way `open_worktree_folder_core` records one. Plain
+        // `add_folder` leaves `parent_id` NULL, which is exactly the sidebar's
+        // test for "top-level folder", so the same worktree lands beside its
+        // repo instead of under it (and the branch-label backfill, which selects
+        // on `parent_id IS NOT NULL`, never reaches it). Falling back to
+        // `add_folder` when nothing resolves keeps `ParentWrite::Preserve` for
+        // every other case, so a reopen can never demote a folder that a
         // worktree open already parented. See issue #552.
-        let add = match worktree_parent_folder_id(&target_path, &folder_index) {
+        let parent_id = root_key
+            .as_ref()
+            .and_then(|key| worktree_parents.get(key).copied());
+        let add = match parent_id {
             Some(parent_id) => {
                 folder_service::add_folder_with_parent(conn, &target_path, Some(parent_id)).await
             }
@@ -865,6 +929,19 @@ pub(crate) async fn import_selected_from_summaries(
         match add.map_err(AppCommandError::from) {
             Ok(entry) => {
                 let folder_id = entry.id;
+                // This folder can now be the repo a LATER group's worktree hangs
+                // off — the sort above put every plain folder ahead of every
+                // worktree precisely so this lands in time. Only plain folders
+                // are recorded: a linked worktree is never anyone's main working
+                // tree. `add_folder` left an existing row's `parent_id` alone, so
+                // the flattening rule is the seed's, applied to the row as read.
+                if root_key.is_none() {
+                    let root = folder_index
+                        .get(&norm_key)
+                        .and_then(|row| row.parent_id)
+                        .unwrap_or(folder_id);
+                    worktree_parents.insert(norm_key, root);
+                }
                 // `DeletedPolicy::Restore`: every item here is a session the
                 // user explicitly checked in the picker, which badges a
                 // soft-deleted row as such — so a deleted one in this list is a
@@ -5234,12 +5311,14 @@ mod tests {
                 path: "/tmp/proj/".into(),
                 name: "proj-deleted".into(),
                 deleted: true,
+                parent_id: None,
             },
             ScanFolderRow {
                 id: 2,
                 path: "/tmp/proj".into(),
                 name: "proj".into(),
                 deleted: false,
+                parent_id: None,
             },
         ];
         let summaries = vec![scan_summary(
@@ -5264,6 +5343,7 @@ mod tests {
             path: "/tmp/gone".into(),
             name: "gone".into(),
             deleted: true,
+            parent_id: None,
         }];
         let summaries = vec![scan_summary(
             "s1",
@@ -5378,6 +5458,108 @@ mod tests {
             Some(repo_id),
             "imported worktree must group under the repo it belongs to"
         );
+    }
+
+    // Selecting a repo's sessions and one of its worktrees' in the SAME import
+    // is the first-time-import shape, and the repo folder it needs exists by the
+    // time the worktree is written — as long as the two are not imported in
+    // whatever order their paths happen to sort in.
+    #[tokio::test]
+    async fn batch_import_nests_a_worktree_under_a_repo_created_in_the_same_run() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+
+        let summaries = vec![
+            scan_summary("s0", AgentType::Codex, Some(&repo.to_string_lossy()), at(0)),
+            scan_summary(
+                "s1",
+                AgentType::Codex,
+                Some(&worktree.to_string_lossy()),
+                at(1),
+            ),
+        ];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![
+                key_of(AgentType::Codex, "s0"),
+                key_of(AgentType::Codex, "s1"),
+            ],
+        )
+        .await
+        .expect("batch import");
+
+        let rows = crate::db::entities::folder::Entity::find()
+            .all(&db.conn)
+            .await
+            .unwrap();
+        let repo_row = rows
+            .iter()
+            .find(|r| path_eq_for_matching(&r.path, &repo.to_string_lossy()))
+            .expect("repo folder row");
+        let worktree_row = rows
+            .iter()
+            .find(|r| path_eq_for_matching(&r.path, &worktree.to_string_lossy()))
+            .expect("worktree folder row");
+        assert_eq!(repo_row.parent_id, None);
+        assert_eq!(
+            worktree_row.parent_id,
+            Some(repo_row.id),
+            "a repo created earlier in the same run is still the worktree's repo"
+        );
+    }
+
+    // The repo folder a worktree resolves to can itself be recorded as somebody
+    // else's worktree child (`open_worktree_folder_core` writes that whenever the
+    // branch switcher adopts an unregistered checkout). Hanging off it directly
+    // would build a two-level chain, and the sidebar's merge is single-level: the
+    // grandchild's conversations would bucket under a folder that is itself
+    // merged away, and render nowhere. Flatten, exactly as the worktree open does.
+    #[tokio::test]
+    async fn batch_import_flattens_onto_the_repos_own_root() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+        let outer_id = seed_folder(&db, "/tmp/outer-root").await;
+        let repo_id = folder_service::add_folder_with_parent(
+            &db.conn,
+            &repo.to_string_lossy(),
+            Some(outer_id),
+        )
+        .await
+        .expect("seed repo folder")
+        .id;
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        let rows = crate::db::entities::folder::Entity::find()
+            .all(&db.conn)
+            .await
+            .unwrap();
+        let worktree_row = rows
+            .iter()
+            .find(|r| r.id != outer_id && r.id != repo_id)
+            .expect("worktree folder row");
+        assert_eq!(worktree_row.parent_id, Some(outer_id));
     }
 
     // Grouping under a repo codeg has never opened would invent a workspace row

--- a/src-tauri/src/commands/conversations.rs
+++ b/src-tauri/src/commands/conversations.rs
@@ -497,8 +497,8 @@ struct ScanFolderRow {
     name: String,
     deleted: bool,
     /// The root folder this row was registered under, when it is a worktree
-    /// child. Only [`worktree_parent_folder_ids`] reads it — to flatten the
-    /// same way `open_worktree_folder_core` does.
+    /// child. Import reconciliation uses it to flatten and validate new parent
+    /// relationships.
     parent_id: Option<i32>,
 }
 
@@ -554,9 +554,10 @@ fn worktree_root_key(path: &str) -> Option<String> {
     (key != normalize_path_for_matching(path)).then_some(key)
 }
 
-/// Normalized path → the folder id a linked worktree of that path should hang
-/// off. Seeded from the folder rows on disk; the importer adds the folders it
-/// creates as it goes.
+/// Normalized path → the candidate root folder id a linked worktree of that
+/// path should hang off. Seeded from the folder rows on disk; the importer adds
+/// the folders it creates as it goes. The write side separately verifies that
+/// the candidate is still a live top-level row.
 ///
 /// The id is FLATTENED the way `open_worktree_folder_core` flattens: a repo
 /// folder that is itself recorded as somebody's worktree child hands down its
@@ -893,6 +894,24 @@ pub(crate) async fn import_selected_from_summaries(
             .then_with(|| a.norm_key.cmp(&b.norm_key))
     });
     let mut worktree_parents = worktree_parent_folder_ids(&folder_index);
+    // Parent ids are not protected by a foreign key. Restrict new writes to
+    // live top-level rows so a stale/dangling id or a pre-existing parent chain
+    // cannot turn this import into a chain or cycle of its own. Plain folders
+    // selected in this batch join the set after `add_folder` revives them.
+    let mut top_level_parent_ids: HashSet<i32> = folder_rows
+        .iter()
+        .filter(|row| !row.deleted && row.parent_id.is_none())
+        .map(|row| row.id)
+        .collect();
+    // Reparenting a folder that already owns children would make those rows
+    // grandchildren. Track counts through this batch so that operation falls
+    // back to Preserve as well.
+    let mut folder_child_counts: HashMap<i32, usize> = HashMap::new();
+    for row in &folder_rows {
+        if let Some(parent_id) = row.parent_id {
+            *folder_child_counts.entry(parent_id).or_default() += 1;
+        }
+    }
 
     for pending in ordered {
         let PendingImport {
@@ -917,9 +936,25 @@ pub(crate) async fn import_selected_from_summaries(
         // `add_folder` when nothing resolves keeps `ParentWrite::Preserve` for
         // every other case, so a reopen can never demote a folder that a
         // worktree open already parented. See issue #552.
+        let target_row = folder_index.get(&norm_key).copied();
+        let target_folder_id = target_row.map(|row| row.id);
+        let existing_parent_id = target_row.and_then(|row| row.parent_id);
+        let target_has_children = target_folder_id.is_some_and(|folder_id| {
+            folder_child_counts.get(&folder_id).copied().unwrap_or(0) > 0
+        });
         let parent_id = root_key
             .as_ref()
-            .and_then(|key| worktree_parents.get(key).copied());
+            .and_then(|key| worktree_parents.get(key).copied())
+            // A historical top-level worktree can have its main-tree row
+            // recorded underneath it. Flattening through that row points back
+            // at the worktree's own folder id even though their PATHS differ,
+            // so the path-level guard in `worktree_root_key` cannot catch it.
+            .filter(|parent_id| Some(*parent_id) != target_folder_id)
+            .filter(|parent_id| top_level_parent_ids.contains(parent_id))
+            // Moving an existing parent under the repo would strand its current
+            // children one level deeper. Rewriting the same established edge is
+            // harmless; any new edge requires a childless target.
+            .filter(|parent_id| existing_parent_id == Some(*parent_id) || !target_has_children);
         let add = match parent_id {
             Some(parent_id) => {
                 folder_service::add_folder_with_parent(conn, &target_path, Some(parent_id)).await
@@ -929,6 +964,26 @@ pub(crate) async fn import_selected_from_summaries(
         match add.map_err(AppCommandError::from) {
             Ok(entry) => {
                 let folder_id = entry.id;
+                // `add_folder_with_parent` sets the resolved parent; the
+                // fallback `add_folder` preserves an existing row's parent and
+                // inserts a new row at the top level. Keep the safety set in
+                // step with that exact persisted state.
+                let persisted_parent_id = parent_id.or(existing_parent_id);
+                if persisted_parent_id != existing_parent_id {
+                    if let Some(old_parent_id) = existing_parent_id {
+                        if let Some(count) = folder_child_counts.get_mut(&old_parent_id) {
+                            *count = count.saturating_sub(1);
+                        }
+                    }
+                    if let Some(new_parent_id) = persisted_parent_id {
+                        *folder_child_counts.entry(new_parent_id).or_default() += 1;
+                    }
+                }
+                if persisted_parent_id.is_none() {
+                    top_level_parent_ids.insert(folder_id);
+                } else {
+                    top_level_parent_ids.remove(&folder_id);
+                }
                 // This folder can now be the repo a LATER group's worktree hangs
                 // off — the sort above put every plain folder ahead of every
                 // worktree precisely so this lands in time. Only plain folders
@@ -936,10 +991,7 @@ pub(crate) async fn import_selected_from_summaries(
                 // tree. `add_folder` left an existing row's `parent_id` alone, so
                 // the flattening rule is the seed's, applied to the row as read.
                 if root_key.is_none() {
-                    let root = folder_index
-                        .get(&norm_key)
-                        .and_then(|row| row.parent_id)
-                        .unwrap_or(folder_id);
+                    let root = persisted_parent_id.unwrap_or(folder_id);
                     worktree_parents.insert(norm_key, root);
                 }
                 // `DeletedPolicy::Restore`: every item here is a session the
@@ -5560,6 +5612,180 @@ mod tests {
             .find(|r| r.id != outer_id && r.id != repo_id)
             .expect("worktree folder row");
         assert_eq!(worktree_row.parent_id, Some(outer_id));
+    }
+
+    // Before imported worktrees were grouped, one could exist as a top-level
+    // folder while its main working tree was still unregistered. Navigating
+    // from that worktree to a branch checked out in the main tree then recorded
+    // the main-tree row under the worktree. Flattening through that row points
+    // straight back at the import target's own id; refuse it or the sidebar
+    // filters the self-parented folder out completely.
+    #[tokio::test]
+    async fn batch_import_refuses_a_parent_that_flattens_to_the_target() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+        let worktree_id = seed_folder(&db, &worktree.to_string_lossy()).await;
+        let repo_id = folder_service::add_folder_with_parent(
+            &db.conn,
+            &repo.to_string_lossy(),
+            Some(worktree_id),
+        )
+        .await
+        .expect("seed inverted main-tree folder")
+        .id;
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        let result = import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        assert_eq!(result.imported, 1);
+        let worktree_row = crate::db::entities::folder::Entity::find_by_id(worktree_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(worktree_row.parent_id, None);
+        let repo_row = crate::db::entities::folder::Entity::find_by_id(repo_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(repo_row.parent_id, Some(worktree_id));
+    }
+
+    // Historical top-level worktrees can also leave a longer inverted chain.
+    // If the main-tree row points at a folder whose own parent is the import
+    // target, using that one-hop "root" would create a two-node cycle. Only an
+    // actual live top-level row is safe to write as a new parent.
+    #[tokio::test]
+    async fn batch_import_refuses_a_flattened_parent_that_is_itself_a_child() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+        let worktree_id = seed_folder(&db, &worktree.to_string_lossy()).await;
+        let middle_id = folder_service::add_folder_with_parent(
+            &db.conn,
+            &root.join("middle").to_string_lossy(),
+            Some(worktree_id),
+        )
+        .await
+        .expect("seed middle folder")
+        .id;
+        let repo_id = folder_service::add_folder_with_parent(
+            &db.conn,
+            &repo.to_string_lossy(),
+            Some(middle_id),
+        )
+        .await
+        .expect("seed chained main-tree folder")
+        .id;
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        let worktree_row = crate::db::entities::folder::Entity::find_by_id(worktree_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(worktree_row.parent_id, None);
+        let middle_row = crate::db::entities::folder::Entity::find_by_id(middle_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(middle_row.parent_id, Some(worktree_id));
+        let repo_row = crate::db::entities::folder::Entity::find_by_id(repo_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(repo_row.parent_id, Some(middle_id));
+    }
+
+    // A worktree imported before grouping existed may already be acting as the
+    // root for worktrees created from it. Moving that row under the real repo
+    // without moving its children would create a two-level chain and hide the
+    // children's conversations in the single-level sidebar merge.
+    #[tokio::test]
+    async fn batch_import_does_not_reparent_a_folder_that_already_has_children() {
+        use sea_orm::EntityTrait;
+        let db = fresh_in_memory_db().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(temp.path()).expect("canonicalize root");
+        let (repo, worktree) = crate::git_repo::fixture_linked_worktree(&root);
+        let repo_id = seed_folder(&db, &repo.to_string_lossy()).await;
+        let worktree_id = seed_folder(&db, &worktree.to_string_lossy()).await;
+        let child_id = folder_service::add_folder_with_parent(
+            &db.conn,
+            &root.join("child").to_string_lossy(),
+            Some(worktree_id),
+        )
+        .await
+        .expect("seed existing child")
+        .id;
+
+        let summaries = vec![scan_summary(
+            "s1",
+            AgentType::Codex,
+            Some(&worktree.to_string_lossy()),
+            at(0),
+        )];
+        import_selected_from_summaries(
+            &db.conn,
+            &EventEmitter::Noop,
+            summaries,
+            vec![key_of(AgentType::Codex, "s1")],
+        )
+        .await
+        .expect("batch import");
+
+        let worktree_row = crate::db::entities::folder::Entity::find_by_id(worktree_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(worktree_row.parent_id, None);
+        let child_row = crate::db::entities::folder::Entity::find_by_id(child_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(child_row.parent_id, Some(worktree_id));
+        let repo_row = crate::db::entities::folder::Entity::find_by_id(repo_id)
+            .one(&db.conn)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(repo_row.parent_id, None);
     }
 
     // Grouping under a repo codeg has never opened would invent a workspace row

--- a/src-tauri/src/git_repo.rs
+++ b/src-tauri/src/git_repo.rs
@@ -14,7 +14,12 @@
 //! Bare repositories are intentionally not supported — they have no working
 //! tree, which makes them an unusual target for a workspace-oriented editor.
 
-use std::{fs, io::ErrorKind, path::Path};
+use std::{
+    ffi::OsStr,
+    fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use crate::app_error::AppCommandError;
 
@@ -24,6 +29,64 @@ use crate::app_error::AppCommandError;
 /// pointer). `Path::exists` treats both as present.
 pub fn is_git_repo(path: &Path) -> bool {
     path.join(".git").exists()
+}
+
+/// The main working tree `path` belongs to, when `path` is a **linked git
+/// worktree** (`git worktree add`). `None` for a normal repo, a submodule or
+/// other plain gitlink, a worktree of a bare repo, and anything unreadable.
+///
+/// This reads git's own on-disk pointers rather than spawning `git`, the same
+/// way the workspace watcher resolves a worktree's metadata dirs: `<path>/.git`
+/// is a FILE holding `gitdir: <private>`, and the private dir carries a
+/// `commondir` file pointing at the repository's shared git dir. `commondir` is
+/// the linked-worktree signature (a submodule's git dir has none), and for a
+/// non-bare repo that shared dir is `<main working tree>/.git`, so its parent is
+/// the answer.
+///
+/// The result is de-verbatimed ([`crate::paths::simplify_verbatim_path`]): it is
+/// compared against, and stored as, ordinary user-facing paths, never fed back
+/// into a jail check.
+pub fn main_worktree_root(path: &Path) -> Option<PathBuf> {
+    let dot_git = path.join(".git");
+    // A normal repo keeps a `.git` DIRECTORY; only a link has a file.
+    if !fs::symlink_metadata(&dot_git).ok()?.file_type().is_file() {
+        return None;
+    }
+    let pointer = fs::read_to_string(&dot_git).ok()?;
+    let gitdir = pointer
+        .lines()
+        .find_map(|line| line.strip_prefix("gitdir:"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    let private = PathBuf::from(gitdir);
+    let private = if private.is_absolute() {
+        private
+    } else {
+        path.join(private)
+    };
+    let private = fs::canonicalize(&private).ok()?;
+
+    let commondir = fs::read_to_string(private.join("commondir")).ok()?;
+    let commondir = commondir.trim();
+    if commondir.is_empty() {
+        return None;
+    }
+    let common = PathBuf::from(commondir);
+    let common = if common.is_absolute() {
+        common
+    } else {
+        private.join(common)
+    };
+    let common = fs::canonicalize(&common).ok()?;
+
+    // Only a non-bare repo keeps its shared git dir at `<root>/.git`. A bare
+    // repo's is the repository directory itself, and it has no working tree to
+    // group under.
+    if common.file_name()? != OsStr::new(".git") {
+        return None;
+    }
+    Some(crate::paths::simplify_verbatim_path(common.parent()?))
 }
 
 /// Preflight guard for git commands. Short-circuits with a typed error code
@@ -67,5 +130,128 @@ pub fn ensure_git_repo(path: &str) -> Result<(), AppCommandError> {
                 git_path.display()
             ))),
         },
+    }
+}
+
+/// Build a fake linked-worktree layout under `root`, returning
+/// `(main_working_tree, linked_worktree)`. Mirrors what real git writes:
+/// `<wt>/.git` is a FILE pointing at a private dir under
+/// `<main>/.git/worktrees/`, which carries a `commondir` file pointing back at
+/// the shared `.git`. Shared with the import tests, which need the same layout
+/// on disk to exercise the folder-parent decision.
+#[cfg(test)]
+pub(crate) fn fixture_linked_worktree(root: &Path) -> (PathBuf, PathBuf) {
+    let main = root.join("main");
+    let common = main.join(".git");
+    fs::create_dir_all(common.join("refs/heads")).expect("common refs");
+    let private = common.join("worktrees/wt");
+    fs::create_dir_all(&private).expect("private dir");
+    // `../..` from `<common>/worktrees/wt` resolves back to `<common>`.
+    fs::write(private.join("commondir"), "../..\n").expect("commondir");
+
+    let worktree = root.join("wt");
+    fs::create_dir_all(&worktree).expect("worktree dir");
+    let private_canon = fs::canonicalize(&private).expect("canon private");
+    fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", private_canon.display()),
+    )
+    .expect("gitdir pointer");
+
+    (
+        crate::paths::simplify_verbatim_path(&fs::canonicalize(&main).expect("canon main")),
+        crate::paths::simplify_verbatim_path(&fs::canonicalize(&worktree).expect("canon worktree")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn main_worktree_root_resolves_a_linked_worktree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize root");
+        let (main, worktree) = fixture_linked_worktree(&root);
+
+        assert_eq!(main_worktree_root(&worktree), Some(main));
+    }
+
+    #[test]
+    fn main_worktree_root_is_none_for_a_normal_repo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize root");
+        std::fs::create_dir_all(root.join(".git")).expect("create .git dir");
+
+        assert_eq!(main_worktree_root(&root), None);
+    }
+
+    #[test]
+    fn main_worktree_root_is_none_without_a_repo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize root");
+
+        assert_eq!(main_worktree_root(&root), None);
+    }
+
+    /// A submodule's `.git` file points at a FULL repository (its own
+    /// `objects/`) with no `commondir` marker. It is not a worktree of the
+    /// superproject and must not be grouped under it.
+    #[test]
+    fn main_worktree_root_is_none_for_a_submodule() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize root");
+
+        let module_git = root.join("super/.git/modules/sub");
+        std::fs::create_dir_all(module_git.join("objects")).expect("module objects");
+        let module_git = std::fs::canonicalize(&module_git).expect("canon module git");
+
+        let submodule = root.join("sub");
+        std::fs::create_dir_all(&submodule).expect("submodule dir");
+        std::fs::write(
+            submodule.join(".git"),
+            format!("gitdir: {}\n", module_git.display()),
+        )
+        .expect("gitdir pointer");
+
+        assert_eq!(main_worktree_root(&submodule), None);
+    }
+
+    /// A worktree of a BARE repo: `commondir` names the repository directory
+    /// itself, so there is no main working tree to group under.
+    #[test]
+    fn main_worktree_root_is_none_for_a_bare_repo_worktree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize root");
+
+        let common = root.join("repo.git");
+        std::fs::create_dir_all(common.join("refs/heads")).expect("common refs");
+        let private = common.join("worktrees/wt");
+        std::fs::create_dir_all(&private).expect("private dir");
+        std::fs::write(private.join("commondir"), "../..\n").expect("commondir");
+
+        let worktree = root.join("wt");
+        std::fs::create_dir_all(&worktree).expect("worktree dir");
+        let private_canon = std::fs::canonicalize(&private).expect("canon private");
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", private_canon.display()),
+        )
+        .expect("gitdir pointer");
+
+        assert_eq!(main_worktree_root(&worktree), None);
+    }
+
+    /// git writes an absolute `gitdir:`, but a hand-written relative one is
+    /// legal and resolves against the worktree directory.
+    #[test]
+    fn main_worktree_root_accepts_a_relative_gitdir_pointer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = std::fs::canonicalize(dir.path()).expect("canonicalize root");
+        let (main, worktree) = fixture_linked_worktree(&root);
+        std::fs::write(worktree.join(".git"), "gitdir: ../main/.git/worktrees/wt\n")
+            .expect("relative gitdir pointer");
+
+        assert_eq!(main_worktree_root(&worktree), Some(main));
     }
 }


### PR DESCRIPTION
Fixes #552.

Importing a session whose cwd is a linked git worktree registers the worktree as one more top-level folder, next to the repo it belongs to instead of under it. `import_selected_from_summaries` calls `folder_service::add_folder`, which is `ParentWrite::Preserve` and inserts `parent_id = NULL`, and `parent_id` is exactly what the sidebar reads to tell "worktree of this repo" from "another project". The branch-label backfill selects on `parent_id IS NOT NULL` as well, so such a folder never picks up its branch name either.

`git_repo::main_worktree_root` resolves the repo a worktree belongs to from git's own on-disk pointers rather than by spawning git: `<wt>/.git` is a file holding `gitdir:`, the private dir it names carries `commondir`, and for a non-bare repo that shared dir is `<main working tree>/.git`. A submodule's git dir has no `commondir` and a bare repo's common dir is not named `.git`, so neither resolves to a parent.

The importer uses `add_folder_with_parent` only when that root is a folder codeg already has open, and otherwise keeps `add_folder`. So a non-worktree cwd is unchanged, a worktree of a repo the user never opened stays top-level rather than inventing a workspace row, and a reopen still cannot demote a folder that a worktree open already parented.

Verified against a real `git worktree add` on Windows, including the sibling layout from the report where the worktree lives outside the repo directory.
