### PR TITLE
fix(agents): keep the provider you picked across an auth-method change

### DIFF
--- a/src/components/settings/acp-agent-settings.test.tsx
+++ b/src/components/settings/acp-agent-settings.test.tsx
@@ -23,6 +23,7 @@ import {
   patchCodexConfigTomlText,
   patchEnvByImportantKey,
   patchImportantConfigText,
+  providerToRebindTo,
   codexSandboxSeedsAcpPreset,
   rebaseDeepSeekDraft,
   setAdapterChannel,
@@ -35,6 +36,7 @@ import type {
   AcpAgentInfo,
   AdapterInfo,
   AgentType,
+  ModelProviderInfo,
   PreflightResult,
 } from "@/lib/types"
 
@@ -147,6 +149,42 @@ function codexSandboxDraft(
     codexSandboxBaseline: codexSandboxBaselineOf(seeded),
   }
 }
+
+// #628: providers arrive ordered by row id, so falling straight to the head of
+// the list rebound the agent to its OLDEST provider whenever the auth-mode
+// dropdown round-tripped through another mode, and the rebind copies that
+// provider's model names over the one the user was on.
+describe("providerToRebindTo", () => {
+  function provider(id: number): ModelProviderInfo {
+    return {
+      id,
+      name: `provider-${id}`,
+      agent_type: "claude_code" as AgentType,
+      api_url: "",
+      api_key: "",
+      model: null,
+    } as ModelProviderInfo
+  }
+
+  it("returns to the provider the user was on, not the first one", () => {
+    const available = [provider(1), provider(2)]
+    expect(providerToRebindTo(available, 2)?.id).toBe(2)
+  })
+
+  it("falls back to the head for a first-time pick", () => {
+    const available = [provider(1), provider(2)]
+    expect(providerToRebindTo(available, null)?.id).toBe(1)
+    expect(providerToRebindTo(available, undefined)?.id).toBe(1)
+  })
+
+  it("falls back to the head when the remembered provider is gone", () => {
+    expect(providerToRebindTo([provider(3), provider(4)], 2)?.id).toBe(3)
+  })
+
+  it("has nothing to bind to when no provider exists", () => {
+    expect(providerToRebindTo([], 2)).toBeNull()
+  })
+})
 
 describe("buildCodexSandboxConfig — Codex sandbox/approval save patch", () => {
   // The core contract. The panel also sends the raw config.toml text and the

--- a/src/components/settings/acp-agent-settings.tsx
+++ b/src/components/settings/acp-agent-settings.tsx
@@ -3870,6 +3870,28 @@ export function buildAcpAdapterCheck(
   }
 }
 
+/**
+ * Which provider an agent should land on when it returns to "model_provider"
+ * auth mode with no binding in the draft.
+ *
+ * `remembered` is the user's own last pick for this agent (or the binding
+ * already saved on it). Going straight to `available[0]` is #628: the list
+ * arrives ordered by row id, so an auth-mode round trip silently rebound the
+ * agent to its OLDEST provider, and the rebind copies that provider's model
+ * names into the draft, the env text and the config text. A remembered
+ * provider that is no longer in the list (deleted, or the agent changed) falls
+ * back to the head, which is the pre-existing behaviour for a first-time pick.
+ */
+export function providerToRebindTo(
+  available: readonly ModelProviderInfo[],
+  remembered: number | null | undefined
+): ModelProviderInfo | null {
+  if (available.length === 0) return null
+  return (
+    available.find((provider) => provider.id === remembered) ?? available[0]
+  )
+}
+
 // `uvReady` reports whether the uv runtime (uvx) is installed — only meaningful
 // for uvx agents (custom Python-package agents; built-in Hermes moved to the
 // npm bridge). Derived from the uv preflight check by the caller. uvx agents
@@ -5471,6 +5493,14 @@ export function AcpAgentSettings() {
     )
   }, [modelProviders, selectedAgent])
 
