### PR TITLE
perf(chat): widen the streaming flush window with the reply it re-renders

### DIFF
--- a/src/contexts/acp-connections-context.test.tsx
+++ b/src/contexts/acp-connections-context.test.tsx
@@ -4,6 +4,8 @@ import { useTranslations } from "next-intl"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   AcpConnectionsProvider,
+  STREAM_FLUSH_FRAME_MS,
+  STREAM_FLUSH_MAX_MS,
   useAcpActions,
   useConnectionStore,
 } from "@/contexts/acp-connections-context"
@@ -2131,6 +2133,150 @@ describe("out-of-turn wire guard + background activity", () => {
     expect(notify).toHaveBeenCalledTimes(1)
 
     resetConversationRuntimeStore()
+  })
+})
+
+describe("streaming flush window widens with the run it re-renders", () => {
+  async function mountStreamingOwner() {
+    h.acpFindConnectionForConversation.mockResolvedValue(null)
+    await mountProvider()
+    await act(async () => {
+      await h.actions!.connect(TAB, "claude_code", "/tmp/x", "sess-1", 42)
+    })
+    const handlers = latestAttachHandlers()
+    emitAcpEvent(handlers, {
+      seq: 1,
+      connection_id: "spawned-conn",
+      type: "status_changed",
+      status: "prompting",
+    })
+    return handlers
+  }
+
+  function liveText(): string {
+    const content = h.store!.getConnection(TAB)?.liveMessage?.content ?? []
+    return content
+      .map((block) => (block.type === "text" ? block.text : ""))
+      .join("")
+  }
+
+  it("holds a long run for more frames, and delivers exactly what arrived", async () => {
+    const handlers = await mountStreamingOwner()
+    // Mount and connect on real timers (they await the transport); only the
+    // flush window below is driven by hand.
+    vi.useFakeTimers()
+    try {
+      // First delta of the turn: the live message is empty, so the window is
+      // the single frame it has always been.
+      const head = "a".repeat(9000)
+      emitAcpEvent(handlers, {
+        seq: 2,
+        connection_id: "spawned-conn",
+        type: "content_delta",
+        text: head,
+      })
+      expect(liveText()).toBe("")
+      act(() => {
+        vi.advanceTimersByTime(STREAM_FLUSH_FRAME_MS)
+      })
+      expect(liveText()).toBe(head)
+
+      // The next delta is armed against a 9000-character run, which is past
+      // the first step: one frame is no longer enough to release it.
+      emitAcpEvent(handlers, {
+        seq: 3,
+        connection_id: "spawned-conn",
+        type: "content_delta",
+        text: "b",
+      })
+      act(() => {
+        vi.advanceTimersByTime(STREAM_FLUSH_FRAME_MS)
+      })
+      expect(liveText()).toBe(head)
+      act(() => {
+        vi.advanceTimersByTime(STREAM_FLUSH_FRAME_MS)
+      })
+      expect(liveText()).toBe(`${head}b`)
+
+      // Whatever the window, every chunk lands once and in order.
+      let expected = `${head}b`
+      for (let i = 0; i < 40; i++) {
+        const text = `-${i}-`
+        expected += text
+        emitAcpEvent(handlers, {
+          seq: 4 + i,
+          connection_id: "spawned-conn",
+          type: "content_delta",
+          text,
+        })
+        act(() => {
+          vi.advanceTimersByTime(STREAM_FLUSH_MAX_MS)
+        })
+      }
+      expect(liveText()).toBe(expected)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The window is sized by the RUN the batch appends to, not by how much the
+  // turn has said in total: a reply that has already written 9 KB and then ran
+  // a tool is back to rendering a short block, and must not keep paying for
+  // the prose above it.
+  it("returns to a single frame when a new run starts", async () => {
+    const handlers = await mountStreamingOwner()
+    vi.useFakeTimers()
+    try {
+      emitAcpEvent(handlers, {
+        seq: 2,
+        connection_id: "spawned-conn",
+        type: "content_delta",
+        text: "a".repeat(9000),
+      })
+      act(() => {
+        vi.advanceTimersByTime(STREAM_FLUSH_FRAME_MS)
+      })
+
+      // A tool call closes the prose run (and flushes the queue itself), so
+      // the reply that resumes after it starts short again.
+      emitAcpEvent(handlers, {
+        seq: 3,
+        connection_id: "spawned-conn",
+        type: "tool_call",
+        tool_call_id: "toolu_1",
+        title: "Read",
+        kind: "read",
+        status: "in_progress",
+        content: null,
+        raw_input: null,
+        raw_output: null,
+      })
+      emitAcpEvent(handlers, {
+        seq: 4,
+        connection_id: "spawned-conn",
+        type: "content_delta",
+        text: "after",
+      })
+      act(() => {
+        vi.advanceTimersByTime(STREAM_FLUSH_FRAME_MS)
+      })
+      expect(liveText()).toBe(`${"a".repeat(9000)}after`)
+
+      // And it stays there while the new run is short, even though the turn
+      // now holds more than 9 KB in total.
+      emitAcpEvent(handlers, {
+        seq: 5,
+        connection_id: "spawned-conn",
+        type: "content_delta",
+        text: " more",
+      })
+      act(() => {
+        vi.advanceTimersByTime(STREAM_FLUSH_FRAME_MS)
+      })
+      expect(liveText()).toBe(`${"a".repeat(9000)}after more`)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/contexts/acp-connections-context.tsx
+++ b/src/contexts/acp-connections-context.tsx
@@ -741,6 +741,44 @@ type StreamingAction =
       parentToolUseId?: string
     }
 
+/** One display frame: the narrowest window streaming deltas coalesce into. */
+export const STREAM_FLUSH_FRAME_MS = 16
+/** The widest — about five batches a second. */
+export const STREAM_FLUSH_MAX_MS = 192
+/** Characters of live prose that buy one more frame of coalescing. */
+const STREAM_FLUSH_CHARS_PER_FRAME = 8 * 1024
+
+/**
+ * How long streaming deltas coalesce before one `STREAM_BATCH` lands, given
+ * the length of the prose run the batch will grow.
+ *
+ * Each batch replaces the live message, and the run it appended to is
+ * re-rendered whole: normalized, re-lexed into markdown blocks, re-highlighted.
+ * That is linear in the run's length, and the window was a flat 16 ms — so the
+ * work a turn cost grew with the SQUARE of its own output, while the rate it
+ * arrived at stayed the same. Past a few tens of KB the renderer could no
+ * longer keep up with the stream, which is #589: at ~300 tok/s the whole UI
+ * stops responding, on hardware with plenty of headroom.
+ *
+ * Measured on a 300 tok/s stream, counting the characters re-rendered across
+ * a turn: 30 s of output cost 32.5M before and 11.1M after; 120 s cost 518.8M
+ * before and 59.9M after.
+ *
+ * A run under 8 KB — nearly every reply — keeps the 16 ms window it has today.
+ * Past that each further 8 KB buys one more frame, so the cost per second
+ * flattens out instead of climbing with the answer. Nothing about WHAT gets
+ * delivered changes: the queue merges and dispatches exactly as before, and
+ * every non-streaming event still flushes it immediately, so a tool card, a
+ * permission prompt or the end of a turn never waits on this window.
+ */
+export function streamFlushDelayMs(liveRunChars: number): number {
+  const frames = Math.max(
+    1,
+    Math.ceil(liveRunChars / STREAM_FLUSH_CHARS_PER_FRAME)
+  )
+  return Math.min(STREAM_FLUSH_MAX_MS, STREAM_FLUSH_FRAME_MS * frames)
+}
+
 type ConnectionsMap = Map<string, ConnectionState>
 const MAX_LIVE_TOOL_RAW_OUTPUT_CHARS = 200_000
 const MAX_BUFFERED_UNMAPPED_EVENTS_PER_CONNECTION = 64
@@ -3478,7 +3516,22 @@ export function AcpConnectionsProvider({ children }: { children: ReactNode }) {
         return
       }
       if (flushTimerRef.current === null) {
-        flushTimerRef.current = setTimeout(flushStreamingQueue, 16)
+        // Size the window from the prose run this batch will grow — the block
+        // the reducer will append to, which is what gets re-rendered whole.
+        // Read as of the last batch, so it costs one map lookup, and a fresh
+        // turn (empty live message, or a run that just restarted after a tool
+        // call) is back to a single frame. See `streamFlushDelayMs`.
+        const content = storeRef.current.connections.get(action.contextKey)
+          ?.liveMessage?.content
+        const last = content?.[content.length - 1]
+        const runChars =
+          last && (last.type === "text" || last.type === "thinking")
+            ? last.text.length
+            : 0
+        flushTimerRef.current = setTimeout(
+          flushStreamingQueue,
+          streamFlushDelayMs(runChars)
+        )
       }
     },
     [flushStreamingQueue]

--- a/src/contexts/streaming-flush-cadence.test.ts
+++ b/src/contexts/streaming-flush-cadence.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import {
+  STREAM_FLUSH_FRAME_MS,
+  STREAM_FLUSH_MAX_MS,
+  streamFlushDelayMs,
+} from "@/contexts/acp-connections-context"
+
+describe("streamFlushDelayMs", () => {
+  it("leaves an ordinary reply on the single-frame window it has today", () => {
+    for (const chars of [0, 1, 200, 4096, 8192]) {
+      expect(streamFlushDelayMs(chars)).toBe(STREAM_FLUSH_FRAME_MS)
+    }
+  })
+
+  it("buys one more frame per further 8 KB, up to the ceiling", () => {
+    expect(streamFlushDelayMs(8193)).toBe(2 * STREAM_FLUSH_FRAME_MS)
+    expect(streamFlushDelayMs(16 * 1024)).toBe(2 * STREAM_FLUSH_FRAME_MS)
+    expect(streamFlushDelayMs(32 * 1024)).toBe(4 * STREAM_FLUSH_FRAME_MS)
+    expect(streamFlushDelayMs(64 * 1024)).toBe(8 * STREAM_FLUSH_FRAME_MS)
+    expect(streamFlushDelayMs(1024 * 1024)).toBe(STREAM_FLUSH_MAX_MS)
+  })
+
+  it("never returns a window that would stall or spin", () => {
+    for (const chars of [-1, 0, Number.MAX_SAFE_INTEGER]) {
+      const delay = streamFlushDelayMs(chars)
+      expect(delay).toBeGreaterThanOrEqual(STREAM_FLUSH_FRAME_MS)
+      expect(delay).toBeLessThanOrEqual(STREAM_FLUSH_MAX_MS)
+    }
+  })
+})
+
+/**
+ * Replay a 300 tok/s stream (one 4-character chunk per token) through a flush
+ * schedule and report what it costs.
+ *
+ * `charsRendered` is the metric #589 is about: every batch re-renders the prose
+ * run it appended to, whole, and that cost is linear in the run's length. With
+ * a flat window the rate is constant while the run keeps growing, so the total
+ * climbs with the square of the turn's own output.
+ */
+function replay(
+  seconds: number,
+  delayFor: (runChars: number) => number
+): { flushes: number; charsRendered: number; delivered: number } {
+  const CHUNK_CHARS = 4
+  const MS_PER_CHUNK = 1000 / 300
+  const chunks = seconds * 300
+
+  let run = 0
+  let pending = 0
+  let nextFlushAt = delayFor(0)
+  let flushes = 0
+  let charsRendered = 0
+
+  for (let i = 0; i < chunks; i++) {
+    pending += CHUNK_CHARS
+    const now = (i + 1) * MS_PER_CHUNK
+    if (now < nextFlushAt) continue
+    run += pending
+    pending = 0
+    flushes++
+    charsRendered += run
+    nextFlushAt = now + delayFor(run)
+  }
+  // The turn always ends on an explicit flush (`turn_complete`).
+  if (pending > 0) {
+    run += pending
+    flushes++
+    charsRendered += run
+  }
+  return { flushes, charsRendered, delivered: run }
+}
+
+const flatWindow = () => STREAM_FLUSH_FRAME_MS
+
+describe("what the flush cadence costs at 300 tokens/sec", () => {
+  it("delivers every character either way", () => {
+    for (const seconds of [10, 30, 120]) {
+      const expected = seconds * 300 * 4
+      expect(replay(seconds, flatWindow).delivered).toBe(expected)
+      expect(replay(seconds, streamFlushDelayMs).delivered).toBe(expected)
+    }
+  })
+
+  it("stops the re-render cost climbing with the square of the answer", () => {
+    const flat30 = replay(30, flatWindow)
+    const flat120 = replay(120, flatWindow)
+    const now30 = replay(30, streamFlushDelayMs)
+    const now120 = replay(120, streamFlushDelayMs)
+
+    // A flat window makes four times the output cost sixteen times the work.
+    expect(flat120.charsRendered / flat30.charsRendered).toBeGreaterThan(12)
+
+    // Backing off keeps that growth near linear…
+    expect(now120.charsRendered / now30.charsRendered).toBeLessThan(8)
+    // …and cuts the absolute cost at both lengths.
+    expect(now30.charsRendered).toBeLessThan(flat30.charsRendered * 0.45)
+    expect(now120.charsRendered).toBeLessThan(flat120.charsRendered * 0.2)
+  })
+
+  it("leaves a short answer on exactly the cadence it has today", () => {
+    // Five seconds at 300 tok/s is 6 KB — under the first step, so the
+    // schedule is unchanged for the replies almost every turn produces.
+    expect(replay(5, streamFlushDelayMs)).toEqual(replay(5, flatWindow))
+  })
+})


### PR DESCRIPTION
For #589: at around 300 tokens a second the whole UI stops responding, on a machine with plenty of headroom.

I measured where the per-batch time goes rather than guessing, driving a realistic chunk stream through the real code.

The store and the timeline are not it. `setLiveMessage` plus `computeTimeline` costs 0.03 to 0.12 ms a batch over a 2000-batch turn, and running the message adapter on top brings that to 0.15 to 1.0 ms. Rendering the reply is three orders of magnitude above that. Every batch replaces the live message, so the prose run it appended to goes to the markdown renderer again whole: normalized, re-lexed into blocks, re-highlighted, re-rendered. In the test renderer that is 3.1 ms a batch at 4 KB and 27 ms at 64 KB; the block splitter alone (marked) is 0.7 ms at 4 KB and 6.9 ms at 64 KB. Handing it an unchanged string costs 0.075 ms, so all of it is the run having grown.

The window those batches landed in was a flat 16 ms no matter how long the reply had got. So the work a turn costs rose with the square of its own output while the rate it arrived at stayed put. Replaying 300 tok/s and counting the characters re-rendered across the turn:

```
                       30 s (35 KB)   120 s (141 KB)
flat 16 ms window          32.5M          518.8M
scaled window              11.1M           59.9M
```

Sixteen times the work for four times the answer, before. Near linear, after. End to end through the real markdown renderer, 30 seconds of output went from 1803 batches and 1.9 to 3.7 times realtime in render work, to 888 batches and 1.4 to 1.6 times. (Those two numbers move with machine load; the character counts above are deterministic, which is what the test asserts on.)

The window now scales with the run being re-rendered: under 8 KB, which is nearly every reply, it is the same 16 ms as today, and past that each further 8 KB buys one more frame, up to 192 ms. It is sized from the run and not from the whole message, so a reply that has already written 9 KB and then ran a tool is back to a single frame for the block it starts next.

Nothing about what gets delivered changes. The queue merges and dispatches exactly as before, every chunk lands once and in order, and every non-streaming event still flushes it immediately, so a tool card, a permission prompt or the end of a turn never waits on this window.

Still open, and deliberately not in here:

- The per-batch cost itself. The run is re-lexed and re-rendered whole each time. Splitting a streaming reply at block boundaries so only the tail is rebuilt would remove that, but not without changing how a list, a table or a fence spanning the split renders, so it needs its own change.
- The "rendering is off" part of the report. I could not reproduce it and found no chunk reordering or loss in the queue, so I have not tried to fix it. It should stay open as its own thing.

Tests: a new `streaming-flush-cadence.test.ts` for the window and for what a 300 tok/s turn costs under it, plus two in `acp-connections-context.test.tsx` driving real events through the provider on fake timers, one checking a long run waits the extra frames and the text arrives exactly as sent, one checking a new run goes back to a single frame.

Composes with the open PRs rather than colliding: #705 and #708 both change `computeTimeline` / `conversation-runtime-store.ts`, and #703 is backend. This touches only the queue in `acp-connections-context.tsx`, which sits above all of them, and it makes their work run fewer times per turn rather than changing what it does.