+  // The provider each agent was last bound to, remembered across auth-mode
+  // changes. The auth-mode handlers drop `draft.modelProviderId` whenever the
+  // mode leaves "model_provider", so that a save in another mode cannot
+  // persist a binding. Without this memory, coming BACK to provider mode falls
+  // through to the auto-select below, which had no record of the user's own
+  // choice. See `providerToRebindTo`.
+  const lastBoundProviderRef = useRef<Partial<Record<AgentType, number>>>({})
+
   const selectedNeedsModelProvider = useMemo(() => {
     if (!selectedDraft) return false
     if (!selectedAgent) return false
@@ -5902,6 +5932,9 @@ export function AcpAgentSettings() {
     (providerIdStr: string) => {
       if (!selectedAgent || !selectedDraft) return
       const providerId = providerIdStr ? Number(providerIdStr) : null
+      if (providerId != null) {
+        lastBoundProviderRef.current[selectedAgent.agent_type] = providerId
+      }
       const provider = providerId
         ? modelProviders.find((p) => p.id === providerId)
         : null
@@ -6113,15 +6146,25 @@ export function AcpAgentSettings() {
     [selectedAgent, selectedDraft, modelProviders, updateSelectedDraft]
   )
 
-  // Auto-select the first available provider when the user switches an agent to
-  // "model_provider" auth mode and hasn't picked one yet. If the list is empty,
-  // the existing "noModelProviderAvailable" hint handles the empty state.
+  // Auto-select a provider when the user switches an agent to
+  // "model_provider" auth mode and the draft holds no binding. If the list is
+  // empty, the existing "noModelProviderAvailable" hint handles the empty
+  // state. The user's own last pick wins over the head of the list, because an
+  // auth-mode round trip lands here too and rebinding to whichever provider
+  // happens to be first copies ITS model names over the one the user was
+  // actually on (#628).
   useEffect(() => {
     if (!selectedNeedsModelProvider) return
     if (selectedDraft?.modelProviderId != null) return
-    if (selectedModelProviders.length === 0) return
-    handleModelProviderSelect(String(selectedModelProviders[0].id))
+    if (!selectedAgent) return
+    const remembered =
+      lastBoundProviderRef.current[selectedAgent.agent_type] ??
+      selectedAgent.model_provider_id
+    const target = providerToRebindTo(selectedModelProviders, remembered)
+    if (!target) return
+    handleModelProviderSelect(String(target.id))
   }, [
+    selectedAgent,
     selectedNeedsModelProvider,
     selectedDraft?.modelProviderId,
     selectedModelProviders,


### PR DESCRIPTION
Fixes #628: with two Claude Code providers pointing at different model names, switching to the second one shows and saves the first one's model name.

Reproduction, which is the "点击cc的认证方式切换供应商" in the issue:

1. Create provider A, then provider B, each with its own `ANTHROPIC_MODEL`.
2. Bind Claude Code to B through the auth-method dropdown.
3. Move the auth method to 官网订阅 or 自定义 and back to 供应商.
4. The panel now shows A's model, and a save writes A's model into `agent_setting.env_json` and `~/.claude/settings.json`.

Cause: `handleClaudeAuthModeChange` sets `modelProviderId: null` whenever the mode leaves `model_provider`, which is right, because a save in another mode must not persist a binding. Coming back therefore arrives with no binding and falls into the auto-select effect, which called `handleModelProviderSelect(selectedModelProviders[0].id)`. `list_all` orders by row id, so `[0]` is the oldest provider, A. The Claude branch of `handleModelProviderSelect` is provider-authoritative by design, so it rewrites `claudeMainModel`, `envText` and `configText` from A while the user believes they are on B.

The change: the panel remembers the provider each agent was last bound to and prefers it. The head of the list stays the fallback for a first-time pick, and for a remembered provider that no longer exists.

Test: `providerToRebindTo` covers the four cases, and the first one fails on the old `available[0]` behaviour.

Not touched here, but adjacent and worth a separate look: the `official_subscription` branch of the same handler builds `allEnvKeys` from the API url and key only, so the eight `ANTHROPIC_*_MODEL` keys survive an auth-mode change in the draft, the env text and `config.env`.
